### PR TITLE
API-410: Fix resolution of BouncyCastle provided JCA implementations

### DIFF
--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SecureYotiClient.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SecureYotiClient.java
@@ -1,6 +1,9 @@
 package com.yoti.api.client.spi.remote;
 
+import static com.yoti.api.client.spi.remote.call.YotiConstants.ASYMMETRIC_CIPHER;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.BOUNCY_CASTLE_PROVIDER;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.DEFAULT_CHARSET;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.SYMMETRIC_CIPHER;
 import static com.yoti.api.client.spi.remote.util.Validation.notNull;
 import static javax.crypto.Cipher.DECRYPT_MODE;
 
@@ -57,8 +60,6 @@ import java.util.Map;
 final class SecureYotiClient implements YotiClient {
 
     private static final Logger LOG = LoggerFactory.getLogger(SecureYotiClient.class);
-    private static final String SYMMETRIC_CIPHER = "AES/CBC/PKCS7Padding";
-    private static final String ASYMMETRIC_CIPHER = "RSA/NONE/PKCS1Padding";
     private static final String RFC3339_PATTERN = "yyyy-MM-dd'T'HH:mm:ss'Z'";
     private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 
@@ -235,7 +236,7 @@ final class SecureYotiClient implements YotiClient {
         }
         byte[] result = null;
         try {
-            Cipher cipher = Cipher.getInstance(SYMMETRIC_CIPHER);
+            Cipher cipher = Cipher.getInstance(SYMMETRIC_CIPHER, BOUNCY_CASTLE_PROVIDER);
             cipher.init(DECRYPT_MODE, key, new IvParameterSpec(initVector.toByteArray()));
             result = cipher.doFinal(source.toByteArray());
         } catch (GeneralSecurityException gse) {
@@ -249,7 +250,7 @@ final class SecureYotiClient implements YotiClient {
     private byte[] decrypt(byte[] source, PrivateKey key) throws ProfileException {
         byte[] result = null;
         try {
-            Cipher cipher = Cipher.getInstance(ASYMMETRIC_CIPHER);
+            Cipher cipher = Cipher.getInstance(ASYMMETRIC_CIPHER, BOUNCY_CASTLE_PROVIDER);
             cipher.init(DECRYPT_MODE, key);
             result = cipher.doFinal(source);
         } catch (GeneralSecurityException gse) {

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/YotiConstants.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/YotiConstants.java
@@ -16,6 +16,10 @@ public class YotiConstants {
     public static final String CONTENT_TYPE_JSON = "application/json";
 
     public static final String JAVA = "Java";
+    public static final String BOUNCY_CASTLE_PROVIDER = "BC";
+    public static final String SIGNATURE_ALGORITHM = "SHA256withRSA";
+    public static final String ASYMMETRIC_CIPHER = "RSA/NONE/PKCS1Padding";
+    public static final String SYMMETRIC_CIPHER = "AES/CBC/PKCS7Padding";
 
     public static final String DEFAULT_CHARSET = "UTF-8";
 

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/factory/SignedMessageFactory.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/factory/SignedMessageFactory.java
@@ -1,6 +1,8 @@
 package com.yoti.api.client.spi.remote.call.factory;
 
 import static com.yoti.api.client.spi.remote.Base64.base64;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.BOUNCY_CASTLE_PROVIDER;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.SIGNATURE_ALGORITHM;
 
 import java.security.GeneralSecurityException;
 import java.security.PrivateKey;
@@ -8,9 +10,6 @@ import java.security.SecureRandom;
 import java.security.Signature;
 
 public class SignedMessageFactory {
-
-    private static final String BOUNCY_CASTLE_PROVIDER = "BC";
-    private static final String SIGNATURE_ALGORITHM = "SHA256withRSA";
 
     private final MessageFactory messageFactory;
 


### PR DESCRIPTION
We should always specify "BC" when we want to get a BouncyCastle _provided_ component.