### PR TITLE
API-476: Final tidy up

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,13 @@ If you are using Maven, you need to add the following dependency:
 <dependency>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-impl</artifactId>
-    <version>1.4.2</version>
+    <version>1.5.0</version>
 </dependency>
 ```
 
 If you are using Gradle, here is the dependency to add:
 
-`compile group: 'com.yoti', name: 'yoti-sdk-impl', version: '1.4.2'`
+`compile group: 'com.yoti', name: 'yoti-sdk-impl', version: '1.5.0'`
 
 You will find all classes packaged under `com.yoti.api`
 

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AttributeConverter.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AttributeConverter.java
@@ -8,69 +8,53 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yoti.api.client.Attribute;
 import com.yoti.api.client.spi.remote.proto.AttrProto;
 import com.yoti.api.client.spi.remote.proto.AttrProto.Anchor;
-import com.yoti.api.client.spi.remote.proto.ContentTypeProto.ContentType;
 import com.yoti.api.client.spi.remote.util.AnchorCertificateParser;
-import com.yoti.api.client.spi.remote.util.AnchorType;
 import com.yoti.api.client.spi.remote.util.AnchorCertificateParser.AnchorVerifierSourceData;
+import com.yoti.api.client.spi.remote.util.AnchorType;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AttributeConverter {
 
     private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
     private static final Logger LOG = LoggerFactory.getLogger(AttributeConverter.class);
 
-    
-    public static Attribute convertAttribute(AttrProto.Attribute attribute) throws ParseException, IOException{
-        if (ContentType.STRING.equals(attribute.getContentType())) {
-            return new com.yoti.api.client.Attribute(attribute.getName(), 
-                attribute.getValue().toString(DEFAULT_CHARSET), 
-                extractMetadata(attribute, AnchorType.SOURCE),
-                extractMetadata(attribute, AnchorType.VERIFIER));
-        } else if (ContentType.DATE.equals(attribute.getContentType())) {
-            return new com.yoti.api.client.Attribute(attribute.getName(),
-                DateAttributeValue.parseFrom(attribute.getValue().toByteArray()),
-                extractMetadata(attribute, AnchorType.SOURCE),
-                extractMetadata(attribute, AnchorType.VERIFIER));        
-        } else if (ContentType.JPEG.equals(attribute.getContentType())) {
-            return new com.yoti.api.client.Attribute(attribute.getName(),
-                new JpegAttributeValue(attribute.getValue().toByteArray()),
-                extractMetadata(attribute, AnchorType.SOURCE),
-                extractMetadata(attribute, AnchorType.VERIFIER));
-        } else if (ContentType.PNG.equals(attribute.getContentType())) {
-            return new com.yoti.api.client.Attribute(attribute.getName(),
-                new PngAttributeValue(attribute.getValue().toByteArray()),
-                extractMetadata(attribute, AnchorType.SOURCE),
-                extractMetadata(attribute, AnchorType.VERIFIER));
-        } else if (ContentType.JSON.equals(attribute.getContentType())) {
-            return new com.yoti.api.client.Attribute(attribute.getName(),
-                JSON_MAPPER.readValue(attribute.getValue().toString(DEFAULT_CHARSET), Map.class),
-                extractMetadata(attribute, AnchorType.SOURCE),
-                extractMetadata(attribute, AnchorType.VERIFIER));
+    public static Attribute convertAttribute(com.yoti.api.client.spi.remote.proto.AttrProto.Attribute attribute) throws ParseException, IOException {
+        switch (attribute.getContentType()) {
+            case STRING:
+                return attributeWithMetadata(attribute, attribute.getValue().toString(DEFAULT_CHARSET));
+            case DATE:
+                return attributeWithMetadata(attribute, DateAttributeValue.parseFrom(attribute.getValue().toByteArray()));
+            case JPEG:
+                return attributeWithMetadata(attribute, new JpegAttributeValue(attribute.getValue().toByteArray()));
+            case PNG:
+                return attributeWithMetadata(attribute, new PngAttributeValue(attribute.getValue().toByteArray()));
+            case JSON:
+                return attributeWithMetadata(attribute, JSON_MAPPER.readValue(attribute.getValue().toString(DEFAULT_CHARSET), Map.class));
+            default:
+                LOG.error("Unknown type {} for attribute {}", attribute.getContentType(), attribute.getName());
+                return attributeWithMetadata(attribute, attribute.getValue().toString(DEFAULT_CHARSET));
         }
+    }
 
-        LOG.error("Unknown type {} for attribute {}", attribute.getContentType(), attribute.getName());
-        return new com.yoti.api.client.Attribute(attribute.getName(), 
-                attribute.getValue().toString(DEFAULT_CHARSET),
-                extractMetadata(attribute, AnchorType.SOURCE),
-                extractMetadata(attribute, AnchorType.VERIFIER));
+    private static Attribute attributeWithMetadata(AttrProto.Attribute attribute, Object value) {
+        return new Attribute(attribute.getName(), value, extractMetadata(attribute, AnchorType.SOURCE), extractMetadata(attribute, AnchorType.VERIFIER));
     }
 
     private static Set<String> extractMetadata(AttrProto.Attribute attribute, AnchorType anchorType) {
         Set<String> entries = new HashSet<String>();
         for (Anchor anchor : attribute.getAnchorsList()) {
             AnchorVerifierSourceData anchorData = AnchorCertificateParser.getTypesFromAnchor(anchor);
-            if(anchorData.getType().equals(anchorType)) {
+            if (anchorData.getType().equals(anchorType)) {
                 entries.addAll(anchorData.getEntries());
             }
         }
         return entries;
     }
 
-    
 }

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/SimpleActivityDetailsTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/SimpleActivityDetailsTest.java
@@ -13,6 +13,7 @@ import com.yoti.api.client.Attribute;
 import com.yoti.api.client.Profile;
 
 public class SimpleActivityDetailsTest {
+
     private static final String USER_ID = "YmFkYWRhZGEtZGFkYWJhZGEK";
     private static final Profile USER_PROFILE = Mockito.mock(Profile.class);
     private static final Profile APP_PROFILE = Mockito.mock(Profile.class);
@@ -21,6 +22,7 @@ public class SimpleActivityDetailsTest {
     private static final byte[] RECEIPT_ID = { 1, 2, 3, 4, 5, 6, 7, 8 };
     private static final String RECEIPT_ID_STRING = Base64.toBase64String(RECEIPT_ID);
     private static final Date TIMESTAMP = new Date();
+    private static final byte[] SOME_SELFIE_BYTES = "selfieTestVal".getBytes();
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldFailConstructionForNullRememberMeId() {
@@ -78,13 +80,13 @@ public class SimpleActivityDetailsTest {
     
     @Test
     public void shouldReturnBase64SelfieIfSelfieSet() {
-        Attribute selfie = new Attribute("selfie", new JpegAttributeValue("selfieTestVal".getBytes()), null);
+        Attribute selfie = new Attribute("selfie", new JpegAttributeValue(SOME_SELFIE_BYTES), null);
         SimpleProfile profile = new SimpleProfile(singletonList(selfie));
 
-        SimpleActivityDetails s = new SimpleActivityDetails(USER_ID, profile, APP_PROFILE, TIMESTAMP, RECEIPT_ID);
-        String expected = "data:image/jpeg;base64," + Base64.toBase64String(s.getUserProfile().getSelfie().getContent());
-        
-        assertEquals(expected, s.getBase64Selfie());
+        SimpleActivityDetails result = new SimpleActivityDetails(USER_ID, profile, APP_PROFILE, TIMESTAMP, RECEIPT_ID);
+
+        String expected = "data:image/jpeg;base64," + Base64.toBase64String(SOME_SELFIE_BYTES);
+        assertEquals(expected, result.getBase64Selfie());
     }
     
     @Test
@@ -92,8 +94,8 @@ public class SimpleActivityDetailsTest {
         Attribute familyName = new Attribute("family_name", "Smith", null);
         SimpleProfile profile = new SimpleProfile(singletonList(familyName));
 
-        SimpleActivityDetails s = new SimpleActivityDetails(USER_ID, profile, APP_PROFILE, TIMESTAMP, RECEIPT_ID);
+        SimpleActivityDetails result = new SimpleActivityDetails(USER_ID, profile, APP_PROFILE, TIMESTAMP, RECEIPT_ID);
         
-        assertEquals("", s.getBase64Selfie());
+        assertEquals("", result.getBase64Selfie());
     }
 }

--- a/yoti-sdk-spring-boot-auto-config/README.md
+++ b/yoti-sdk-spring-boot-auto-config/README.md
@@ -26,7 +26,7 @@ If you are using Maven, you need to add the following dependencies:
 If you are using Gradle, here is the dependency to add:
 
 ```
-compile group: 'com.yoti', name: 'yoti-sdk-spring-boot-auto-config', version: '1.4.1'
+compile group: 'com.yoti', name: 'yoti-sdk-spring-boot-auto-config', version: '1.5.0'
 ```
 
 

--- a/yoti-sdk-spring-boot-auto-config/pom.xml
+++ b/yoti-sdk-spring-boot-auto-config/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
-      <version>1.5.6.RELEASE</version>
+      <version>1.5.10.RELEASE</version>
       <scope>provided</scope>
     </dependency>
 

--- a/yoti-sdk-spring-boot-example/README.md
+++ b/yoti-sdk-spring-boot-example/README.md
@@ -16,7 +16,7 @@ Before you start, you'll need to create an Application in [Dashboard](https://ww
     <dependency>
       <groupId>com.yoti</groupId>
       <artifactId>yoti-sdk-impl</artifactId>
-      <version>1.4.2</version>
+      <version>1.5.0</version>
     </dependency>
 ```
 

--- a/yoti-sdk-spring-security/README.md
+++ b/yoti-sdk-spring-security/README.md
@@ -25,14 +25,14 @@ If you are using Maven, you need to add the following dependencies:
 <dependency>
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-security</artifactId>
-  <version>1.4.2</version>
+  <version>1.5.0</version>
 </dependency>
 ```
 
 If you are using Gradle, here is the dependency to add:
 
 ```
-compile group: 'com.yoti', name: 'yoti-sdk-spring-security', version: '1.4.2'
+compile group: 'com.yoti', name: 'yoti-sdk-spring-security', version: '1.5.0'
 ```
 
 ### Provide a `YotiClient` instance

--- a/yoti-sdk-spring-security/pom.xml
+++ b/yoti-sdk-spring-security/pom.xml
@@ -11,6 +11,7 @@
     <owasp.dependency.check.cvss.limit>4</owasp.dependency.check.cvss.limit>
     <owasp.dependency.check.cve.update.limit>24</owasp.dependency.check.cve.update.limit>
     <findbugs.version>3.0.0</findbugs.version>
+    <spring.core.version>4.3.14.RELEASE</spring.core.version>
   </properties>
 
   <groupId>com.yoti</groupId>
@@ -45,6 +46,36 @@
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-core</artifactId>
         <version>1.3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-core</artifactId>
+        <version>${spring.core.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-aop</artifactId>
+        <version>${spring.core.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-beans</artifactId>
+        <version>${spring.core.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-web</artifactId>
+        <version>${spring.core.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-context</artifactId>
+        <version>${spring.core.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-expression</artifactId>
+        <version>${spring.core.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Some changes I chose to make, some were forced upon me....

**CVE**
There were some more CVE errors, this time for Spring.  One is from spring-boot, one is spring-core (security).  Rather than add more CVE exclusions,  I have bumped the versions of both to the lowest possible release needed.

**finbugs**
There were a few:
1. It didn't like handling _Exception_
2. It didn't like deserialisation of an object.  It turns out we don't have to use _InputStream_ after all.  Since we have a String, we can just use its bytes and get the BC _ASN1Primitive_ that way.  The tests pass, so I believe it works.