### PR TITLE
API-407: Support for extended document_details attribute in Java SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk</artifactId>
   <packaging>pom</packaging>
-  <version>1.4.2-SNAPSHOT</version>
+  <version>1.4.3-SNAPSHOT</version>
   <name>Yoti SDK</name>
   <description>Java SDK for simple integration with the Yoti platform</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>

--- a/yoti-sdk-api/pom.xml
+++ b/yoti-sdk-api/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-api</artifactId>
-  <version>1.4.2-SNAPSHOT</version>
+  <version>1.4.3-SNAPSHOT</version>
   <name>Yoti SDK API</name>
   <description>Java SDK for simple integration with the Yoti platform</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/DocumentDetails.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/DocumentDetails.java
@@ -5,6 +5,7 @@ package com.yoti.api.client;
  *
  */
 public interface DocumentDetails {
+
     /**
      * Return document type.
      * 
@@ -33,7 +34,18 @@ public interface DocumentDetails {
      */
     Date getExpirationDate();
 
+    /**
+     * Either a country code, or the name of the issuing authority
+     *
+     * @return Either a country code, or the name of the issuing authority
+     */
+    String getIssuingAuthority();
+
     static enum DocumentType {
-        PASSPORT
+        PASSPORT,
+        DRIVING_LICENCE,
+        AADHAAR,
+        PASS_CARD
     }
+
 }

--- a/yoti-sdk-impl/pom.xml
+++ b/yoti-sdk-impl/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-impl</artifactId>
-  <version>1.4.2-SNAPSHOT</version>
+  <version>1.4.3-SNAPSHOT</version>
   <name>Yoti SDK implementation package</name>
   <description>Java SDK for simple integration with the Yoti platform</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>
@@ -28,7 +28,7 @@
   </developers>
 
   <properties>
-    <yoti.sdk.version>1.4.2-SNAPSHOT</yoti.sdk.version>
+    <yoti.sdk.version>1.4.3-SNAPSHOT</yoti.sdk.version>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
     <owasp.dependency.check.cvss.limit>4</owasp.dependency.check.cvss.limit>

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/DocumentDetailsAttributeValue.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/DocumentDetailsAttributeValue.java
@@ -1,45 +1,56 @@
 package com.yoti.api.client.spi.remote;
 
-import java.io.UnsupportedEncodingException;
-import java.text.ParseException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import com.yoti.api.client.Date;
 import com.yoti.api.client.DocumentDetails;
 
+import java.io.UnsupportedEncodingException;
+import java.text.ParseException;
+
 final class DocumentDetailsAttributeValue implements DocumentDetails {
-    private static final String DETAILS_REGEX = "([A-Za-z]*) ([A-Za-z]{3}) ([A-Za-z0-9]*) (.*)";
-    private static final Pattern DETAILS_PATTERN = Pattern.compile(DETAILS_REGEX);
-    private static final int TYPE_GROUP = 1;
-    private static final int COUNTRY_GROUP = 2;
-    private static final int NUMBER_GROUP = 3;
-    private static final int EXPIRATION_GROUP = 4;
+
+    private static final String MINIMUM_ACCEPTABLE = "([A-Za-z_]*) ([A-Za-z]{3}) ([A-Za-z0-9]{1}).*";
+    private static final int TYPE_INDEX = 0;
+    private static final int COUNTRY_INDEX = 1;
+    private static final int NUMBER_INDEX = 2;
+    private static final int EXPIRATION_INDEX = 3;
+    private static final int AUTHORITY_INDEX = 4;
+
     private final DocumentType type;
     private final String issuingCountry;
     private final Date expirationDate;
     private final String number;
+    private final String authority;
 
-    public DocumentDetailsAttributeValue(DocumentType type, String issuingCountry, Date expirationDate, String number) {
+    public DocumentDetailsAttributeValue(DocumentType type, String issuingCountry, Date expirationDate, String number, String authority) {
         this.type = type;
         this.issuingCountry = issuingCountry;
         this.expirationDate = expirationDate;
         this.number = number;
+        this.authority = authority;
     }
 
     public static DocumentDetails parseFrom(String attribute) throws UnsupportedEncodingException, ParseException {
-        DocumentDetailsAttributeValue result = null;
-        if (attribute != null) {
-            Matcher matcher = DETAILS_PATTERN.matcher(attribute);
-            if (matcher.matches()) {
-                DocumentType type = DocumentType.valueOf(matcher.group(TYPE_GROUP));
-                String issuingCountry = matcher.group(COUNTRY_GROUP);
-                Date expirationDate = DateAttributeValue.parseFrom(matcher.group(EXPIRATION_GROUP));
-                String number = matcher.group(NUMBER_GROUP);
-                result = new DocumentDetailsAttributeValue(type, issuingCountry, expirationDate, number);
-            }
+        if (attribute == null || !attribute.matches(MINIMUM_ACCEPTABLE)) {
+            return null;
         }
-        return result;
+
+        String[] attributes = attribute.split(" ");
+        DocumentType documentType = DocumentType.valueOf(attributes[TYPE_INDEX]);
+        String issuingCountry = attributes[COUNTRY_INDEX];
+        String number = attributes[NUMBER_INDEX];
+        Date expirationDate = getDateSafely(attributes, EXPIRATION_INDEX);
+        String issuingAuthority = getSafely(attributes, AUTHORITY_INDEX);
+        return new DocumentDetailsAttributeValue(documentType, issuingCountry, expirationDate, number, issuingAuthority);
+    }
+
+    private static Date getDateSafely(String[] attributes, int index) throws UnsupportedEncodingException, ParseException {
+        String expirationDate = getSafely(attributes, index);
+        return expirationDate == null ? null : DateAttributeValue.parseFrom(expirationDate);
+    }
+
+    private static String getSafely(String[] attributes, int index) {
+        String value = attributes.length > index ? attributes[index] : null;
+        return "-".equals(value) ? null : value;
     }
 
     @Override
@@ -61,4 +72,21 @@ final class DocumentDetailsAttributeValue implements DocumentDetails {
     public Date getExpirationDate() {
         return expirationDate;
     }
+
+    @Override
+    public String getIssuingAuthority() {
+        return authority;
+    }
+
+    @Override
+    public String toString() {
+        return "DocumentDetailsAttributeValue{" +
+                "type=" + type +
+                ", issuingCountry='" + issuingCountry + '\'' +
+                ", number='" + number + '\'' +
+                ", expirationDate=" + expirationDate +
+                ", issuingAuthority='" + authority + '\'' +
+                '}';
+    }
+
 }

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/DocumentDetailsAttributeValueTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/DocumentDetailsAttributeValueTest.java
@@ -1,49 +1,108 @@
 package com.yoti.api.client.spi.remote;
 
+import static com.yoti.api.client.DocumentDetails.DocumentType.AADHAAR;
+import static com.yoti.api.client.DocumentDetails.DocumentType.DRIVING_LICENCE;
+import static com.yoti.api.client.DocumentDetails.DocumentType.PASSPORT;
+import static com.yoti.api.client.DocumentDetails.DocumentType.PASS_CARD;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-import java.io.UnsupportedEncodingException;
-import java.text.ParseException;
-
+import com.yoti.api.client.DocumentDetails;
 import org.junit.Test;
 
-import com.yoti.api.client.DocumentDetails;
+import java.text.ParseException;
 
 public class DocumentDetailsAttributeValueTest {
-    private static final String VALID_ATTRIBUTE = "PASSPORT GBR 1234abc 2016-05-01";
+
     private static final String INVALID_ATTRIBUTE__TYPE = "XXXPORT GBR 1234abc 2016-05-01";
     private static final String INVALID_ATTRIBUTE__NUMBER = "PASSPORT GBR $%^$%^£ 2016-05-01";
     private static final String INVALID_ATTRIBUTE__COUNTRY = "PASSPORT 13 1234abc 2016-05-01";
-    private static final String INVALID_ATTRIBUTE__DATE = "PASSPORT GBR 1234abc X016-05-01";
+    private static final String INVALID_ATTRIBUTE__DATE = "PASSPORT GBR 1234abc" + " X016-05-01";
 
     @Test
-    public void shouldParseValidAttribute() throws UnsupportedEncodingException, ParseException {
-        DocumentDetails details = DocumentDetailsAttributeValue.parseFrom(VALID_ATTRIBUTE);
-        assertNotNull(details);
-        assertEquals(DocumentDetails.DocumentType.PASSPORT, details.getType());
+    public void shouldReturnNullForNullAttribute() throws Exception {
+        DocumentDetails result = DocumentDetailsAttributeValue.parseFrom(null);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void shouldReturnNullWhenAttributesAreMissing() throws Exception {
+        DocumentDetails result = DocumentDetailsAttributeValue.parseFrom("PASSPORT GBR");
+
+        assertNull(result);
+    }
+
+    @Test
+    public void shouldParseMandatoryAttributes() throws Exception {
+        DocumentDetails result = DocumentDetailsAttributeValue.parseFrom("PASSPORT GBR 1234abc");
+
+        assertNotNull(result);
+        assertEquals(PASSPORT, result.getType());
+        assertEquals("GBR", result.getIssuingCountry());
+        assertEquals("1234abc", result.getDocumentNumber());
+        assertNull(result.getExpirationDate());
+        assertNull(result.getIssuingAuthority());
+    }
+
+    @Test
+    public void shouldParseOneOptionalAttribute() throws Exception {
+        DocumentDetails result = DocumentDetailsAttributeValue.parseFrom("AADHAAR IND 1234abc 2016-05-01");
+
+        assertNotNull(result);
+        assertEquals(AADHAAR, result.getType());
+        assertEquals("IND", result.getIssuingCountry());
+        assertEquals("1234abc", result.getDocumentNumber());
+        assertEquals("2016-05-01", result.getExpirationDate().toString());
+        assertNull(result.getIssuingAuthority());
+    }
+
+    @Test
+    public void shouldParseTwoOptionalAttributes() throws Exception {
+        DocumentDetails result = DocumentDetailsAttributeValue.parseFrom("DRIVING_LICENCE GBR 1234abc 2016-05-01 DVLA");
+
+        assertNotNull(result);
+        assertEquals(DRIVING_LICENCE, result.getType());
+        assertEquals("GBR", result.getIssuingCountry());
+        assertEquals("1234abc", result.getDocumentNumber());
+        assertEquals("2016-05-01", result.getExpirationDate().toString());
+        assertEquals("DVLA", result.getIssuingAuthority());
+    }
+
+    @Test
+    public void shouldParseWhenOneOptionalAttributeIsMissing() throws Exception {
+        DocumentDetails result = DocumentDetailsAttributeValue.parseFrom("PASS_CARD GBR 1234abc - DVLA");
+
+        assertNotNull(result);
+        assertEquals(PASS_CARD, result.getType());
+        assertEquals("GBR", result.getIssuingCountry());
+        assertEquals("1234abc", result.getDocumentNumber());
+        assertNull(result.getExpirationDate());
+        assertEquals("DVLA", result.getIssuingAuthority());
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void shouldFailOnInvalidType() throws UnsupportedEncodingException, ParseException {
+    public void shouldFailOnInvalidType() throws Exception {
         DocumentDetailsAttributeValue.parseFrom(INVALID_ATTRIBUTE__TYPE);
     }
 
     @Test
-    public void shouldFailOnInvalidNumber() throws UnsupportedEncodingException, ParseException {
-        DocumentDetails details = DocumentDetailsAttributeValue.parseFrom(INVALID_ATTRIBUTE__NUMBER);
-        assertNull(details);
+    public void shouldFailOnInvalidNumber() throws Exception {
+        DocumentDetails result = DocumentDetailsAttributeValue.parseFrom(INVALID_ATTRIBUTE__NUMBER);
+
+        assertNull(result);
     }
 
     @Test(expected = ParseException.class)
-    public void shouldFailOnInvalidDate() throws UnsupportedEncodingException, ParseException {
+    public void shouldFailOnInvalidDate() throws Exception {
         DocumentDetailsAttributeValue.parseFrom(INVALID_ATTRIBUTE__DATE);
     }
 
     @Test
-    public void shouldFailOnInvalidCountry() throws UnsupportedEncodingException, ParseException {
-        DocumentDetails details = DocumentDetailsAttributeValue.parseFrom(INVALID_ATTRIBUTE__COUNTRY);
-        assertNull(details);
+    public void shouldFailOnInvalidCountry() throws Exception {
+        DocumentDetails result = DocumentDetailsAttributeValue.parseFrom(INVALID_ATTRIBUTE__COUNTRY);
+
+        assertNull(result);
     }
 }

--- a/yoti-sdk-spring-boot-auto-config/pom.xml
+++ b/yoti-sdk-spring-boot-auto-config/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <properties>
-    <yoti.sdk.version>1.4.2-SNAPSHOT</yoti.sdk.version>
+    <yoti.sdk.version>1.4.3-SNAPSHOT</yoti.sdk.version>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
     <owasp.dependency.check.cvss.limit>4</owasp.dependency.check.cvss.limit>
@@ -15,7 +15,7 @@
 
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-boot-auto-config</artifactId>
-  <version>1.4.2-SNAPSHOT</version>
+  <version>1.4.3-SNAPSHOT</version>
   <name>Yoti Spring Boot Integration</name>
   <description>Library to integrate the Java Yoti SDK with Spring Boot Applications</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>

--- a/yoti-sdk-spring-boot-example/pom.xml
+++ b/yoti-sdk-spring-boot-example/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-boot-example</artifactId>
-  <version>1.4.2-SNAPSHOT</version>
+  <version>1.4.3-SNAPSHOT</version>
   <name>Yoti Spring Boot Example</name>
   <parent>
     <groupId>org.springframework.boot</groupId>
@@ -13,7 +13,7 @@
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <properties>
-    <yoti.sdk.version>1.4.2-SNAPSHOT</yoti.sdk.version>
+    <yoti.sdk.version>1.4.3-SNAPSHOT</yoti.sdk.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
   </properties>

--- a/yoti-sdk-spring-security/pom.xml
+++ b/yoti-sdk-spring-security/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <properties>
-    <yoti.sdk.version>1.4.2-SNAPSHOT</yoti.sdk.version>
+    <yoti.sdk.version>1.4.3-SNAPSHOT</yoti.sdk.version>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
     <owasp.dependency.check.cvss.limit>4</owasp.dependency.check.cvss.limit>
@@ -15,7 +15,7 @@
 
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-security</artifactId>
-  <version>1.4.2-SNAPSHOT</version>
+  <version>1.4.3-SNAPSHOT</version>
   <name>Spring Security Integration For The Yoti SDK</name>
   <description>Library to integrate the Java Yoti SDK with Spring Security</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>


### PR DESCRIPTION
There was a problem where DocumentDetails would not be parsed if no optional attributes were provided, now fixed.  It now also supports the new _issuingAuthority_ attribute.

For now, the new document types have been included in the enum because removing the enum would be a breaking change.  There's a more detailed discussion in the ticket.
https://lampkicking.atlassian.net/projects/API/issues/API-407

This doesn't have to go in, in its present form.  If we review the ticket and decide to do something about the questions raised then we'll address them first before merging/releasing this.