### PR TITLE
[SDK-218]: Fixed inter-project dependencies

### DIFF
--- a/yoti-sdk-impl/pom.xml
+++ b/yoti-sdk-impl/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-impl</artifactId>
-  <version>1.4-SNAPSHOT</version>
+  <version>1.3</version>
   <name>Yoti SDK implementation package</name>
   <description>Java SDK for simple integration with the Yoti platform</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>

--- a/yoti-sdk-spring-security/pom.xml
+++ b/yoti-sdk-spring-security/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>com.yoti</groupId>
       <artifactId>yoti-sdk-api</artifactId>
-      <version>1.3</version>
+      <version>1.4-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.yoti</groupId>


### PR DESCRIPTION
 so the -Denforcer.skip flag doesn't have to be specified on build