### PR TITLE
API-413: Update README for isAgeVerified() bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ If you are using Maven, you need to add the following dependency:
 
 If you are using Gradle, here is the dependency to add:
 
-`compile group: 'com.yoti', name: 'yoti-sdk-impl', version: '1.3'`
+`compile group: 'com.yoti', name: 'yoti-sdk-impl', version: '1.4.1'`
 
 You will find all classes packaged under `com.yoti.api`
 
@@ -176,6 +176,7 @@ try {
         String familyName = profile.getFamilyName();
         String mobileNumber = profile.getPhoneNumber();
         String emailAddress = profile.getEmailAddress();
+        Boolean isAgeVerified = profile.isAgeVerified();
         Date dateOfBirth = profile.getDateOfBirth();
         Gender gender = profile.getGender();
         String postalAddress = profile.getPostalAddress();
@@ -301,6 +302,20 @@ Combining this with the Spring Boot Auto Configuration can make integration very
 * Windows users - if you see `unmappable character for encoding Cp1252` when running `mvn clean install`, you need to set the default encoding to be UTF-8 before proceeding. This can be done by setting the `JAVA_TOOL_OPTIONS` variable from the Command Prompt: `set JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8`
 
 ## Known Issues
+
+### Age Verification
+
+#### Affects
+
+* Versions prior to 1.4.2
+
+#### Description
+
+A bug in the isAgeVerified() property of the profile meant that isAgeVerified() would always return null (i.e. not checked).
+
+#### How to fix
+
+Use SDK version 1.4.2 or later.
 
 ### Loading Private Keys
 

--- a/README.md
+++ b/README.md
@@ -96,13 +96,13 @@ If you are using Maven, you need to add the following dependency:
 <dependency>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-impl</artifactId>
-    <version>1.4.1</version>
+    <version>1.4.2</version>
 </dependency>
 ```
 
 If you are using Gradle, here is the dependency to add:
 
-`compile group: 'com.yoti', name: 'yoti-sdk-impl', version: '1.4.1'`
+`compile group: 'com.yoti', name: 'yoti-sdk-impl', version: '1.4.2'`
 
 You will find all classes packaged under `com.yoti.api`
 
@@ -311,7 +311,7 @@ Combining this with the Spring Boot Auto Configuration can make integration very
 
 #### Description
 
-A bug in the isAgeVerified() property of the profile meant that isAgeVerified() would always return null (i.e. not checked).
+A bug in the `isAgeVerified()` property of the profile meant that `isAgeVerified()` would always return null (i.e. not checked).
 
 #### How to fix
 

--- a/yoti-sdk-spring-boot-example/README.md
+++ b/yoti-sdk-spring-boot-example/README.md
@@ -16,7 +16,7 @@ Before you start, you'll need to create an Application in [Dashboard](https://ww
     <dependency>
       <groupId>com.yoti</groupId>
       <artifactId>yoti-sdk-impl</artifactId>
-      <version>1.4.1</version>
+      <version>1.4.2</version>
     </dependency>
 ```
 

--- a/yoti-sdk-spring-security/README.md
+++ b/yoti-sdk-spring-security/README.md
@@ -32,7 +32,7 @@ If you are using Maven, you need to add the following dependencies:
 If you are using Gradle, here is the dependency to add:
 
 ```
-compile group: 'com.yoti', name: 'yoti-sdk-spring-security', version: '1.0'
+compile group: 'com.yoti', name: 'yoti-sdk-spring-security', version: '1.4.1'
 ```
 
 ### Provide a `YotiClient` instance

--- a/yoti-sdk-spring-security/README.md
+++ b/yoti-sdk-spring-security/README.md
@@ -25,14 +25,14 @@ If you are using Maven, you need to add the following dependencies:
 <dependency>
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-security</artifactId>
-  <version>1.4.1</version>
+  <version>1.4.2</version>
 </dependency>
 ```
 
 If you are using Gradle, here is the dependency to add:
 
 ```
-compile group: 'com.yoti', name: 'yoti-sdk-spring-security', version: '1.4.1'
+compile group: 'com.yoti', name: 'yoti-sdk-spring-security', version: '1.4.2'
 ```
 
 ### Provide a `YotiClient` instance


### PR DESCRIPTION
Is this a reasonable update for isAgeVerified()?

I'll bump the version numbers to 1.4.2 when it has been released.