### PR TITLE
SDK-389: Break up SecureYotiClient

### DIFF
--- a/yoti-sdk-impl/findbugs-rules.xml
+++ b/yoti-sdk-impl/findbugs-rules.xml
@@ -7,12 +7,6 @@
 <FindBugsFilter>
 
     <Match>
-        <Class name="com.yoti.api.client.spi.remote.SecureYotiClient"/>
-        <Method name="decryptConnectToken"/>
-        <Bug pattern="REC_CATCH_EXCEPTION"/>
-    </Match>
-
-    <Match>
         <Class name="com.yoti.api.client.spi.remote.call.Receipt"/>
         <Bug pattern="EI_EXPOSE_REP"/>
     </Match>
@@ -23,12 +17,12 @@
     </Match>
 
     <Match>
-        <Class name="com.yoti.api.client.spi.remote.SecureYotiClient"/>
+        <Class name="com.yoti.api.client.spi.remote.ProfileReader"/>
         <Bug pattern="CIPHER_INTEGRITY"/>
     </Match>
 
     <Match>
         <Bug pattern="CRLF_INJECTION_LOGS"/>
     </Match>
-</FindBugsFilter>
 
+</FindBugsFilter>

--- a/yoti-sdk-impl/pom.xml
+++ b/yoti-sdk-impl/pom.xml
@@ -54,6 +54,11 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ActivityDetailsFactory.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ActivityDetailsFactory.java
@@ -18,9 +18,9 @@ import com.yoti.api.client.ActivityDetails;
 import com.yoti.api.client.Profile;
 import com.yoti.api.client.ProfileException;
 import com.yoti.api.client.spi.remote.call.Receipt;
-import com.yoti.api.client.spi.remote.util.Decryption;
+import com.yoti.api.client.spi.remote.util.DecryptionHelper;
 
-public class ActivityDetailsFactory {
+class ActivityDetailsFactory {
 
     private static final String RFC3339_PATTERN = "yyyy-MM-dd'T'HH:mm:ss'Z'";
 
@@ -30,12 +30,12 @@ public class ActivityDetailsFactory {
         this.profileReader = notNull(profileReader, "profileReader");
     }
 
-    public static ActivityDetailsFactory newInstance() {
+    static ActivityDetailsFactory newInstance() {
         return new ActivityDetailsFactory(ProfileReader.newInstance());
     }
 
-    public ActivityDetails create(Receipt receipt, PrivateKey privateKey) throws ProfileException {
-        byte[] decryptedKey = Decryption.decryptAsymmetric(receipt.getWrappedReceiptKey(), privateKey);
+    ActivityDetails create(Receipt receipt, PrivateKey privateKey) throws ProfileException {
+        byte[] decryptedKey = DecryptionHelper.decryptAsymmetric(receipt.getWrappedReceiptKey(), privateKey);
         Key secretKey = new SecretKeySpec(decryptedKey, SYMMETRIC_CIPHER);
 
         Profile userProfile = profileReader.read(receipt.getOtherPartyProfile(), secretKey);

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ActivityDetailsFactory.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ActivityDetailsFactory.java
@@ -1,0 +1,66 @@
+package com.yoti.api.client.spi.remote;
+
+import static com.yoti.api.client.spi.remote.call.YotiConstants.DEFAULT_CHARSET;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.SYMMETRIC_CIPHER;
+import static com.yoti.api.client.spi.remote.util.Validation.notNull;
+
+import java.io.UnsupportedEncodingException;
+import java.security.Key;
+import java.security.PrivateKey;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import javax.crypto.spec.SecretKeySpec;
+
+import com.yoti.api.client.ActivityDetails;
+import com.yoti.api.client.Profile;
+import com.yoti.api.client.ProfileException;
+import com.yoti.api.client.spi.remote.call.Receipt;
+import com.yoti.api.client.spi.remote.util.Decryption;
+
+public class ActivityDetailsFactory {
+
+    private static final String RFC3339_PATTERN = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+
+    private final ProfileReader profileReader;
+
+    private ActivityDetailsFactory(ProfileReader profileReader) {
+        this.profileReader = notNull(profileReader, "profileReader");
+    }
+
+    public static ActivityDetailsFactory newInstance() {
+        return new ActivityDetailsFactory(ProfileReader.newInstance());
+    }
+
+    public ActivityDetails create(Receipt receipt, PrivateKey privateKey) throws ProfileException {
+        byte[] decryptedKey = Decryption.decryptAsymmetric(receipt.getWrappedReceiptKey(), privateKey);
+        Key secretKey = new SecretKeySpec(decryptedKey, SYMMETRIC_CIPHER);
+
+        Profile userProfile = profileReader.read(receipt.getOtherPartyProfile(), secretKey);
+        Profile applicationProfile = profileReader.read(receipt.getProfile(), secretKey);
+        String rememberMeId = parseRememberMeId(receipt.getRememberMeId());
+        Date timestamp = parseTimestamp(receipt.getTimestamp());
+
+        return new SimpleActivityDetails(rememberMeId, userProfile, applicationProfile, timestamp, receipt.getReceiptId());
+    }
+
+    private String parseRememberMeId(byte[] rmi) throws ProfileException {
+        try {
+            return (rmi == null) ? null : new String(Base64.getEncoder().encode(rmi), DEFAULT_CHARSET);
+        } catch (UnsupportedEncodingException e) {
+            throw new ProfileException("Cannot parse user ID", e);
+        }
+    }
+
+    private Date parseTimestamp(String timestamp) throws ProfileException {
+        try {
+            DateFormat dateFormat = new SimpleDateFormat(RFC3339_PATTERN);
+            return dateFormat.parse(timestamp);
+        } catch (ParseException e) {
+            throw new ProfileException("Cannot parse timestamp", e);
+        }
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AttributeConverter.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AttributeConverter.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class AttributeConverter {
+class AttributeConverter {
 
     private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
     private static final Logger LOG = LoggerFactory.getLogger(AttributeConverter.class);
@@ -32,11 +32,11 @@ public class AttributeConverter {
         this.documentDetailsAttributeParser = documentDetailsAttributeParser;
     }
 
-    public static final AttributeConverter newInstance() {
+    static final AttributeConverter newInstance() {
         return new AttributeConverter(new DocumentDetailsAttributeParser());
     }
 
-    public <T> Attribute<T> convertAttribute(AttrProto.Attribute attribute) throws ParseException, IOException {
+    <T> Attribute<T> convertAttribute(AttrProto.Attribute attribute) throws ParseException, IOException {
         Object value = convertValueFromProto(attribute);
         value = convertSpecialType(attribute, value);
         Set<String> sources = extractMetadata(attribute, AnchorType.SOURCE);

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AttributeListConverter.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AttributeListConverter.java
@@ -15,7 +15,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class AttributeListConverter {
+class AttributeListConverter {
 
     private static final Logger LOG = LoggerFactory.getLogger(AttributeListConverter.class);
 
@@ -25,11 +25,11 @@ public class AttributeListConverter {
         this.attributeConverter = attributeConverter;
     }
 
-    public static AttributeListConverter newInstance() {
+    static AttributeListConverter newInstance() {
         return new AttributeListConverter(AttributeConverter.newInstance());
     }
 
-    public List<Attribute<?>> parseAttributeList(byte[] attributeListBytes) throws ProfileException {
+    List<Attribute<?>> parseAttributeList(byte[] attributeListBytes) throws ProfileException {
         if (attributeListBytes == null || attributeListBytes.length == 0) {
             return Collections.emptyList();
         }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AttributeListConverter.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AttributeListConverter.java
@@ -1,0 +1,63 @@
+package com.yoti.api.client.spi.remote;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.yoti.api.client.Attribute;
+import com.yoti.api.client.ProfileException;
+import com.yoti.api.client.spi.remote.proto.AttrProto;
+import com.yoti.api.client.spi.remote.proto.AttributeListProto;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AttributeListConverter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AttributeListConverter.class);
+
+    private final AttributeConverter attributeConverter;
+
+    private AttributeListConverter(AttributeConverter attributeConverter) {
+        this.attributeConverter = attributeConverter;
+    }
+
+    public static AttributeListConverter newInstance() {
+        return new AttributeListConverter(AttributeConverter.newInstance());
+    }
+
+    public List<Attribute<?>> parseAttributeList(byte[] attributeListBytes) throws ProfileException {
+        if (attributeListBytes == null || attributeListBytes.length == 0) {
+            return Collections.emptyList();
+        }
+
+        AttributeListProto.AttributeList attributeList = parseProto(attributeListBytes);
+        List<Attribute<?>> attributes = parseAttributes(attributeList);
+        LOG.debug("{} attribute(s) parsed", attributes.size());
+        return attributes;
+    }
+
+    private AttributeListProto.AttributeList parseProto(byte[] attributeListBytes) throws ProfileException {
+        try {
+            return AttributeListProto.AttributeList.parseFrom(attributeListBytes);
+        } catch (InvalidProtocolBufferException e) {
+            throw new ProfileException("Cannot parse profile data", e);
+        }
+    }
+
+    private List<Attribute<?>> parseAttributes(AttributeListProto.AttributeList message) {
+        List<Attribute<?>> parsedAttributes = new ArrayList<>();
+        for (AttrProto.Attribute attribute : message.getAttributesList()) {
+            try {
+                parsedAttributes.add(attributeConverter.convertAttribute(attribute));
+            } catch (IOException | ParseException e) {
+                LOG.warn("Cannot parse value for attribute '{}'", attribute.getName());
+            }
+        }
+        return parsedAttributes;
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/DocumentDetailsAttributeParser.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/DocumentDetailsAttributeParser.java
@@ -6,7 +6,7 @@ import java.text.ParseException;
 import com.yoti.api.client.Date;
 import com.yoti.api.client.DocumentDetails;
 
-public class DocumentDetailsAttributeParser {
+class DocumentDetailsAttributeParser {
 
     private static final String MINIMUM_ACCEPTABLE = "([A-Za-z_]*) ([A-Za-z]{3}) ([A-Za-z0-9]{1}).*";
     private static final int TYPE_INDEX = 0;
@@ -15,7 +15,7 @@ public class DocumentDetailsAttributeParser {
     private static final int EXPIRATION_INDEX = 3;
     private static final int AUTHORITY_INDEX = 4;
 
-    public DocumentDetails parseFrom(String attribute) throws UnsupportedEncodingException, ParseException {
+    DocumentDetails parseFrom(String attribute) throws UnsupportedEncodingException, ParseException {
         if (attribute == null || !attribute.matches(MINIMUM_ACCEPTABLE)) {
             return null;
         }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/HumanProfileAdapter.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/HumanProfileAdapter.java
@@ -23,14 +23,14 @@ final class HumanProfileAdapter implements HumanProfile {
     private static final String ATTRIBUTE_DOB = "date_of_birth";
     private static final String ATTRIBUTE_AGE_OVER = "age_over:";
     private static final String ATTRIBUTE_AGE_UNDER = "age_under:";
-    public static final String ATTRIBUTE_GENDER = "gender";
+    static final String ATTRIBUTE_GENDER = "gender";
     private static final String ATTRIBUTE_POSTAL_ADDRESS = "postal_address";
-    public static final String ATTRIBUTE_STRUCTURED_POSTAL_ADDRESS = "structured_postal_address";
+    private static final String ATTRIBUTE_STRUCTURED_POSTAL_ADDRESS = "structured_postal_address";
     private static final String ATTRIBUTE_NATIONALITY = "nationality";
     private static final String ATTRIBUTE_PHONE_NUMBER = "phone_number";
     private static final String ATTRIBUTE_SELFIE = "selfie";
     private static final String ATTRIBUTE_EMAIL_ADDRESS = "email_address";
-    public static final String ATTRIBUTE_DOCUMENT_DETAILS = "document_details";
+    static final String ATTRIBUTE_DOCUMENT_DETAILS = "document_details";
 
     private final Profile wrapped;
 

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ProfileReader.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ProfileReader.java
@@ -1,0 +1,74 @@
+package com.yoti.api.client.spi.remote;
+
+import static javax.crypto.Cipher.DECRYPT_MODE;
+
+import static com.yoti.api.client.spi.remote.call.YotiConstants.BOUNCY_CASTLE_PROVIDER;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.SYMMETRIC_CIPHER;
+
+import java.security.GeneralSecurityException;
+import java.security.Key;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+
+import com.yoti.api.client.Attribute;
+import com.yoti.api.client.Profile;
+import com.yoti.api.client.ProfileException;
+import com.yoti.api.client.spi.remote.proto.EncryptedDataProto;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+public class ProfileReader {
+
+    private final AttributeListConverter attributeListConverter;
+
+    private ProfileReader(AttributeListConverter attributeListConverter) {
+        this.attributeListConverter = attributeListConverter;
+    }
+
+    public static ProfileReader newInstance() {
+        return new ProfileReader(AttributeListConverter.newInstance());
+    }
+
+    public Profile read(byte[] encryptedProfileBytes, Key secretKey) throws ProfileException {
+        List<Attribute<?>> attributeList = new ArrayList<>();
+        if (encryptedProfileBytes != null && encryptedProfileBytes.length > 0) {
+            byte[] profileData = decryptProfile(encryptedProfileBytes, secretKey);
+            attributeList = attributeListConverter.parseAttributeList(profileData);
+        }
+        return new SimpleProfile(attributeList);
+    }
+
+    private byte[] decryptProfile(byte[] encryptedProfileBytes, Key secretKey) throws ProfileException {
+        EncryptedDataProto.EncryptedData encryptedData = parseEncryptedContent(encryptedProfileBytes);
+        return decrypt(encryptedData, secretKey);
+    }
+
+    private EncryptedDataProto.EncryptedData parseEncryptedContent(byte[] encryptedProfileBytes) throws ProfileException {
+        try {
+            return EncryptedDataProto.EncryptedData.parseFrom(encryptedProfileBytes);
+        } catch (InvalidProtocolBufferException e) {
+            throw new ProfileException("Cannot decode profile", e);
+        }
+    }
+
+    private byte[] decrypt(EncryptedDataProto.EncryptedData encryptedData, Key secretKey) throws ProfileException {
+        ByteString initVector = encryptedData.getIv();
+        if (initVector == null || initVector.size() == 0) {
+            throw new ProfileException("Receipt key IV must not be null.");
+        }
+        try {
+            Cipher cipher = Cipher.getInstance(SYMMETRIC_CIPHER, BOUNCY_CASTLE_PROVIDER);
+            cipher.init(DECRYPT_MODE, secretKey, new IvParameterSpec(initVector.toByteArray()));
+            return cipher.doFinal(encryptedData.getCipherText().toByteArray());
+        } catch (GeneralSecurityException gse) {
+            throw new ProfileException("Error decrypting data", gse);
+        } catch (IllegalArgumentException iae) {
+            throw new ProfileException("Base64 encoding error", iae);
+        }
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ProfileReader.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ProfileReader.java
@@ -21,7 +21,7 @@ import com.yoti.api.client.spi.remote.proto.EncryptedDataProto;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 
-public class ProfileReader {
+class ProfileReader {
 
     private final AttributeListConverter attributeListConverter;
 
@@ -29,11 +29,11 @@ public class ProfileReader {
         this.attributeListConverter = attributeListConverter;
     }
 
-    public static ProfileReader newInstance() {
+    static ProfileReader newInstance() {
         return new ProfileReader(AttributeListConverter.newInstance());
     }
 
-    public Profile read(byte[] encryptedProfileBytes, Key secretKey) throws ProfileException {
+    Profile read(byte[] encryptedProfileBytes, Key secretKey) throws ProfileException {
         List<Attribute<?>> attributeList = new ArrayList<>();
         if (encryptedProfileBytes != null && encryptedProfileBytes.length > 0) {
             byte[] profileData = decryptProfile(encryptedProfileBytes, secretKey);

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ReceiptFetcher.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ReceiptFetcher.java
@@ -10,12 +10,12 @@ import com.yoti.api.client.ProfileException;
 import com.yoti.api.client.spi.remote.call.ProfileService;
 import com.yoti.api.client.spi.remote.call.Receipt;
 import com.yoti.api.client.spi.remote.call.RemoteProfileService;
-import com.yoti.api.client.spi.remote.util.Decryption;
+import com.yoti.api.client.spi.remote.util.DecryptionHelper;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ReceiptFetcher {
+class ReceiptFetcher {
 
     private static final Logger LOG = LoggerFactory.getLogger(ReceiptFetcher.class);
 
@@ -25,11 +25,11 @@ public class ReceiptFetcher {
         this.profileService = profileService;
     }
 
-    public static ReceiptFetcher newInstance() {
+    static ReceiptFetcher newInstance() {
         return new ReceiptFetcher(RemoteProfileService.newInstance());
     }
 
-    public Receipt fetch(String encryptedConnectToken, KeyPair keyPair, String appId) throws ProfileException {
+    Receipt fetch(String encryptedConnectToken, KeyPair keyPair, String appId) throws ProfileException {
         LOG.debug("Decrypting connect token: '{}'", encryptedConnectToken);
         String connectToken = decryptConnectToken(encryptedConnectToken, keyPair.getPrivate());
         LOG.debug("Connect token decrypted: '{}'", connectToken);
@@ -41,7 +41,7 @@ public class ReceiptFetcher {
     private String decryptConnectToken(String encryptedConnectToken, PrivateKey privateKey) throws ProfileException {
         try {
             byte[] byteValue = Base64.getUrlDecoder().decode(encryptedConnectToken);
-            byte[] decryptedToken = Decryption.decryptAsymmetric(byteValue, privateKey);
+            byte[] decryptedToken = DecryptionHelper.decryptAsymmetric(byteValue, privateKey);
             return new String(decryptedToken, DEFAULT_CHARSET);
         } catch (Exception e) {
             throw new ProfileException("Cannot decrypt connect token", e);

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ReceiptFetcher.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ReceiptFetcher.java
@@ -1,0 +1,60 @@
+package com.yoti.api.client.spi.remote;
+
+import static com.yoti.api.client.spi.remote.call.YotiConstants.DEFAULT_CHARSET;
+
+import java.security.KeyPair;
+import java.security.PrivateKey;
+
+import com.yoti.api.client.ActivityFailureException;
+import com.yoti.api.client.ProfileException;
+import com.yoti.api.client.spi.remote.call.ProfileService;
+import com.yoti.api.client.spi.remote.call.Receipt;
+import com.yoti.api.client.spi.remote.call.RemoteProfileService;
+import com.yoti.api.client.spi.remote.util.Decryption;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ReceiptFetcher {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ReceiptFetcher.class);
+
+    private final ProfileService profileService;
+
+    private ReceiptFetcher(ProfileService profileService) {
+        this.profileService = profileService;
+    }
+
+    public static ReceiptFetcher newInstance() {
+        return new ReceiptFetcher(RemoteProfileService.newInstance());
+    }
+
+    public Receipt fetch(String encryptedConnectToken, KeyPair keyPair, String appId) throws ProfileException {
+        LOG.debug("Decrypting connect token: '{}'", encryptedConnectToken);
+        String connectToken = decryptConnectToken(encryptedConnectToken, keyPair.getPrivate());
+        LOG.debug("Connect token decrypted: '{}'", connectToken);
+        Receipt receipt = profileService.getReceipt(keyPair, appId, connectToken);
+        validateReceipt(receipt, connectToken);
+        return receipt;
+    }
+
+    private String decryptConnectToken(String encryptedConnectToken, PrivateKey privateKey) throws ProfileException {
+        try {
+            byte[] byteValue = Base64.getUrlDecoder().decode(encryptedConnectToken);
+            byte[] decryptedToken = Decryption.decryptAsymmetric(byteValue, privateKey);
+            return new String(decryptedToken, DEFAULT_CHARSET);
+        } catch (Exception e) {
+            throw new ProfileException("Cannot decrypt connect token", e);
+        }
+    }
+
+    private void validateReceipt(Receipt receipt, String connectToken) throws ProfileException {
+        if (receipt == null) {
+            throw new ProfileException("No receipt for '" + connectToken + "' was found");
+        }
+        if (receipt.getOutcome() == null || !receipt.getOutcome().isSuccessful()) {
+            throw new ActivityFailureException("Sharing activity unsuccessful for " + receipt.getDisplayReceiptId());
+        }
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SecureYotiClient.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SecureYotiClient.java
@@ -1,54 +1,27 @@
 package com.yoti.api.client.spi.remote;
 
-import static javax.crypto.Cipher.DECRYPT_MODE;
-
-import static com.yoti.api.client.spi.remote.call.YotiConstants.ASYMMETRIC_CIPHER;
-import static com.yoti.api.client.spi.remote.call.YotiConstants.BOUNCY_CASTLE_PROVIDER;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.DEFAULT_CHARSET;
-import static com.yoti.api.client.spi.remote.call.YotiConstants.SYMMETRIC_CIPHER;
 import static com.yoti.api.client.spi.remote.util.Validation.notNull;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
-import java.security.GeneralSecurityException;
-import java.security.Key;
 import java.security.KeyPair;
-import java.security.PrivateKey;
 import java.security.Security;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
-import javax.crypto.Cipher;
-import javax.crypto.spec.IvParameterSpec;
-import javax.crypto.spec.SecretKeySpec;
 
 import com.yoti.api.client.ActivityDetails;
-import com.yoti.api.client.ActivityFailureException;
 import com.yoti.api.client.AmlException;
-import com.yoti.api.client.Attribute;
 import com.yoti.api.client.InitialisationException;
 import com.yoti.api.client.KeyPairSource;
 import com.yoti.api.client.KeyPairSource.StreamVisitor;
-import com.yoti.api.client.Profile;
 import com.yoti.api.client.ProfileException;
 import com.yoti.api.client.YotiClient;
 import com.yoti.api.client.aml.AmlProfile;
 import com.yoti.api.client.aml.AmlResult;
-import com.yoti.api.client.spi.remote.call.ProfileService;
 import com.yoti.api.client.spi.remote.call.Receipt;
 import com.yoti.api.client.spi.remote.call.aml.RemoteAmlService;
-import com.yoti.api.client.spi.remote.proto.AttrProto;
-import com.yoti.api.client.spi.remote.proto.AttributeListProto.AttributeList;
-import com.yoti.api.client.spi.remote.proto.EncryptedDataProto.EncryptedData;
 
-import com.google.protobuf.ByteString;
-import com.google.protobuf.InvalidProtocolBufferException;
 import org.bouncycastle.openssl.PEMKeyPair;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
@@ -61,34 +34,33 @@ import org.slf4j.LoggerFactory;
 final class SecureYotiClient implements YotiClient {
 
     private static final Logger LOG = LoggerFactory.getLogger(SecureYotiClient.class);
-    private static final String RFC3339_PATTERN = "yyyy-MM-dd'T'HH:mm:ss'Z'";
 
     private final String appId;
     private final KeyPair keyPair;
-    private final ProfileService profileService;
+    private final ReceiptFetcher receiptFetcher;
     private final RemoteAmlService remoteAmlService;
-    private final AttributeConverter attributeConverter;
+    private final ActivityDetailsFactory activityDetailsFactory;
 
     static {
         Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
     }
 
     SecureYotiClient(String applicationId,
-                     KeyPairSource kpSource,
-                     ProfileService profileService,
-                     RemoteAmlService remoteAmlService,
-                     AttributeConverter attributeConverter) throws InitialisationException {
+            KeyPairSource kpSource,
+            ReceiptFetcher receiptFetcher,
+            ActivityDetailsFactory activityDetailsFactory,
+            RemoteAmlService remoteAmlService) throws InitialisationException {
         this.appId = notNull(applicationId, "Application id");
         this.keyPair = loadKeyPair(notNull(kpSource, "Key pair source"));
-        this.profileService = notNull(profileService, "Profile service");
-        this.remoteAmlService = notNull(remoteAmlService, "Aml service");
-        this.attributeConverter = notNull(attributeConverter, "Attribute Converter");
+        this.receiptFetcher = notNull(receiptFetcher, "receiptFetcher");
+        this.remoteAmlService = notNull(remoteAmlService, "amlService");
+        this.activityDetailsFactory = notNull(activityDetailsFactory, "activityDetailsFactory");
     }
 
     @Override
     public ActivityDetails getActivityDetails(String encryptedConnectToken) throws ProfileException {
-        Receipt receipt = getReceipt(encryptedConnectToken, keyPair);
-        return buildActivityDetails(receipt, keyPair.getPrivate());
+        Receipt receipt = receiptFetcher.fetch(encryptedConnectToken, keyPair, appId);
+        return activityDetailsFactory.create(receipt, keyPair.getPrivate());
     }
 
     @Override
@@ -97,131 +69,12 @@ final class SecureYotiClient implements YotiClient {
         return remoteAmlService.performCheck(keyPair, appId, amlProfile);
     }
 
-    private Receipt getReceipt(String encryptedConnectToken, KeyPair keyPair) throws ProfileException {
-        LOG.debug("Decrypting connect token: '{}'", encryptedConnectToken);
-        String connectToken = decryptConnectToken(encryptedConnectToken, keyPair.getPrivate());
-        LOG.debug("Connect token decrypted: '{}'", connectToken);
-        Receipt receipt = profileService.getReceipt(keyPair, appId, connectToken);
-        if (receipt == null) {
-            throw new ProfileException("No receipt for '" + connectToken + "' was found");
-        }
-        return receipt;
-    }
-
     private KeyPair loadKeyPair(KeyPairSource kpSource) throws InitialisationException {
         try {
             LOG.debug("Loading key pair from '{}'", kpSource);
             return kpSource.getFromStream(new KeyStreamVisitor());
         } catch (IOException e) {
             throw new InitialisationException("Cannot load key pair", e);
-        }
-    }
-
-    private String decryptConnectToken(String encryptedConnectToken, PrivateKey privateKey) throws ProfileException {
-        String connectToken = null;
-        try {
-            byte[] byteValue = Base64.getUrlDecoder().decode(encryptedConnectToken);
-            byte[] decryptedToken = decrypt(byteValue, privateKey);
-            connectToken = new String(decryptedToken, DEFAULT_CHARSET);
-        } catch (Exception e) {
-            throw new ProfileException("Cannot decrypt connect token", e);
-        }
-        return connectToken;
-    }
-
-    private ActivityDetails buildActivityDetails(Receipt receipt, PrivateKey privateKey) throws ProfileException {
-        validateReceipt(receipt);
-        Key secretKey = new SecretKeySpec(decrypt(receipt.getWrappedReceiptKey(), privateKey), SYMMETRIC_CIPHER);
-        Profile userProfile = createProfile(receipt.getOtherPartyProfile(), secretKey);
-        Profile applicationProfile = createProfile(receipt.getProfile(), secretKey);
-        return createActivityDetails(userProfile, applicationProfile, receipt);
-    }
-
-    private void validateReceipt(Receipt receipt) throws ActivityFailureException {
-        if (receipt.getOutcome() == null || !receipt.getOutcome().isSuccessful()) {
-            throw new ActivityFailureException("Sharing activity unsuccessful for " + receipt.getDisplayReceiptId());
-        }
-    }
-
-    private Profile createProfile(byte[] profileBytes, Key secretKey) throws ProfileException {
-        List<Attribute<?>> attributeList = new ArrayList<>();
-        if (profileBytes != null && profileBytes.length > 0) {
-            EncryptedData encryptedData = parseProfileContent(profileBytes);
-            byte[] profileData = decrypt(encryptedData.getCipherText(), secretKey, encryptedData.getIv());
-            attributeList = parseProfile(profileData);
-        }
-        return new SimpleProfile(attributeList);
-    }
-
-    private EncryptedData parseProfileContent(byte[] profileContent) throws ProfileException {
-        try {
-            return EncryptedData.parseFrom(profileContent);
-        } catch (InvalidProtocolBufferException e) {
-            throw new ProfileException("Cannot decode profile", e);
-        }
-    }
-
-    private List<Attribute<?>> parseProfile(byte[] profileData) throws ProfileException {
-        try {
-            AttributeList message = AttributeList.parseFrom(profileData);
-            List<Attribute<?>> attributeList = parseAttributes(message);
-            LOG.debug("{} attribute(s) parsed", attributeList.size());
-            return attributeList;
-        } catch (InvalidProtocolBufferException e) {
-            throw new ProfileException("Cannot parse profile data", e);
-        }
-    }
-
-    private List<Attribute<?>> parseAttributes(AttributeList message) {
-        List<Attribute<?>> parsedAttributes = new ArrayList<>();
-        for (AttrProto.Attribute attribute : message.getAttributesList()) {
-            try {
-                parsedAttributes.add(attributeConverter.convertAttribute(attribute));
-            } catch (IOException | ParseException e) {
-                LOG.warn("Cannot parse value for attribute '{}'", attribute.getName());
-            }
-        }
-        return parsedAttributes;
-    }
-
-    private ActivityDetails createActivityDetails(Profile userProfile, Profile applicationProfile, Receipt receipt) throws ProfileException {
-        try {
-            byte[] rmi = receipt.getRememberMeId();
-            String rememberMeId = (rmi == null) ? null : new String(Base64.getEncoder().encode(rmi), DEFAULT_CHARSET);
-            SimpleDateFormat format = new SimpleDateFormat(RFC3339_PATTERN);
-            Date timestamp = format.parse(receipt.getTimestamp());
-            return new SimpleActivityDetails(rememberMeId, userProfile, applicationProfile, timestamp, receipt.getReceiptId());
-        } catch (UnsupportedEncodingException e) {
-            throw new ProfileException("Cannot parse user ID", e);
-        } catch (ParseException e) {
-            throw new ProfileException("Cannot parse timestamp", e);
-        }
-    }
-
-    private byte[] decrypt(ByteString source, Key key, ByteString initVector) throws ProfileException {
-        if (initVector == null || initVector.size() == 0) {
-            throw new ProfileException("Receipt key IV must not be null.");
-        }
-        try {
-            Cipher cipher = Cipher.getInstance(SYMMETRIC_CIPHER, BOUNCY_CASTLE_PROVIDER);
-            cipher.init(DECRYPT_MODE, key, new IvParameterSpec(initVector.toByteArray()));
-            return cipher.doFinal(source.toByteArray());
-        } catch (GeneralSecurityException gse) {
-            throw new ProfileException("Error decrypting data", gse);
-        } catch (IllegalArgumentException iae) {
-            throw new ProfileException("Base64 encoding error", iae);
-        }
-    }
-
-    private byte[] decrypt(byte[] source, PrivateKey key) throws ProfileException {
-        try {
-            Cipher cipher = Cipher.getInstance(ASYMMETRIC_CIPHER, BOUNCY_CASTLE_PROVIDER);
-            cipher.init(DECRYPT_MODE, key);
-            return cipher.doFinal(source);
-        } catch (GeneralSecurityException gse) {
-            throw new ProfileException("Error decrypting data", gse);
-        } catch (IllegalArgumentException iae) {
-            throw new ProfileException("Base64 encoding error", iae);
         }
     }
 

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SecureYotiClient.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SecureYotiClient.java
@@ -199,7 +199,7 @@ final class SecureYotiClient implements YotiClient {
     }
 
     private byte[] decrypt(ByteString source, Key key, ByteString initVector) throws ProfileException {
-        if (initVector == null) {
+        if (initVector == null || initVector.size() == 0) {
             throw new ProfileException("Receipt key IV must not be null.");
         }
         try {

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SecureYotiClientFactory.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SecureYotiClientFactory.java
@@ -1,14 +1,13 @@
 package com.yoti.api.client.spi.remote;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.yoti.api.client.InitialisationException;
 import com.yoti.api.client.YotiClient;
 import com.yoti.api.client.YotiClientConfiguration;
 import com.yoti.api.client.YotiClientFactory;
-import com.yoti.api.client.spi.remote.call.RemoteProfileService;
 import com.yoti.api.client.spi.remote.call.aml.RemoteAmlService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class SecureYotiClientFactory implements YotiClientFactory {
 
@@ -24,9 +23,10 @@ public final class SecureYotiClientFactory implements YotiClientFactory {
         LOG.debug("Creating SecureYotiClient for application '{}' from '{}'", configuration.getApplicationId(), configuration.getKeyPairSource());
         return new SecureYotiClient(configuration.getApplicationId(),
                 configuration.getKeyPairSource(),
-                RemoteProfileService.newInstance(),
-                RemoteAmlService.newInstance(),
-                AttributeConverter.newInstance());
+                ReceiptFetcher.newInstance(),
+                ActivityDetailsFactory.newInstance(),
+                RemoteAmlService.newInstance()
+        );
     }
 
 }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/factory/MessageFactory.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/factory/MessageFactory.java
@@ -5,9 +5,9 @@ import java.io.UnsupportedEncodingException;
 import static com.yoti.api.client.spi.remote.Base64.base64;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.DEFAULT_CHARSET;
 
-public class MessageFactory {
+class MessageFactory {
 
-    public byte[] create(String httpMethod, String path, byte[] body) {
+    byte[] create(String httpMethod, String path, byte[] body) {
         try {
             String message = httpMethod + "&" + path;
             if (body != null && body.length > 0) {

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/util/Decryption.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/util/Decryption.java
@@ -1,0 +1,29 @@
+package com.yoti.api.client.spi.remote.util;
+
+import static javax.crypto.Cipher.DECRYPT_MODE;
+
+import static com.yoti.api.client.spi.remote.call.YotiConstants.ASYMMETRIC_CIPHER;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.BOUNCY_CASTLE_PROVIDER;
+
+import java.security.GeneralSecurityException;
+import java.security.PrivateKey;
+
+import javax.crypto.Cipher;
+
+import com.yoti.api.client.ProfileException;
+
+public class Decryption {
+
+    public static byte[] decryptAsymmetric(byte[] source, PrivateKey key) throws ProfileException {
+        try {
+            Cipher cipher = Cipher.getInstance(ASYMMETRIC_CIPHER, BOUNCY_CASTLE_PROVIDER);
+            cipher.init(DECRYPT_MODE, key);
+            return cipher.doFinal(source);
+        } catch (GeneralSecurityException gse) {
+            throw new ProfileException("Error decrypting data", gse);
+        } catch (IllegalArgumentException iae) {
+            throw new ProfileException("Base64 encoding error", iae);
+        }
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/util/DecryptionHelper.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/util/DecryptionHelper.java
@@ -12,7 +12,7 @@ import javax.crypto.Cipher;
 
 import com.yoti.api.client.ProfileException;
 
-public class Decryption {
+public class DecryptionHelper {
 
     public static byte[] decryptAsymmetric(byte[] source, PrivateKey key) throws ProfileException {
         try {

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/ActivityDetailsFactoryTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/ActivityDetailsFactoryTest.java
@@ -1,0 +1,156 @@
+package com.yoti.api.client.spi.remote;
+
+import static com.yoti.api.client.spi.remote.util.CryptoUtil.encryptAsymmetric;
+import static com.yoti.api.client.spi.remote.util.CryptoUtil.generateKeyPairFrom;
+import static com.yoti.api.client.spi.remote.util.CryptoUtil.generateSymmetricKey;
+
+import static org.bouncycastle.util.encoders.Base64.decode;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.security.GeneralSecurityException;
+import java.security.Key;
+import java.security.KeyPair;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+import com.yoti.api.client.ActivityDetails;
+import com.yoti.api.client.ApplicationProfile;
+import com.yoti.api.client.HumanProfile;
+import com.yoti.api.client.Profile;
+import com.yoti.api.client.ProfileException;
+import com.yoti.api.client.spi.remote.call.Receipt;
+import com.yoti.api.client.spi.remote.util.CryptoUtil;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ActivityDetailsFactoryTest {
+
+    private static final byte[] PROFILE_CONTENT = { 0, 1, 2, 3 };
+    private static final byte[] OTHER_PROFILE_CONTENT = { 4, 5, 6, 7 };
+
+    private static final Date DATE = new GregorianCalendar(1980, Calendar.AUGUST, 5).getTime();
+    private static final String RFC3339_PATTERN = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+    private static final DateFormat RFC3339_FORMAT = new SimpleDateFormat(RFC3339_PATTERN);
+    private static final String VALID_TIMESTAMP = RFC3339_FORMAT.format(DATE);
+
+    private static final String SOME_USER_ID_STRING = "aBase64EncodedUserId";
+    private static final byte[] SOME_USER_ID_BYTES = decode(SOME_USER_ID_STRING);
+    private static final String ENCODED_RECEIPT_STRING = "base64EncodedReceipt";
+    private static final byte[] DECODED_RECEIPT_BYTES = decode(ENCODED_RECEIPT_STRING);
+
+    @InjectMocks ActivityDetailsFactory testObj;
+
+    @Mock ProfileReader profileReaderMock;
+
+    KeyPair keyPair;
+    byte[] validReceiptKey;
+    @Mock Profile profileMock;
+    @Mock Profile otherProfileMock;
+
+    @Before
+    public void setUp() throws Exception {
+        Key receiptKey = generateSymmetricKey();
+        keyPair = generateKeyPairFrom(CryptoUtil.KEY_PAIR_PEM);
+        validReceiptKey = encryptAsymmetric(receiptKey.getEncoded(), keyPair.getPublic());
+    }
+
+    @Test
+    public void shouldFailWithNoReceiptKey() throws Exception {
+        Receipt receipt = new Receipt.Builder()
+                .withWrappedReceiptKey(null)
+                .build();
+
+        try {
+            testObj.create(receipt, keyPair.getPrivate());
+        } catch (ProfileException e) {
+            assertThat(e.getMessage(), containsString("Base64 encoding error"));
+            assertTrue(e.getCause() instanceof IllegalArgumentException);
+            return;
+        }
+        fail("Expected an Exception");
+    }
+
+    @Test
+    public void shouldFailWithInvalidReceiptKey() throws Exception {
+        byte[] invalidReceiptKey = { 1, 2, 3 };
+        Receipt receipt = new Receipt.Builder()
+                .withWrappedReceiptKey(invalidReceiptKey)
+                .build();
+
+        try {
+            testObj.create(receipt, keyPair.getPrivate());
+        } catch (ProfileException e) {
+            assertThat(e.getMessage(), containsString("Error decrypting data"));
+            assertTrue(e.getCause() instanceof GeneralSecurityException);
+            return;
+        }
+        fail("Expected an Exception");
+    }
+
+    @Test
+    public void shouldFailWithInvalidTimestamp() throws Exception {
+        Receipt receipt = new Receipt.Builder()
+                .withWrappedReceiptKey(validReceiptKey)
+                .withTimestamp("someInvalidValue")
+                .build();
+
+        try {
+            testObj.create(receipt, keyPair.getPrivate());
+        } catch (ProfileException e) {
+            assertThat(e.getMessage(), containsString("timestamp"));
+            assertTrue(e.getCause() instanceof ParseException);
+            return;
+        }
+        fail("Expected an Exception");
+    }
+
+    @Test
+    public void shouldGetCorrectProfilesFromProfileReader() throws Exception {
+        Receipt receipt = new Receipt.Builder()
+                .withWrappedReceiptKey(validReceiptKey)
+                .withTimestamp(VALID_TIMESTAMP)
+                .withRememberMeId(SOME_USER_ID_BYTES)
+                .withProfile(PROFILE_CONTENT)
+                .withOtherPartyProfile(OTHER_PROFILE_CONTENT)
+                .withReceiptId(DECODED_RECEIPT_BYTES)
+                .build();
+        when(profileReaderMock.read(eq(PROFILE_CONTENT), any(Key.class))).thenReturn(profileMock);
+        when(profileReaderMock.read(eq(OTHER_PROFILE_CONTENT), any(Key.class))).thenReturn(otherProfileMock);
+
+        ActivityDetails result = testObj.create(receipt, keyPair.getPrivate());
+
+        assertSame(otherProfileMock, getWrappedProfile(result.getUserProfile()));
+        assertSame(profileMock, getWrappedProfile(result.getApplicationProfile()));
+        assertEquals(SOME_USER_ID_STRING, result.getUserId());
+        assertEquals(ENCODED_RECEIPT_STRING, result.getReceiptId());
+        assertEquals(DATE, result.getTimestamp());
+    }
+
+    private Profile getWrappedProfile(HumanProfile humanProfile) throws Exception {
+        return (Profile) FieldUtils.getField(HumanProfileAdapter.class, "wrapped", true).get(humanProfile);
+    }
+
+    private Profile getWrappedProfile(ApplicationProfile applicationProfile) throws Exception {
+        return (Profile) FieldUtils.getField(ApplicationProfileAdapter.class, "wrapped", true).get(applicationProfile);
+    }
+
+}

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/AttributeListConverterTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/AttributeListConverterTest.java
@@ -1,0 +1,112 @@
+package com.yoti.api.client.spi.remote;
+
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.hamcrest.core.IsCollectionContaining.hasItems;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.List;
+import java.util.Map;
+
+import com.yoti.api.client.Attribute;
+import com.yoti.api.client.Date;
+import com.yoti.api.client.ProfileException;
+import com.yoti.api.client.spi.remote.proto.AttrProto;
+import com.yoti.api.client.spi.remote.proto.AttributeListProto;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AttributeListConverterTest {
+
+    private static final String STRING_ATTRIBUTE_NAME = "testStringAttr";
+    private static final String DATE_ATTRIBUTE_NAME = "testDateAttr";
+    private static final String JSON_ATTRIBUTE_NAME = "testJsonAttr";
+
+    private static final AttrProto.Attribute STRING_ATTRIBUTE_PROTO = AttrProto.Attribute.newBuilder()
+            .setName(STRING_ATTRIBUTE_NAME)
+            .build();
+
+    private static final AttrProto.Attribute DATE_ATTRIBUTE_PROTO = AttrProto.Attribute.newBuilder()
+            .setName(DATE_ATTRIBUTE_NAME)
+            .build();
+
+    private static final AttrProto.Attribute JSON_ATTRIBUTE_PROTO = AttrProto.Attribute.newBuilder()
+            .setName(JSON_ATTRIBUTE_NAME)
+            .build();
+
+    private static final byte[] PROFILE_DATA = AttributeListProto.AttributeList.newBuilder()
+            .addAttributes(STRING_ATTRIBUTE_PROTO)
+            .addAttributes(DATE_ATTRIBUTE_PROTO)
+            .addAttributes(JSON_ATTRIBUTE_PROTO)
+            .build()
+            .toByteArray();
+
+    @InjectMocks AttributeListConverter testObj;
+
+    @Mock AttributeConverter attributeConverterMock;
+
+    @Mock Attribute<String> stringAttributeMock;
+    @Mock Attribute<Date> dateAttributeMock;
+    @Mock Attribute<Map> jsonAttributeMock;
+
+    @Test
+    public void shouldReturnEmptyListForNullProfileData() throws Exception {
+        List<Attribute<?>> result = testObj.parseAttributeList(null);
+
+        assertThat(result, hasSize(0));
+    }
+
+    @Test
+    public void shouldReturnEmptyListForEmptyProfileData() throws Exception {
+        List<Attribute<?>> result = testObj.parseAttributeList(new byte[0]);
+
+        assertThat(result, hasSize(0));
+    }
+
+    @Test
+    public void shouldWrapInvalidProtocolBufferException() throws Exception {
+        try {
+            testObj.parseAttributeList(new byte[] { 1, 2, 3 });
+        } catch (ProfileException e) {
+            assertTrue(e.getCause() instanceof InvalidProtocolBufferException);
+            return;
+        }
+        fail("Expected an Exception");
+    }
+
+    @Test
+    public void shouldSuccesfullyConvertAttributes() throws Exception {
+        when(attributeConverterMock.<String>convertAttribute(STRING_ATTRIBUTE_PROTO)).thenReturn(stringAttributeMock);
+        when(attributeConverterMock.<Date>convertAttribute(DATE_ATTRIBUTE_PROTO)).thenReturn(dateAttributeMock);
+        when(attributeConverterMock.<Map>convertAttribute(JSON_ATTRIBUTE_PROTO)).thenReturn(jsonAttributeMock);
+
+        List<Attribute<?>> result = testObj.parseAttributeList(PROFILE_DATA);
+
+        assertThat(result, hasSize(3));
+        assertThat(result, hasItems(stringAttributeMock, dateAttributeMock, jsonAttributeMock));
+    }
+
+    @Test
+    public void shouldTolerateFailureToParseSomeAttributes() throws Exception {
+        when(attributeConverterMock.<String>convertAttribute(STRING_ATTRIBUTE_PROTO)).thenReturn(stringAttributeMock);
+        when(attributeConverterMock.<Date>convertAttribute(DATE_ATTRIBUTE_PROTO)).thenThrow(new IOException());
+        when(attributeConverterMock.<Map>convertAttribute(JSON_ATTRIBUTE_PROTO)).thenThrow(new ParseException("some message", 1));
+
+        List<Attribute<?>> result = testObj.parseAttributeList(PROFILE_DATA);
+
+        assertThat(result, hasSize(1));
+        assertThat(result, hasItem(stringAttributeMock));
+    }
+
+}

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/ProfileReaderTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/ProfileReaderTest.java
@@ -1,0 +1,166 @@
+package com.yoti.api.client.spi.remote;
+
+import static com.yoti.api.client.spi.remote.util.CryptoUtil.encryptSymmetric;
+import static com.yoti.api.client.spi.remote.util.CryptoUtil.generateSymmetricKey;
+
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+
+import java.security.GeneralSecurityException;
+import java.security.Key;
+import java.util.Arrays;
+
+import com.yoti.api.client.Attribute;
+import com.yoti.api.client.Profile;
+import com.yoti.api.client.ProfileException;
+import com.yoti.api.client.spi.remote.proto.AttrProto;
+import com.yoti.api.client.spi.remote.proto.AttributeListProto;
+import com.yoti.api.client.spi.remote.proto.EncryptedDataProto;
+import com.yoti.api.client.spi.remote.util.CryptoUtil;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.hamcrest.core.IsCollectionContaining;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProfileReaderTest {
+
+    private static final String STRING_ATTRIBUTE_NAME = "testStringAttr";
+    private static final AttrProto.Attribute STRING_ATTRIBUTE_PROTO = AttrProto.Attribute.newBuilder()
+            .setName(STRING_ATTRIBUTE_NAME)
+            .build();
+    private static final byte[] PROFILE_DATA_BYTES = AttributeListProto.AttributeList.newBuilder()
+            .addAttributes(STRING_ATTRIBUTE_PROTO)
+            .build()
+            .toByteArray();
+
+    @InjectMocks ProfileReader testObj;
+
+    @Mock AttributeListConverter attributeListConverterMock;
+
+    CryptoUtil.EncryptionResult validProfileEncryptionResult;
+    Key receiptKey;
+
+    @Before
+    public void setUp() throws Exception {
+        receiptKey = generateSymmetricKey();
+        validProfileEncryptionResult = encryptSymmetric(PROFILE_DATA_BYTES, receiptKey);
+    }
+
+    @Test
+    public void shouldWrapInvalidProtocolBufferException() {
+        byte[] invalidProfileContent = new byte[] { 1, 2, 3 };
+
+        try {
+            testObj.read(invalidProfileContent, receiptKey);
+        } catch (ProfileException e) {
+            assertThat(e.getMessage(), containsString("Cannot decode profile"));
+            assertTrue(e.getCause() instanceof InvalidProtocolBufferException);
+            return;
+        }
+        fail("Expected an Exception");
+    }
+
+    @Test
+    public void shouldFailWithNoIV() {
+        byte[] profileContent = EncryptedDataProto.EncryptedData.newBuilder()
+                .setCipherText(ByteString.copyFrom(validProfileEncryptionResult.data))
+                .build()
+                .toByteArray();
+
+        try {
+            testObj.read(profileContent, receiptKey);
+        } catch (ProfileException e) {
+            assertThat(e.getMessage(), containsString("Receipt key IV must not be null."));
+            return;
+        }
+        fail("Expected an Exception");
+    }
+
+    @Test
+    public void shouldWrapExcetionFromInvalidIV() {
+        byte[] profileContent = EncryptedDataProto.EncryptedData.newBuilder()
+                .setCipherText(ByteString.copyFrom(validProfileEncryptionResult.data))
+                .setIv(ByteString.copyFrom(new byte[] { 1, 2 }))
+                .build()
+                .toByteArray();
+
+        try {
+            testObj.read(profileContent, receiptKey);
+        } catch (ProfileException e) {
+            assertThat(e.getMessage(), containsString("Error decrypting data"));
+            assertTrue(e.getCause() instanceof GeneralSecurityException);
+            return;
+        }
+        fail("Expected an Exception");
+    }
+
+    @Test
+    public void shouldWrapExceptionFromHavingNoEncryptedData() {
+        byte[] profileContent = EncryptedDataProto.EncryptedData.newBuilder()
+                .setIv(ByteString.copyFrom(validProfileEncryptionResult.iv))
+                .build()
+                .toByteArray();
+
+        try {
+            testObj.read(profileContent, receiptKey);
+        } catch (ProfileException e) {
+            assertThat(e.getMessage(), containsString("Error decrypting data"));
+            assertTrue(e.getCause() instanceof GeneralSecurityException);
+            return;
+        }
+        fail("Expected an Exception");
+    }
+
+    @Test
+    public void shouldWrapExcetionFromInvalidEncryptedData() {
+        byte[] profileContent = EncryptedDataProto.EncryptedData.newBuilder()
+                .setCipherText(ByteString.copyFrom(new byte[] { 1, 2 }))
+                .setIv(ByteString.copyFrom(validProfileEncryptionResult.iv))
+                .build()
+                .toByteArray();
+
+        try {
+            testObj.read(profileContent, receiptKey);
+        } catch (ProfileException e) {
+            assertThat(e.getMessage(), containsString("Error decrypting data"));
+            assertTrue(e.getCause() instanceof GeneralSecurityException);
+            return;
+        }
+        fail("Expected an Exception");
+    }
+
+    @Test
+    public void shouldGetEmptyProfileWhenGivenNullContent() throws Exception {
+        Profile result = testObj.read(null, receiptKey);
+
+        assertThat(result.getAttributes(), hasSize(0));
+    }
+
+    @Test
+    public void shouldDecodeProfileCorrectly() throws Exception {
+        Attribute<String> stringAttribute = new Attribute<>("someName", "someValue");
+        byte[] profileContent = EncryptedDataProto.EncryptedData.newBuilder()
+                .setCipherText(ByteString.copyFrom(validProfileEncryptionResult.data))
+                .setIv(ByteString.copyFrom(validProfileEncryptionResult.iv))
+                .build()
+                .toByteArray();
+        when(attributeListConverterMock.parseAttributeList(PROFILE_DATA_BYTES)).thenReturn(Arrays.<Attribute<?>>asList(stringAttribute));
+
+        Profile result = testObj.read(profileContent, receiptKey);
+
+        assertThat(result.getAttributes(), hasSize(1));
+        assertThat(result.getAttributes(), IsCollectionContaining.hasItem(stringAttribute));
+    }
+
+}

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/ReceiptFetcherTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/ReceiptFetcherTest.java
@@ -1,0 +1,149 @@
+package com.yoti.api.client.spi.remote;
+
+import static com.yoti.api.client.spi.remote.util.CryptoUtil.base64Url;
+import static com.yoti.api.client.spi.remote.util.CryptoUtil.encryptAsymmetric;
+import static com.yoti.api.client.spi.remote.util.CryptoUtil.generateKeyPairFrom;
+
+import static org.bouncycastle.util.encoders.Base64.decode;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.security.KeyPair;
+import java.security.PublicKey;
+
+import com.yoti.api.client.ActivityFailureException;
+import com.yoti.api.client.ProfileException;
+import com.yoti.api.client.spi.remote.call.ProfileService;
+import com.yoti.api.client.spi.remote.call.Receipt;
+import com.yoti.api.client.spi.remote.util.CryptoUtil;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReceiptFetcherTest {
+
+    private static final String TOKEN = "test-token-test-test-test";
+    private static final String APP_ID = "appId";
+    private static final String ENCODED_RECEIPT_STRING = "base64EncodedReceipt";
+    private static final byte[] DECODED_RECEIPT_BYTES = decode(ENCODED_RECEIPT_STRING);
+
+    @InjectMocks ReceiptFetcher testObj;
+
+    @Mock ProfileService profileServiceMock;
+
+    KeyPair keyPair;
+    String encryptedToken;
+
+    @Before
+    public void setUp() throws Exception {
+        keyPair = generateKeyPairFrom(CryptoUtil.KEY_PAIR_PEM);
+        PublicKey publicKey = keyPair.getPublic();
+        encryptedToken = base64Url(encryptAsymmetric(TOKEN.getBytes(), publicKey));
+    }
+
+    @Test
+    public void shouldFailForNullToken() throws Exception {
+        try {
+            testObj.fetch(null, keyPair, APP_ID);
+        } catch (ProfileException e) {
+            assertThat(e.getMessage(), containsString("Cannot decrypt connect token"));
+            assertTrue(e.getCause() instanceof NullPointerException);
+            return;
+        }
+        fail("Expected an Exception");
+    }
+
+    @Test
+    public void shouldFailForNonBase64Token() throws Exception {
+        try {
+            testObj.fetch(TOKEN, keyPair, APP_ID);
+        } catch (ProfileException e) {
+            assertThat(e.getMessage(), containsString("Cannot decrypt connect token"));
+            assertTrue(e.getCause() instanceof IllegalArgumentException);
+            return;
+        }
+        fail("Expected an Exception");
+    }
+
+    @Test
+    public void shouldFailForBadlyEncryptedToken() throws Exception {
+        try {
+            testObj.fetch(Base64.getEncoder().encodeToString(TOKEN.getBytes()), keyPair, APP_ID);
+        } catch (ProfileException e) {
+            assertThat(e.getMessage(), containsString("Cannot decrypt connect token"));
+            assertTrue(e.getCause() instanceof ProfileException);
+            assertThat(e.getCause().getMessage(), containsString("Error decrypting data"));
+            return;
+        }
+        fail("Expected an Exception");
+    }
+
+    @Test
+    public void shouldFailWithExceptionFromProfileService() throws Exception {
+        ProfileException profileException = new ProfileException("Test exception");
+        when(profileServiceMock.getReceipt(any(KeyPair.class), anyString(), anyString())).thenThrow(profileException);
+
+        try {
+            testObj.fetch(encryptedToken, keyPair, APP_ID);
+        } catch (ProfileException e) {
+            assertSame(profileException, e);
+            return;
+        }
+        fail("Expected an Exception");
+    }
+
+    @Test
+    public void shouldFailWhenNoReceiptReturned() throws Exception {
+        when(profileServiceMock.getReceipt(any(KeyPair.class), anyString(), anyString())).thenReturn(null);
+
+        try {
+            testObj.fetch(encryptedToken, keyPair, APP_ID);
+        } catch (ProfileException e) {
+            assertThat(e.getMessage(), containsString("No receipt"));
+            assertThat(e.getMessage(), containsString(TOKEN));
+            return;
+        }
+        fail("Expected an Exception");
+    }
+
+    @Test
+    public void shouldFailForFailureReceipt() throws Exception {
+        Receipt receipt = new Receipt.Builder()
+                .withReceiptId(DECODED_RECEIPT_BYTES)
+                .withOutcome(Receipt.Outcome.FAILURE)
+                .build();
+        when(profileServiceMock.getReceipt(keyPair, APP_ID, TOKEN)).thenReturn(receipt);
+
+        try {
+            testObj.fetch(encryptedToken, keyPair, APP_ID);
+        } catch (ActivityFailureException e) {
+            assertThat(e.getMessage(), containsString(ENCODED_RECEIPT_STRING));
+            return;
+        }
+        fail("Expected an Exception");
+    }
+
+    @Test
+    public void shouldReturnSuccessReceipt() throws Exception {
+        Receipt receipt = new Receipt.Builder()
+                .withOutcome(Receipt.Outcome.SUCCESS)
+                .build();
+        when(profileServiceMock.getReceipt(keyPair, APP_ID, TOKEN)).thenReturn(receipt);
+
+        Receipt result = testObj.fetch(encryptedToken, keyPair, APP_ID);
+
+        assertSame(result, receipt);
+    }
+
+}

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/SecureYotiClientTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/SecureYotiClientTest.java
@@ -2,56 +2,36 @@ package com.yoti.api.client.spi.remote;
 
 import static com.yoti.api.client.spi.remote.util.CryptoUtil.base64Url;
 import static com.yoti.api.client.spi.remote.util.CryptoUtil.encryptAsymmetric;
-import static com.yoti.api.client.spi.remote.util.CryptoUtil.encryptSymmetric;
-import static com.yoti.api.client.spi.remote.util.CryptoUtil.generateKey;
 import static com.yoti.api.client.spi.remote.util.CryptoUtil.generateKeyPairFrom;
+import static com.yoti.api.client.spi.remote.util.CryptoUtil.generateSymmetricKey;
 
-import static org.bouncycastle.util.encoders.Base64.decode;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
-import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.security.GeneralSecurityException;
 import java.security.Key;
 import java.security.KeyPair;
-import java.security.PublicKey;
-import java.text.ParseException;
-import java.util.Collection;
-import java.util.Map;
+import java.security.PrivateKey;
 
 import com.yoti.api.client.ActivityDetails;
-import com.yoti.api.client.ActivityFailureException;
-import com.yoti.api.client.Attribute;
-import com.yoti.api.client.Date;
 import com.yoti.api.client.InitialisationException;
 import com.yoti.api.client.KeyPairSource;
-import com.yoti.api.client.Profile;
 import com.yoti.api.client.ProfileException;
-import com.yoti.api.client.spi.remote.call.ProfileService;
 import com.yoti.api.client.spi.remote.call.Receipt;
 import com.yoti.api.client.spi.remote.call.aml.RemoteAmlService;
-import com.yoti.api.client.spi.remote.proto.AttrProto;
-import com.yoti.api.client.spi.remote.proto.AttributeListProto.AttributeList;
-import com.yoti.api.client.spi.remote.proto.EncryptedDataProto;
 import com.yoti.api.client.spi.remote.util.CryptoUtil;
-import com.yoti.api.client.spi.remote.util.CryptoUtil.EncryptionResult;
 
-import com.google.protobuf.ByteString;
 import org.bouncycastle.openssl.PEMException;
 import org.junit.Before;
 import org.junit.Test;
@@ -62,336 +42,36 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class SecureYotiClientTest {
 
-    private static final String STRING_ATTRIBUTE_NAME = "testStringAttr";
-    private static final String DATE_ATTRIBUTE_NAME = "testDateAttr";
-    private static final String JSON_ATTRIBUTE_NAME = "testJsonAttr";
-    private static final AttrProto.Attribute STRING_ATTRIBUTE_PROTO = createAttribute(STRING_ATTRIBUTE_NAME);
-    private static final AttrProto.Attribute DATE_ATTRIBUTE_PROTO = createAttribute(DATE_ATTRIBUTE_NAME);
-    private static final AttrProto.Attribute JSON_ATTRIBUTE_PROTO = createAttribute(JSON_ATTRIBUTE_NAME);
-
     private static final String TOKEN = "test-token-test-test-test";
     private static final String APP_ID = "appId";
-    private static final byte[] USER_ID = "YmFkYWRhZGEtZGFkYWJhZGEK".getBytes();
-    private static final String TIMESTAMP = "2006-01-02T15:04:05Z07:00";
-    private static final String INVALID_TIMESTAMP = "xx2006-01-02T15:04:05Z07:00";
-    private static final String ENCODED_RECEIPT_STRING = "base64EncodedReceipt";
-    private static final byte[] DECODED_RECEIPT_BYTES = decode(ENCODED_RECEIPT_STRING);
 
-    @Mock ProfileService profileServiceMock;
+    @Mock ReceiptFetcher receiptFetcherMock;
     @Mock RemoteAmlService remoteAmlServiceMock;
-    @Mock AttributeConverter attributeConverterMock;
+    @Mock ActivityDetailsFactory activityDetailsFactoryMock;
 
-    @Mock Attribute<String> stringAttributeMock;
-    @Mock Attribute<Date> dateAttributeMock;
-    @Mock Attribute<Map> jsonAttributeMock;
-
+    @Mock Receipt receiptMock;
+    @Mock ActivityDetails activityDetailsMock;
     String encryptedToken;
     KeyPairSource validKeyPairSource;
     byte[] validReceiptKey;
-    EncryptionResult encryptionResult;
 
     @Before
     public void setUp() throws Exception {
-        Key receiptKey = generateKey();
-        PublicKey publicKey = generateKeyPairFrom(CryptoUtil.KEY_PAIR_PEM).getPublic();
-        validReceiptKey = encryptAsymmetric(receiptKey.getEncoded(), publicKey);
-        encryptionResult = encryptSymmetric(createProfileData(), receiptKey);
+        Key receiptKey = generateSymmetricKey();
+        KeyPair keyPair = generateKeyPairFrom(CryptoUtil.KEY_PAIR_PEM);
+        validReceiptKey = encryptAsymmetric(receiptKey.getEncoded(), keyPair.getPublic());
 
-        encryptedToken = base64Url(encryptAsymmetric(TOKEN.getBytes(), publicKey));
+        encryptedToken = base64Url(encryptAsymmetric(TOKEN.getBytes(), keyPair.getPublic()));
         validKeyPairSource = new StaticKeyPairSource(CryptoUtil.KEY_PAIR_PEM);
-
-        when(stringAttributeMock.getName()).thenReturn(STRING_ATTRIBUTE_NAME);
-        when(dateAttributeMock.getName()).thenReturn(DATE_ATTRIBUTE_NAME);
-        when(jsonAttributeMock.getName()).thenReturn(JSON_ATTRIBUTE_NAME);
     }
 
     @Test
-    public void getActivityDetails_shouldGetCorrectProfile() throws Exception {
-        byte[] profileContent = marshalProfile(encryptionResult.data, encryptionResult.iv);
-        Receipt receipt = new Receipt.Builder()
-                .withRememberMeId(USER_ID)
-                .withWrappedReceiptKey(validReceiptKey)
-                .withOtherPartyProfile(profileContent)
-                .withProfile(profileContent)
-                .withTimestamp(TIMESTAMP)
-                .withReceiptId(DECODED_RECEIPT_BYTES)
-                .withOutcome(Receipt.Outcome.SUCCESS)
-                .build();
-        when(profileServiceMock.getReceipt(any(KeyPair.class), anyString(), anyString())).thenReturn(receipt);
-        when(attributeConverterMock.<String>convertAttribute(STRING_ATTRIBUTE_PROTO)).thenReturn(stringAttributeMock);
-        when(attributeConverterMock.<Date>convertAttribute(DATE_ATTRIBUTE_PROTO)).thenReturn(dateAttributeMock);
-        when(attributeConverterMock.<Map>convertAttribute(JSON_ATTRIBUTE_PROTO)).thenReturn(jsonAttributeMock);
-
-        SecureYotiClient testObj = new SecureYotiClient(APP_ID, validKeyPairSource, profileServiceMock, remoteAmlServiceMock, attributeConverterMock);
-        ActivityDetails result = testObj.getActivityDetails(encryptedToken);
-
-        Collection<Attribute<?>> profileAttributes = result.getUserProfile().getAttributes();
-        assertThat(profileAttributes, hasSize(3));
-        assertThat(profileAttributes, hasItems(stringAttributeMock, dateAttributeMock, jsonAttributeMock));
-    }
-
-    @Test
-    public void getActivityDetails_shouldTolerateFailureToParseSomeAttributes() throws Exception {
-        byte[] profileContent = marshalProfile(encryptionResult.data, encryptionResult.iv);
-        Receipt receipt = new Receipt.Builder()
-                .withRememberMeId(USER_ID)
-                .withWrappedReceiptKey(validReceiptKey)
-                .withOtherPartyProfile(profileContent)
-                .withProfile(profileContent)
-                .withTimestamp(TIMESTAMP)
-                .withReceiptId(DECODED_RECEIPT_BYTES)
-                .withOutcome(Receipt.Outcome.SUCCESS)
-                .build();
-        when(profileServiceMock.getReceipt(any(KeyPair.class), anyString(), anyString())).thenReturn(receipt);
-        when(attributeConverterMock.<String>convertAttribute(STRING_ATTRIBUTE_PROTO)).thenReturn(stringAttributeMock);
-        when(attributeConverterMock.<Date>convertAttribute(DATE_ATTRIBUTE_PROTO)).thenThrow(new IOException());
-        when(attributeConverterMock.<Map>convertAttribute(JSON_ATTRIBUTE_PROTO)).thenThrow(new ParseException("some message", 1));
-
-        SecureYotiClient testObj = new SecureYotiClient(APP_ID, validKeyPairSource, profileServiceMock, remoteAmlServiceMock, attributeConverterMock);
-        ActivityDetails result = testObj.getActivityDetails(encryptedToken);
-
-        Collection<Attribute<?>> profileAttributes = result.getUserProfile().getAttributes();
-        assertThat(profileAttributes, hasSize(1));
-        assertThat(profileAttributes, hasItem(stringAttributeMock));
-    }
-
-    @Test
-    public void getActivityDetails_shouldGetEmptyProfileWithNullContent() throws Exception {
-        Receipt receipt = new Receipt.Builder()
-                .withRememberMeId(USER_ID)
-                .withWrappedReceiptKey(validReceiptKey)
-                .withOtherPartyProfile(null)
-                .withProfile(null)
-                .withTimestamp(TIMESTAMP)
-                .withReceiptId(DECODED_RECEIPT_BYTES)
-                .withOutcome(Receipt.Outcome.SUCCESS)
-                .build();
-        when(profileServiceMock.getReceipt(any(KeyPair.class), anyString(), anyString())).thenReturn(receipt);
-
-        SecureYotiClient testObj = new SecureYotiClient(APP_ID, validKeyPairSource, profileServiceMock, remoteAmlServiceMock, attributeConverterMock);
-        ActivityDetails result = testObj.getActivityDetails(encryptedToken);
-
-        assertNotNull(result);
-        Profile profile = result.getUserProfile();
-        assertNotNull(profile.getAttributes());
-        assertEquals(0, profile.getAttributes().size());
-    }
-
-    @Test
-    public void getActivityDetails_shouldGetEmptyProfileWithEmptyContent() throws Exception {
-        byte[] profileContent = new byte[0];
-        Receipt receipt = new Receipt.Builder()
-                .withRememberMeId(USER_ID)
-                .withWrappedReceiptKey(validReceiptKey)
-                .withOtherPartyProfile(profileContent)
-                .withProfile(profileContent)
-                .withTimestamp(TIMESTAMP)
-                .withReceiptId(DECODED_RECEIPT_BYTES)
-                .withOutcome(Receipt.Outcome.SUCCESS)
-                .build();
-        when(profileServiceMock.getReceipt(any(KeyPair.class), anyString(), anyString())).thenReturn(receipt);
-
-        SecureYotiClient testObj = new SecureYotiClient(APP_ID, validKeyPairSource, profileServiceMock, remoteAmlServiceMock, attributeConverterMock);
-        ActivityDetails result = testObj.getActivityDetails(encryptedToken);
-
-        assertNotNull(result);
-        Profile profile = result.getUserProfile();
-        assertNotNull(profile.getAttributes());
-        assertEquals(0, profile.getAttributes().size());
-    }
-
-    @Test
-    public void getActivityDetails_shouldFailWithInvalidTimestamp() throws Exception {
-        Receipt receipt = new Receipt.Builder()
-                .withRememberMeId(USER_ID)
-                .withWrappedReceiptKey(validReceiptKey)
-                .withOtherPartyProfile(null)
-                .withProfile(null)
-                .withTimestamp(INVALID_TIMESTAMP)
-                .withReceiptId(DECODED_RECEIPT_BYTES)
-                .withOutcome(Receipt.Outcome.SUCCESS)
-                .build();
-        when(profileServiceMock.getReceipt(any(KeyPair.class), anyString(), anyString())).thenReturn(receipt);
-
-        try {
-            SecureYotiClient testObj = new SecureYotiClient(APP_ID, validKeyPairSource, profileServiceMock, remoteAmlServiceMock, attributeConverterMock);
-            testObj.getActivityDetails(encryptedToken);
-        } catch (ProfileException e) {
-            assertThat(e.getMessage(), containsString("timestamp"));
-            assertTrue(e.getCause() instanceof ParseException);
-            return;
-        }
-        fail("Expected an Exception");
-    }
-
-    @Test
-    public void getActivityDetails_shouldFailWithNoIV() throws Exception {
-        byte[] profileContent = marshalProfile(encryptionResult.data, null);
-        Receipt receipt = new Receipt.Builder()
-                .withRememberMeId(USER_ID)
-                .withWrappedReceiptKey(validReceiptKey)
-                .withOtherPartyProfile(profileContent)
-                .withOutcome(Receipt.Outcome.SUCCESS)
-                .build();
-        when(profileServiceMock.getReceipt(any(KeyPair.class), anyString(), anyString())).thenReturn(receipt);
-
-        try {
-            SecureYotiClient testObj = new SecureYotiClient(APP_ID, validKeyPairSource, profileServiceMock, remoteAmlServiceMock, attributeConverterMock);
-            testObj.getActivityDetails(encryptedToken);
-        } catch (ProfileException e) {
-            assertThat(e.getMessage(), containsString("Receipt key IV must not be null."));
-            return;
-        }
-        fail("Expected an Exception");
-    }
-
-    @Test
-    public void getActivityDetails_shouldFailWithInvalidIV() throws Exception {
-        byte[] profileContent = marshalProfile(encryptionResult.data, new byte[] { 1, 2 });
-        Receipt receipt = new Receipt.Builder()
-                .withRememberMeId(USER_ID)
-                .withWrappedReceiptKey(validReceiptKey)
-                .withOtherPartyProfile(profileContent)
-                .withOutcome(Receipt.Outcome.SUCCESS)
-                .build();
-        when(profileServiceMock.getReceipt(any(KeyPair.class), anyString(), anyString())).thenReturn(receipt);
-
-        try {
-            SecureYotiClient testObj = new SecureYotiClient(APP_ID, validKeyPairSource, profileServiceMock, remoteAmlServiceMock, attributeConverterMock);
-            testObj.getActivityDetails(encryptedToken);
-        } catch (ProfileException e) {
-            assertThat(e.getMessage(), containsString("Error decrypting data"));
-            assertTrue(e.getCause() instanceof GeneralSecurityException);
-            return;
-        }
-        fail("Expected an Exception");
-    }
-
-    @Test
-    public void getActivityDetails_shouldFailWithNoReceipt() throws Exception {
-        when(profileServiceMock.getReceipt(any(KeyPair.class), anyString(), anyString())).thenReturn(null);
-
-        try {
-            SecureYotiClient testObj = new SecureYotiClient(APP_ID, validKeyPairSource, profileServiceMock, remoteAmlServiceMock, attributeConverterMock);
-            testObj.getActivityDetails(encryptedToken);
-        } catch (ProfileException e) {
-            assertThat(e.getMessage(), containsString("No receipt"));
-            assertThat(e.getMessage(), containsString(TOKEN));
-            return;
-        }
-        fail("Expected an Exception");
-    }
-
-    @Test
-    public void getActivityDetails_shouldFailWithFailureReceipt() throws Exception {
-        Receipt receipt = new Receipt.Builder()
-                .withReceiptId(DECODED_RECEIPT_BYTES)
-                .withOutcome(Receipt.Outcome.FAILURE)
-                .build();
-        when(profileServiceMock.getReceipt(any(KeyPair.class), anyString(), anyString())).thenReturn(receipt);
-
-        try {
-            SecureYotiClient testObj = new SecureYotiClient(APP_ID, validKeyPairSource, profileServiceMock, remoteAmlServiceMock, attributeConverterMock);
-            testObj.getActivityDetails(encryptedToken);
-        } catch (ActivityFailureException e) {
-            assertThat(e.getMessage(), containsString(ENCODED_RECEIPT_STRING));
-            return;
-        }
-        fail("Expected an Exception");
-    }
-
-    @Test
-    public void getActivityDetails_shouldFailWithInvalidProfileData() throws Exception {
-        byte[] profileContent = marshalProfile(new byte[] { 1, 2 }, encryptionResult.iv);
-        Receipt receipt = new Receipt.Builder()
-                .withOutcome(Receipt.Outcome.SUCCESS)
-                .withWrappedReceiptKey(validReceiptKey)
-                .withOtherPartyProfile(profileContent)
-                .build();
-        when(profileServiceMock.getReceipt(any(KeyPair.class), anyString(), anyString())).thenReturn(receipt);
-
-        try {
-            SecureYotiClient testObj = new SecureYotiClient(APP_ID, validKeyPairSource, profileServiceMock, remoteAmlServiceMock, attributeConverterMock);
-            testObj.getActivityDetails(encryptedToken);
-        } catch (ProfileException e) {
-            assertThat(e.getMessage(), containsString("Error decrypting data"));
-            assertTrue(e.getCause() instanceof GeneralSecurityException);
-            return;
-        }
-        fail("Expected an Exception");
-    }
-
-    @Test
-    public void getActivityDetails_shouldFailWithInvalidReceiptKey() throws Exception {
-        byte[] profileContent = marshalProfile(encryptionResult.data, encryptionResult.iv);
-        byte[] invalidReceiptKey = { 1, 2, 3 };
-        Receipt receipt = new Receipt.Builder()
-                .withOutcome(Receipt.Outcome.SUCCESS)
-                .withWrappedReceiptKey(invalidReceiptKey)
-                .withOtherPartyProfile(profileContent)
-                .build();
-        when(profileServiceMock.getReceipt(any(KeyPair.class), anyString(), anyString())).thenReturn(receipt);
-
-        try {
-            SecureYotiClient testObj = new SecureYotiClient(APP_ID, validKeyPairSource, profileServiceMock, remoteAmlServiceMock, attributeConverterMock);
-            testObj.getActivityDetails(encryptedToken);
-        } catch (ProfileException e) {
-            assertThat(e.getMessage(), containsString("Error decrypting data"));
-            assertTrue(e.getCause() instanceof GeneralSecurityException);
-            return;
-        }
-        fail("Expected an Exception");
-    }
-
-    @Test
-    public void getActivityDetails_shouldFailWithNoReceiptKey() throws Exception {
-        byte[] profileContent = marshalProfile(encryptionResult.data, encryptionResult.iv);
-        Receipt receipt = new Receipt.Builder()
-                .withOutcome(Receipt.Outcome.SUCCESS)
-                .withWrappedReceiptKey(null)
-                .withOtherPartyProfile(profileContent)
-                .build();
-        when(profileServiceMock.getReceipt(any(KeyPair.class), anyString(), anyString())).thenReturn(receipt);
-
-        try {
-            SecureYotiClient testObj = new SecureYotiClient(APP_ID, validKeyPairSource, profileServiceMock, remoteAmlServiceMock, attributeConverterMock);
-            testObj.getActivityDetails(encryptedToken);
-        } catch (ProfileException e) {
-            assertThat(e.getMessage(), containsString("Base64 encoding error"));
-            assertTrue(e.getCause() instanceof IllegalArgumentException);
-            return;
-        }
-        fail("Expected an Exception");
-    }
-
-    @Test
-    public void getActivityDetails_shouldFailWithNoProfileData() throws Exception {
-        byte[] profileContent = marshalProfile(null, encryptionResult.iv);
-        Receipt receipt = new Receipt.Builder()
-                .withOutcome(Receipt.Outcome.SUCCESS)
-                .withWrappedReceiptKey(validReceiptKey)
-                .withOtherPartyProfile(profileContent)
-                .build();
-        when(profileServiceMock.getReceipt(any(KeyPair.class), anyString(), anyString())).thenReturn(receipt);
-
-        try {
-            SecureYotiClient testObj = new SecureYotiClient(APP_ID, validKeyPairSource, profileServiceMock, remoteAmlServiceMock, attributeConverterMock);
-            testObj.getActivityDetails(encryptedToken);
-        } catch (ProfileException e) {
-            assertThat(e.getMessage(), containsString("Error decrypting data"));
-            assertTrue(e.getCause() instanceof GeneralSecurityException);
-            return;
-        }
-        fail("Expected an Exception");
-    }
-
-    @Test
-    public void getActivityDetails_shouldFailWithExceptionFromProfileService() throws Exception {
+    public void getActivityDetails_shouldFailWithExceptionFromReceiptFetcher() throws Exception {
         ProfileException profileException = new ProfileException("Test exception");
-        when(profileServiceMock.getReceipt(any(KeyPair.class), anyString(), anyString())).thenThrow(profileException);
+        when(receiptFetcherMock.fetch(eq(encryptedToken), any(KeyPair.class), eq(APP_ID))).thenThrow(profileException);
 
         try {
-            SecureYotiClient testObj = new SecureYotiClient(APP_ID, validKeyPairSource, profileServiceMock, remoteAmlServiceMock, attributeConverterMock);
+            SecureYotiClient testObj = new SecureYotiClient(APP_ID, validKeyPairSource, receiptFetcherMock, activityDetailsFactoryMock, remoteAmlServiceMock);
             testObj.getActivityDetails(encryptedToken);
         } catch (ProfileException e) {
             assertSame(profileException, e);
@@ -401,12 +81,39 @@ public class SecureYotiClientTest {
     }
 
     @Test
-    public void getActivityDetails_shouldFailWhenStreamExceptionLoadingKeys() throws Exception {
-        KeyPairSource exceptionKeyPairSource = new StaticKeyPairSource(true);
+    public void getActivityDetails_shouldFailWithExceptionFromActivityDetailsFactory() throws Exception {
+        ProfileException profileException = new ProfileException("Test exception");
+        when(receiptFetcherMock.fetch(eq(encryptedToken), any(KeyPair.class), eq(APP_ID))).thenReturn(receiptMock);
+        when(activityDetailsFactoryMock.create(eq(receiptMock), any(PrivateKey.class))).thenThrow(profileException);
 
         try {
-            SecureYotiClient testObj = new SecureYotiClient(APP_ID, exceptionKeyPairSource, profileServiceMock, remoteAmlServiceMock, attributeConverterMock);
+            SecureYotiClient testObj = new SecureYotiClient(APP_ID, validKeyPairSource, receiptFetcherMock, activityDetailsFactoryMock, remoteAmlServiceMock);
             testObj.getActivityDetails(encryptedToken);
+        } catch (ProfileException e) {
+            assertSame(profileException, e);
+            verify(activityDetailsFactoryMock).create(eq(receiptMock), any(PrivateKey.class));
+            return;
+        }
+        fail("Expected an Exception");
+    }
+
+    @Test
+    public void getActivityDetails_shouldReturnActivityDetails() throws Exception {
+        when(receiptFetcherMock.fetch(eq(encryptedToken), any(KeyPair.class), eq(APP_ID))).thenReturn(receiptMock);
+        when(activityDetailsFactoryMock.create(eq(receiptMock), any(PrivateKey.class))).thenReturn(activityDetailsMock);
+
+        SecureYotiClient testObj = new SecureYotiClient(APP_ID, validKeyPairSource, receiptFetcherMock, activityDetailsFactoryMock, remoteAmlServiceMock);
+        ActivityDetails result = testObj.getActivityDetails(encryptedToken);
+
+        assertSame(activityDetailsMock, result);
+    }
+
+    @Test
+    public void constructor_shouldFailWhenStreamExceptionLoadingKeys() throws Exception {
+        KeyPairSource badKeyPairSource = new StaticKeyPairSource(true);
+
+        try {
+            new SecureYotiClient(APP_ID, badKeyPairSource, receiptFetcherMock, activityDetailsFactoryMock, remoteAmlServiceMock);
         } catch (InitialisationException e) {
             assertTrue(e.getCause() instanceof IOException);
             assertThat(e.getCause().getMessage(), containsString("Test stream exception"));
@@ -416,12 +123,11 @@ public class SecureYotiClientTest {
     }
 
     @Test
-    public void getActivityDetails_shouldFailWhenKeyPairSourceExceptionLoadingKeys() throws Exception {
-        KeyPairSource exceptionKeyPairSource = new StaticKeyPairSource(false);
+    public void constructor_shouldFailWhenKeyPairSourceExceptionLoadingKeys() throws Exception {
+        KeyPairSource badKeyPairSource = new StaticKeyPairSource(false);
 
         try {
-            SecureYotiClient testObj = new SecureYotiClient(APP_ID, exceptionKeyPairSource, profileServiceMock, remoteAmlServiceMock, attributeConverterMock);
-            testObj.getActivityDetails(encryptedToken);
+            new SecureYotiClient(APP_ID, badKeyPairSource, receiptFetcherMock, activityDetailsFactoryMock, remoteAmlServiceMock);
         } catch (InitialisationException e) {
             assertTrue(e.getCause() instanceof IOException);
             assertThat(e.getCause().getMessage(), containsString("Test source exception"));
@@ -433,7 +139,7 @@ public class SecureYotiClientTest {
     @Test
     public void constructor_shouldFailWithNullApplicationId() throws Exception {
         try {
-            new SecureYotiClient(null, validKeyPairSource, profileServiceMock, remoteAmlServiceMock, attributeConverterMock);
+            new SecureYotiClient(null, validKeyPairSource, receiptFetcherMock, activityDetailsFactoryMock, remoteAmlServiceMock);
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), containsString("Application id"));
             return;
@@ -444,7 +150,7 @@ public class SecureYotiClientTest {
     @Test
     public void constructor_shouldFailWithNullKeyPairSource() throws Exception {
         try {
-            new SecureYotiClient(APP_ID, null, profileServiceMock, remoteAmlServiceMock, attributeConverterMock);
+            new SecureYotiClient(APP_ID, null, receiptFetcherMock, activityDetailsFactoryMock, remoteAmlServiceMock);
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), containsString("Key pair source"));
             return;
@@ -453,11 +159,22 @@ public class SecureYotiClientTest {
     }
 
     @Test
-    public void constructor_shouldFailWithNullProfileService() throws Exception {
+    public void constructor_shouldFailWithNullReceiptFetcher() throws Exception {
         try {
-            new SecureYotiClient(APP_ID, validKeyPairSource, null, remoteAmlServiceMock, attributeConverterMock);
+            new SecureYotiClient(APP_ID, validKeyPairSource, null, activityDetailsFactoryMock, remoteAmlServiceMock);
         } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), containsString("Profile service"));
+            assertThat(e.getMessage(), containsString("receiptFetcher"));
+            return;
+        }
+        fail("Expected an Exception");
+    }
+
+    @Test
+    public void constructor_shouldFailWithNullActivityDetailsFactory() throws Exception {
+        try {
+            new SecureYotiClient(APP_ID, validKeyPairSource, receiptFetcherMock, null, remoteAmlServiceMock);
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("activityDetailsFactory"));
             return;
         }
         fail("Expected an Exception");
@@ -466,20 +183,9 @@ public class SecureYotiClientTest {
     @Test
     public void constructor_shouldFailWithNullAmlService() throws Exception {
         try {
-            new SecureYotiClient(APP_ID, validKeyPairSource, profileServiceMock, null, attributeConverterMock);
+            new SecureYotiClient(APP_ID, validKeyPairSource, receiptFetcherMock, activityDetailsFactoryMock, null);
         } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), containsString("Aml service"));
-            return;
-        }
-        fail("Expected an Exception");
-    }
-
-    @Test
-    public void constructor_shouldFailWithNullAttributeConverter() throws Exception {
-        try {
-            new SecureYotiClient(APP_ID, validKeyPairSource, profileServiceMock, remoteAmlServiceMock, null);
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), containsString("Attribute Converter"));
+            assertThat(e.getMessage(), containsString("amlService"));
             return;
         }
         fail("Expected an Exception");
@@ -490,7 +196,7 @@ public class SecureYotiClientTest {
         KeyPairSource invalidKeyPairSource = new StaticKeyPairSource("no-key-pair-in-file");
 
         try {
-            new SecureYotiClient(APP_ID, invalidKeyPairSource, profileServiceMock, remoteAmlServiceMock, attributeConverterMock);
+            new SecureYotiClient(APP_ID, invalidKeyPairSource, receiptFetcherMock, activityDetailsFactoryMock, remoteAmlServiceMock);
         } catch (InitialisationException e) {
             assertThat(e.getMessage(), containsString("No key pair found in the provided source"));
             return;
@@ -503,53 +209,13 @@ public class SecureYotiClientTest {
         KeyPairSource invalidKeyPairSource = new StaticKeyPairSource(CryptoUtil.INVALID_KEY_PAIR_PEM);
 
         try {
-            new SecureYotiClient(APP_ID, invalidKeyPairSource, profileServiceMock, remoteAmlServiceMock, attributeConverterMock);
+            new SecureYotiClient(APP_ID, invalidKeyPairSource, receiptFetcherMock, activityDetailsFactoryMock, remoteAmlServiceMock);
         } catch (InitialisationException e) {
             assertThat(e.getMessage(), containsString("Cannot load key pair"));
             assertTrue(e.getCause() instanceof PEMException);
             return;
         }
         fail("Expected an Exception");
-    }
-
-    @Test
-    public void getActivityDetails_shouldFailWithInvalidToken() throws Exception {
-        try {
-            SecureYotiClient testObj = new SecureYotiClient(APP_ID, validKeyPairSource, profileServiceMock, remoteAmlServiceMock, attributeConverterMock);
-            testObj.getActivityDetails(TOKEN);
-        } catch (ProfileException e) {
-            assertThat(e.getMessage(), containsString("Cannot decrypt connect token"));
-            assertTrue(e.getCause() instanceof IllegalArgumentException);
-            return;
-        }
-        fail("Expected an Exception");
-    }
-
-    @Test
-    public void getActivityDetails_shouldFailWithNullToken() throws Exception {
-        try {
-            SecureYotiClient testObj = new SecureYotiClient(APP_ID, validKeyPairSource, profileServiceMock, remoteAmlServiceMock, attributeConverterMock);
-            testObj.getActivityDetails(null);
-        } catch (ProfileException e) {
-            assertThat(e.getMessage(), containsString("Cannot decrypt connect token"));
-            assertTrue(e.getCause() instanceof NullPointerException);
-            return;
-        }
-        fail("Expected an Exception");
-    }
-
-    private byte[] createProfileData() {
-        return AttributeList.newBuilder()
-                .addAttributes(STRING_ATTRIBUTE_PROTO)
-                .addAttributes(DATE_ATTRIBUTE_PROTO)
-                .addAttributes(JSON_ATTRIBUTE_PROTO)
-                .build().toByteArray();
-    }
-
-    private static AttrProto.Attribute createAttribute(String name) {
-        return AttrProto.Attribute.newBuilder()
-                .setName(name)
-                .build();
     }
 
     private static class StaticKeyPairSource implements KeyPairSource {
@@ -582,17 +248,6 @@ public class SecureYotiClientTest {
             }
         }
 
-    }
-
-    private byte[] marshalProfile(byte[] data, byte[] iv) {
-        EncryptedDataProto.EncryptedData.Builder eb = EncryptedDataProto.EncryptedData.newBuilder();
-        if (iv != null) {
-            eb = eb.setIv(ByteString.copyFrom(iv));
-        }
-        if (data != null) {
-            eb = eb.setCipherText(ByteString.copyFrom(data));
-        }
-        return eb.build().toByteArray();
     }
 
 }

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/util/CryptoUtil.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/util/CryptoUtil.java
@@ -102,7 +102,7 @@ public class CryptoUtil {
         return keyPair;
     }
 
-    public static Key generateKey()  throws GeneralSecurityException {
+    public static Key generateSymmetricKey() throws GeneralSecurityException {
         KeyGenerator keyGen = KeyGenerator.getInstance(SYMMETRIC_KEY_ALGO, BOUNCY_CASTLE_PROVIDER);
         keyGen.init(SYMMETRIC_LENGTH);
         return keyGen.generateKey();

--- a/yoti-sdk-parent/pom.xml
+++ b/yoti-sdk-parent/pom.xml
@@ -86,6 +86,7 @@
     <junit.version>4.12</junit.version>
     <mockito.version>2.18.3</mockito.version>
     <hamcrest.version>1.3</hamcrest.version>
+    <commons.lang3.version>3.7</commons.lang3.version>
 
     <!-- maven + plugin versions -->
     <maven.compiler.version>3.0</maven.compiler.version>
@@ -215,7 +216,13 @@
         <artifactId>hamcrest-library</artifactId>
         <version>${hamcrest.version}</version>
       </dependency>
-      
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${commons.lang3.version}</version>
+      </dependency>
+
+
     </dependencies>
   </dependencyManagement>
   


### PR DESCRIPTION
Some big changes, but there should be no change to the API or the behaviour of the SDK to anyone using it.

More detail in the ticket.