### PR TITLE
API-264: Update remaining build version numbers to 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ If you are using Maven, you need to add the following dependency:
 <dependency>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-impl</artifactId>
-    <version>1.3</version>
+    <version>1.4-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk</artifactId>
   <packaging>pom</packaging>
-  <version>1.0</version>
+  <version>1.4-SNAPSHOT</version>
   <name>Yoti SDK</name>
   <description>Java SDK for simple integration with the Yoti platform</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>
@@ -34,6 +34,7 @@
     <module>yoti-sdk-spring-security</module>
     <module>yoti-sdk-spring-boot-example</module>
   </modules>
+
   <build>
     <plugins>
       <plugin>
@@ -46,4 +47,5 @@
       </plugin>
     </plugins>
   </build>
+
 </project>

--- a/yoti-sdk-spring-boot-auto-config/README.md
+++ b/yoti-sdk-spring-boot-auto-config/README.md
@@ -18,7 +18,7 @@ If you are using Maven, you need to add the following dependencies:
 <dependency>
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-boot-auto-config</artifactId>
-  <version>1.3</version>
+  <version>1.4-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -26,7 +26,7 @@ If you are using Maven, you need to add the following dependencies:
 If you are using Gradle, here is the dependency to add:
 
 ```
-compile group: 'com.yoti', name: 'yoti-sdk-spring-boot-auto-config', version: '1.3'
+compile group: 'com.yoti', name: 'yoti-sdk-spring-boot-auto-config', version: '1.4-SNAPSHOT'
 ```
 
 

--- a/yoti-sdk-spring-boot-example/README.md
+++ b/yoti-sdk-spring-boot-example/README.md
@@ -16,7 +16,7 @@ Before you start, you'll need to create an Application in [Dashboard](https://ww
     <dependency>
       <groupId>com.yoti</groupId>
       <artifactId>yoti-sdk-impl</artifactId>
-      <version>1.3</version>
+      <version>1.4-SNAPSHOT</version>
     </dependency>
 ```
 

--- a/yoti-sdk-spring-security/README.md
+++ b/yoti-sdk-spring-security/README.md
@@ -25,7 +25,7 @@ If you are using Maven, you need to add the following dependencies:
 <dependency>
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-security</artifactId>
-  <version>1.0</version>
+  <version>1.4-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/yoti-sdk-spring-security/pom.xml
+++ b/yoti-sdk-spring-security/pom.xml
@@ -15,7 +15,7 @@
 
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-security</artifactId>
-  <version>1.0</version>
+  <version>1.4-SNAPSHOT</version>
   <name>Spring Security Integration For The Yoti SDK</name>
   <description>Library to integrate the Java Yoti SDK with Spring Security</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>


### PR DESCRIPTION
We have version numbers coming out of our ears.  These should be the last of them.
I suggest we merge these to master.