### PR TITLE
FIX-BUILD Update module versions

### DIFF
--- a/yoti-sdk-dummy/pom.xml
+++ b/yoti-sdk-dummy/pom.xml
@@ -117,7 +117,7 @@
     <dependency>
       <groupId>com.yoti</groupId>
       <artifactId>yoti-sdk-api</artifactId>
-      <version>1.3</version>
+      <version>1.4-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/yoti-sdk-spring-boot-auto-config/pom.xml
+++ b/yoti-sdk-spring-boot-auto-config/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>com.yoti</groupId>
       <artifactId>yoti-sdk-api</artifactId>
-      <version>1.3</version>
+      <version>1.4-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.yoti</groupId>


### PR DESCRIPTION
Even after this change, you still need to run with the -Denforcer.skip=true flag