### PR TITLE
SDK-199: added resource exception as cause of profile exception

### DIFF
--- a/yoti-sdk-api/pom.xml
+++ b/yoti-sdk-api/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-api</artifactId>
-  <version>1.3</version>
+  <version>1.4-SNAPSHOT</version>
   <name>Yoti SDK API</name>
   <description>Java SDK for simple integration with the Yoti platform</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>

--- a/yoti-sdk-impl/pom.xml
+++ b/yoti-sdk-impl/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-impl</artifactId>
-  <version>1.3</version>
+  <version>1.4-SNAPSHOT</version>
   <name>Yoti SDK implementation package</name>
   <description>Java SDK for simple integration with the Yoti platform</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>2.5.0</version>
+      <version>3.5.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>com.yoti</groupId>
       <artifactId>yoti-sdk-api</artifactId>
-      <version>1.3</version>
+      <version>1.4-SNAPSHOT</version>
     </dependency>
     <!-- Testing dependencies -->
     <dependency>

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/RemoteProfileService.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/RemoteProfileService.java
@@ -122,11 +122,12 @@ public final class RemoteProfileService implements ProfileService {
             int responseCode = re.getResponseCode();
             switch (responseCode) {
             case HTTP_INTERNAL_ERROR:
-                throw new ProfileException("Error completing sharing: " + re.getResponseBody());
+                throw new ProfileException("Error completing sharing: " + re.getResponseBody(), re);
             case HTTP_NOT_FOUND:
-                throw new ProfileException("Profile not found: " + re.getResponseBody());
+                throw new ProfileException("Profile not found. This can be due to a used or expired token. Details: " 
+                    + re.getResponseBody(), re);
             default:
-                throw new ProfileException("Unexpected response: " + responseCode + " " + re.getResponseBody());
+                throw new ProfileException("Unexpected response: " + responseCode + " " + re.getResponseBody(), re);
             }
         }
     }

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/call/RemoteProfileServiceTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/call/RemoteProfileServiceTest.java
@@ -131,6 +131,25 @@ public class RemoteProfileServiceTest {
 
         assertNull(null, receipt);
     }
+    
+    @Test(expected = ResourceException.class)
+    public void shouldThrowExceptionWithResourceExceptionCause()
+            throws Throwable {
+        ResourceFetcher resourceFetcher = mock(ResourceFetcher.class);
+        when(resourceFetcher.fetchResource(Mockito.<UrlConnector> any(), Mockito.<Map<String, String>> any(),
+                eq(ProfileResponse.class))).thenThrow(new ResourceException(404, "Test exception"));
+        RemoteProfileService profileService = new RemoteProfileService(resourceFetcher);
+
+        KeyPair keyPair = generateKeyPairFrom(KEY_PAIR_PEM);
+        Receipt receipt;
+		try {
+			receipt = profileService.getReceipt(keyPair, APP_ID, TOKEN);
+		} catch (Exception e) {
+			throw e.getCause();
+		}
+
+        assertNull(null, receipt);
+    }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldFailWithNullKeyPair() throws IOException, GeneralSecurityException, ProfileException {


### PR DESCRIPTION
Every time a profile exception is raised because of an http error code, the underlying ResourceException is passed as a cause. Clients can leverage that and use the included status code to show consistent messages to users.

Upgraded protobuf-java to 3.5.0 to overcome CVE-2015-5237.
Protobuf people say the issue is solved in 3.4.0, but the owasp plugin still issues an error.
You'll need to pass -Ddependency-check.skip=true in order to install the artifact.

Set version to 1.4-SNAPSHOT so we can test before synchronising to Central.