### PR TITLE
API-264: Fix creation of AML beans, to match approach take elsewhere

### DIFF
--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/aml/AmlAddressBuilder.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/aml/AmlAddressBuilder.java
@@ -1,0 +1,29 @@
+package com.yoti.api.client.aml;
+
+import java.util.ServiceLoader;
+
+public class AmlAddressBuilder {
+
+    private String postCode;
+    private String country;
+
+    public AmlAddressBuilder withPostCode(String postCode) {
+        this.postCode = postCode;
+        return this;
+    }
+
+    public AmlAddressBuilder withCountry(String country) {
+        this.country = country;
+        return this;
+    }
+
+    public AmlAddress build() {
+        ServiceLoader<AmlAddressFactory> addressFactoryLoader = ServiceLoader.load(AmlAddressFactory.class);
+        if (! addressFactoryLoader.iterator().hasNext()) {
+            throw new IllegalStateException("Cannot find any implementation of AmlAddressFactory");
+        }
+        AmlAddressFactory amlAddressFactory = addressFactoryLoader.iterator().next();
+        return amlAddressFactory.create(postCode, country);
+    }
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/aml/AmlAddressFactory.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/aml/AmlAddressFactory.java
@@ -1,0 +1,7 @@
+package com.yoti.api.client.aml;
+
+public interface AmlAddressFactory {
+
+    AmlAddress create(String postCode, String country);
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/aml/AmlProfileBuilder.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/aml/AmlProfileBuilder.java
@@ -1,0 +1,41 @@
+package com.yoti.api.client.aml;
+
+import java.util.ServiceLoader;
+
+public class AmlProfileBuilder {
+
+    private String givenNames;
+    private String familyName;
+    private String ssn;
+    private AmlAddress amlAddress;
+
+    public AmlProfileBuilder withGivenNames(String givenNames) {
+        this.givenNames = givenNames;
+        return this;
+    }
+
+    public AmlProfileBuilder withFamilyName(String familyName) {
+        this.familyName = familyName;
+        return this;
+    }
+
+    public AmlProfileBuilder withSsn(String ssn) {
+        this.ssn = ssn;
+        return this;
+    }
+
+    public AmlProfileBuilder withAddress(AmlAddress amlAddress) {
+        this.amlAddress = amlAddress;
+        return this;
+    }
+
+    public AmlProfile build() {
+        ServiceLoader<AmlProfileFactory> profileFactoryLoader = ServiceLoader.load(AmlProfileFactory.class);
+        if (! profileFactoryLoader.iterator().hasNext()) {
+            throw new IllegalStateException("Cannot find any implementation of AmlProfileFactory");
+        }
+        AmlProfileFactory amlProfileFactory = profileFactoryLoader.iterator().next();
+        return amlProfileFactory.create(givenNames, familyName, ssn, amlAddress);
+    }
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/aml/AmlProfileFactory.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/aml/AmlProfileFactory.java
@@ -1,0 +1,6 @@
+package com.yoti.api.client.aml;
+
+public interface AmlProfileFactory {
+
+    AmlProfile create(String givenNames, String familyName, String ssn, AmlAddress amlAddress);
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/aml/SimpleAmlAddressFactory.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/aml/SimpleAmlAddressFactory.java
@@ -1,0 +1,12 @@
+package com.yoti.api.client.spi.remote.call.aml;
+
+import com.yoti.api.client.aml.AmlAddress;
+import com.yoti.api.client.aml.AmlAddressFactory;
+
+public class SimpleAmlAddressFactory implements AmlAddressFactory {
+
+    public AmlAddress create(String postCode, String country) {
+        return new SimpleAmlAddress(postCode, country);
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/aml/SimpleAmlProfileFactory.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/aml/SimpleAmlProfileFactory.java
@@ -1,0 +1,13 @@
+package com.yoti.api.client.spi.remote.call.aml;
+
+import com.yoti.api.client.aml.AmlAddress;
+import com.yoti.api.client.aml.AmlProfile;
+import com.yoti.api.client.aml.AmlProfileFactory;
+
+public final class SimpleAmlProfileFactory implements AmlProfileFactory {
+
+    public AmlProfile create(String givenNames, String familyName, String ssn, AmlAddress amlAddress) {
+        return new SimpleAmlProfile(givenNames, familyName, ssn, amlAddress);
+    }
+
+}

--- a/yoti-sdk-impl/src/main/resources/META-INF/services/com.yoti.api.client.aml.AmlAddressFactory
+++ b/yoti-sdk-impl/src/main/resources/META-INF/services/com.yoti.api.client.aml.AmlAddressFactory
@@ -1,0 +1,1 @@
+com.yoti.api.client.spi.remote.call.aml.SimpleAmlAddressFactory

--- a/yoti-sdk-impl/src/main/resources/META-INF/services/com.yoti.api.client.aml.AmlProfileFactory
+++ b/yoti-sdk-impl/src/main/resources/META-INF/services/com.yoti.api.client.aml.AmlProfileFactory
@@ -1,0 +1,1 @@
+com.yoti.api.client.spi.remote.call.aml.SimpleAmlProfileFactory


### PR DESCRIPTION
This commit changes how AML are created.  Now clients can use builder, and the only have to reference classes from the sdk-api project in their code (though they do have to import the sdk-impl project anyway).