### PR TITLE
API-360: Additional CVE exclusion for jackson

### DIFF
--- a/yoti-sdk-impl/suppressed-cves.xml
+++ b/yoti-sdk-impl/suppressed-cves.xml
@@ -15,8 +15,10 @@
         The jackson-databind devs discuss it here: https://github.com/FasterXML/jackson-databind/issues/1904
         Recommended reading is here: https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062
         Our conclusion is in API-360
+        There is now an additional CVE, seemingly for the same issue: https://nvd.nist.gov/vuln/detail/CVE-2018-5968
       ]]></notes>
       <gav>com.fasterxml.jackson.core:jackson-databind:2.7.9.1</gav>
       <cve>CVE-2017-17485</cve>
+      <cve>CVE-2018-5968</cve>
    </suppress>
 </suppressions>

--- a/yoti-sdk-spring-boot-auto-config/suppressed-cves.xml
+++ b/yoti-sdk-spring-boot-auto-config/suppressed-cves.xml
@@ -15,8 +15,10 @@
         The jackson-databind devs discuss it here: https://github.com/FasterXML/jackson-databind/issues/1904
         Recommended reading is here: https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062
         Our conclusion is in API-360
+        There is now an additional CVE, seemingly for the same issue: https://nvd.nist.gov/vuln/detail/CVE-2018-5968
       ]]></notes>
       <gav>com.fasterxml.jackson.core:jackson-databind:2.7.9.1</gav>
       <cve>CVE-2017-17485</cve>
+      <cve>CVE-2018-5968</cve>
    </suppress>
 </suppressions>

--- a/yoti-sdk-spring-security/suppressed-cves.xml
+++ b/yoti-sdk-spring-security/suppressed-cves.xml
@@ -14,9 +14,11 @@
         The problem is described here: https://nvd.nist.gov/vuln/detail/CVE-2017-17485#VulnChangeHistoryDiv
         The jackson-databind devs discuss it here: https://github.com/FasterXML/jackson-databind/issues/1904
         Recommended reading is here: https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062
-        Our conclusion is in API-360
+        Our conclusion is in API-360.
+        There is now an additional CVE, seemingly for the same issue: https://nvd.nist.gov/vuln/detail/CVE-2018-5968
       ]]></notes>
       <gav>com.fasterxml.jackson.core:jackson-databind:2.7.9.1</gav>
       <cve>CVE-2017-17485</cve>
+      <cve>CVE-2018-5968</cve>
    </suppress>
 </suppressions>


### PR DESCRIPTION
We now have an additional CVE for jackson-databind.  It seems to be the same issue we agreed to ignore last week.
https://nvd.nist.gov/vuln/detail/CVE-2018-5968