### PR TITLE
[SDK-190]: Updated README with extra command to use when running the …

### DIFF
--- a/yoti-sdk-spring-boot-example/README.md
+++ b/yoti-sdk-spring-boot-example/README.md
@@ -29,13 +29,13 @@ Before you start, you'll need to create an Application in [Dashboard](https://ww
 
 ## Running
 * You can run your server-app by executing `java -jar target/yoti-sdk-spring-boot-example-1.3.jar`
+  * If you are using Java 9, you can run the server-app as follows `java -jar target/yoti-sdk-spring-boot-example-1.3.jar --add-exports java.base/jdk.internal.ref=ALL-UNNAMED`
 * Your endpoint is listening under `https://localhost:8443/login`.
 
 In order to receive calls on your /login endpoint, you need to expose your server-app to the outside world. We require that you use the domain from the Callback URL and HTTPS.
 
 ## Requirements for running the application
 * Java 6 or above
-* If you are using Java 9, you should add an `add-exports` argument to the command you use to run the .jar file, so that it is `java -jar target/yoti-sdk-spring-boot-example-1.3.jar --add-exports java.base/jdk.internal.ref=ALL-UNNAMED`
 * If you are using Oracle JDK/JRE you need to install JCE extension in your server's Java to allow strong encryption (http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html). This is not a requirement if you are using OpenJDK.
 
 

--- a/yoti-sdk-spring-boot-example/README.md
+++ b/yoti-sdk-spring-boot-example/README.md
@@ -35,6 +35,7 @@ In order to receive calls on your /login endpoint, you need to expose your serve
 
 ## Requirements for running the application
 * Java 6 or above
+* If you are using Java 9, you should add an `add-exports` argument to the command you use to run the .jar file, so that it is `java -jar target/yoti-sdk-spring-boot-example-1.3.jar --add-exports java.base/jdk.internal.ref=ALL-UNNAMED`
 * If you are using Oracle JDK/JRE you need to install JCE extension in your server's Java to allow strong encryption (http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html). This is not a requirement if you are using OpenJDK.
 
 

--- a/yoti-sdk-spring-boot-example/README.md
+++ b/yoti-sdk-spring-boot-example/README.md
@@ -20,9 +20,9 @@ Before you start, you'll need to create an Application in [Dashboard](https://ww
     </dependency>
 ```
 
-## Building and running your example server-app
+## Building your example server-app
 1. In Dashboard edit the "Callback URL" field with the URL pointing to your /login endpoint.
-`Ex. https://mydomain.com/login`. Note that your endpoint must be visible on the Internet.
+`Ex. https://mydomain.com/login`. Note that your endpoint must be accessible on the Internet.
 1. Edit the `resources/application.yml` and replace the `yoti-client-sdk-id-from-dashboard` value with the `Yoti client SDK ID` you can find in Dashboard.
 1. Download your Application's key pair from Yoti-Dashboard and copy it to `resources/app-keypair.pem`.
 1. Run `mvn clean package` to build the project.


### PR DESCRIPTION
…example project with Java 9

Wasn't entirely sure about the wording - or whether to mention anything when we instruct the users to run the original command `java -jar target/yoti-sdk-spring-boot-example-1.3.jar` above.