### PR TITLE
API-413: Fix isAgeVerified property

### DIFF
--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/HumanProfileAdapter.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/HumanProfileAdapter.java
@@ -1,5 +1,7 @@
 package com.yoti.api.client.spi.remote;
 
+import static java.lang.Boolean.parseBoolean;
+
 import com.yoti.api.client.Attribute;
 import com.yoti.api.client.Date;
 import com.yoti.api.client.DocumentDetails;
@@ -103,9 +105,13 @@ final class HumanProfileAdapter implements HumanProfile {
 
     @Override
     public Boolean isAgeVerified() {
-        Boolean isAgeOver = wrapped.findAttributeStartingWith(ATTRIBUTE_AGE_OVER, Boolean.class);
-        Boolean isAgeUnder = wrapped.findAttributeStartingWith(ATTRIBUTE_AGE_UNDER, Boolean.class);
+        Boolean isAgeOver = parseFromStringValue(wrapped.findAttributeStartingWith(ATTRIBUTE_AGE_OVER, String.class));
+        Boolean isAgeUnder = parseFromStringValue(wrapped.findAttributeStartingWith(ATTRIBUTE_AGE_UNDER, String.class));
         return isAgeOver != null ? isAgeOver : isAgeUnder;
+    }
+
+    private Boolean parseFromStringValue(String value) {
+        return value == null ? null : parseBoolean(value);
     }
 
     @Override

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/HumanProfileAdapterTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/HumanProfileAdapterTest.java
@@ -54,7 +54,7 @@ public class HumanProfileAdapterTest {
 
     @Test
     public void isAgeVerified_shouldReturnValueOfAgeOver() {
-        when(profileMock.findAttributeStartingWith(ATTR_AGE_OVER, Boolean.class)).thenReturn(TRUE);
+        when(profileMock.findAttributeStartingWith(ATTR_AGE_OVER, String.class)).thenReturn("true");
 
         Boolean result = testObj.isAgeVerified();
 
@@ -63,7 +63,7 @@ public class HumanProfileAdapterTest {
 
     @Test
     public void isAgeVerified_shouldReturnValueOfAgeUnder() {
-        when(profileMock.findAttributeStartingWith(ATTR_AGE_UNDER, Boolean.class)).thenReturn(FALSE);
+        when(profileMock.findAttributeStartingWith(ATTR_AGE_UNDER, String.class)).thenReturn("false");
 
         Boolean result = testObj.isAgeVerified();
 
@@ -73,8 +73,8 @@ public class HumanProfileAdapterTest {
     // This scenario should never happen, but to be pragmatic...
     @Test
     public void isAgeVerified_shouldPreferAgeOverWhenBothAttributesArePresent() {
-        when(profileMock.findAttributeStartingWith(ATTR_AGE_OVER, Boolean.class)).thenReturn(TRUE);
-        when(profileMock.findAttributeStartingWith(ATTR_AGE_UNDER, Boolean.class)).thenReturn(FALSE);
+        when(profileMock.findAttributeStartingWith(ATTR_AGE_OVER, String.class)).thenReturn("true");
+        when(profileMock.findAttributeStartingWith(ATTR_AGE_UNDER, String.class)).thenReturn("false");
 
         Boolean result = testObj.isAgeVerified();
 


### PR DESCRIPTION
This is the shortest, simplest fix for the isAgeOver property.

I have a test in _connect-api-sandbox-service_ that tests this method with the _age_over:xx_ form of the derived property.  That test now passes.  Sandbox doesn't _yet_ support _age_under:xx_ so that still isn't tested.

Also note there is nothing in the getyoti java docs about _isAgeOver_ or the _age_over:xx_ / _age_under:xx_ attributes.  Same goes for the other language SDKs I looked at (which don't appear to support _age_under:xx_ either).

Once this approved I'll release it as 1.4.2-SNAPSHOT.

There are other SDK methods + properties I would to see tests for - DocumentDetails, Structured Address and any property we expect to support with _getAttribute(name, clazz)_