### PR TITLE
SDK-394: Stop using Enums for attribute values

### DIFF
--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/DocumentDetails.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/DocumentDetails.java
@@ -6,12 +6,17 @@ package com.yoti.api.client;
  */
 public interface DocumentDetails {
 
+    String DOCUMENT_TYPE_PASSPORT = "PASSPORT";
+    String DOCUMENT_TYPE_DRIVING_LICENCE = "DRIVING_LICENCE";
+    String DOCUMENT_TYPE_AADHAAR = "AADHAAR";
+    String DOCUMENT_TYPE_PASS_CARD = "PASS_CARD";
+
     /**
      * Return document type.
      * 
      * @return Return document type
      */
-    DocumentType getType();
+    String getType();
 
     /**
      * Return issuing country
@@ -40,12 +45,5 @@ public interface DocumentDetails {
      * @return Either a country code, or the name of the issuing authority
      */
     String getIssuingAuthority();
-
-    static enum DocumentType {
-        PASSPORT,
-        DRIVING_LICENCE,
-        AADHAAR,
-        PASS_CARD
-    }
 
 }

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/HumanProfile.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/HumanProfile.java
@@ -7,34 +7,39 @@ import java.util.Map;
  */
 public interface HumanProfile extends Profile {
 
+    String GENDER_MALE = "MALE";
+    String GENDER_FEMALE = "FEMALE";
+    String GENDER_TRANSGENDER = "TRANSGENDER";
+    String GENDER_OTHER = "OTHER";
+
     /**
      * Corresponds to primary name in passport, and surname in English.
      *
      * @return the family name
      */
     Attribute<String> getFamilyName();
-    
+
     /**
      * Corresponds to secondary names in passport, and first/middle names in English.
      *
      * @return the given names
      */
     Attribute<String> getGivenNames();
-    
+
     /**
      * The full name attribute.
      *
      * @return the full name
      */
     Attribute<String> getFullName();
-    
+
     /**
      * Date of birth
      *
      * @return Date of birth
      */
     Attribute<Date> getDateOfBirth();
-    
+
     /**
      * Did the user pass the age verification check?
      *
@@ -47,7 +52,7 @@ public interface HumanProfile extends Profile {
      *
      * @return the gender
      */
-    Attribute<Gender> getGender();
+    Attribute<String> getGender();
 
     /**
      * The user's postal address as a String
@@ -55,21 +60,21 @@ public interface HumanProfile extends Profile {
      * @return the postal address
      */
     Attribute<String> getPostalAddress();
-    
+
     /**
      * The user's structured postal address as a Json
      *
      * @return the postal address
      */
     Attribute<Map<?, ?>> getStructuredPostalAddress();
-    
+
     /**
      * Corresponds to the nationality in the passport.
      *
      * @return the nationality
      */
     Attribute<String> getNationality();
-    
+
     /**
      * The user's phone number, as verified at registration time. This will be a number with + for international prefix
      * and no spaces, e.g. "+447777123456".
@@ -84,23 +89,19 @@ public interface HumanProfile extends Profile {
      * @return the selfie
      */
     Attribute<Image> getSelfie();
-    
+
     /**
      * The user's verified email address.
      *
      * @return the email address
      */
     Attribute<String> getEmailAddress();
-    
+
     /**
      * Document details
      *
      * @return the document details
      */
     Attribute<DocumentDetails> getDocumentDetails();
-    
-    static enum Gender {
-        MALE, FEMALE, OTHER
-    }
 
 }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ActivityDetailsFactory.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ActivityDetailsFactory.java
@@ -18,9 +18,9 @@ import com.yoti.api.client.ActivityDetails;
 import com.yoti.api.client.Profile;
 import com.yoti.api.client.ProfileException;
 import com.yoti.api.client.spi.remote.call.Receipt;
-import com.yoti.api.client.spi.remote.util.Decryption;
+import com.yoti.api.client.spi.remote.util.DecryptionHelper;
 
-public class ActivityDetailsFactory {
+class ActivityDetailsFactory {
 
     private static final String RFC3339_PATTERN = "yyyy-MM-dd'T'HH:mm:ss'Z'";
 
@@ -30,12 +30,12 @@ public class ActivityDetailsFactory {
         this.profileReader = notNull(profileReader, "profileReader");
     }
 
-    public static ActivityDetailsFactory newInstance() {
+    static ActivityDetailsFactory newInstance() {
         return new ActivityDetailsFactory(ProfileReader.newInstance());
     }
 
-    public ActivityDetails create(Receipt receipt, PrivateKey privateKey) throws ProfileException {
-        byte[] decryptedKey = Decryption.decryptAsymmetric(receipt.getWrappedReceiptKey(), privateKey);
+    ActivityDetails create(Receipt receipt, PrivateKey privateKey) throws ProfileException {
+        byte[] decryptedKey = DecryptionHelper.decryptAsymmetric(receipt.getWrappedReceiptKey(), privateKey);
         Key secretKey = new SecretKeySpec(decryptedKey, SYMMETRIC_CIPHER);
 
         Profile userProfile = profileReader.read(receipt.getOtherPartyProfile(), secretKey);

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AttributeConverter.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AttributeConverter.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class AttributeConverter {
+class AttributeConverter {
 
     private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
     private static final Logger LOG = LoggerFactory.getLogger(AttributeConverter.class);
@@ -32,11 +32,11 @@ public class AttributeConverter {
         this.documentDetailsAttributeParser = documentDetailsAttributeParser;
     }
 
-    public static final AttributeConverter newInstance() {
+    static final AttributeConverter newInstance() {
         return new AttributeConverter(new DocumentDetailsAttributeParser());
     }
 
-    public <T> Attribute<T> convertAttribute(AttrProto.Attribute attribute) throws ParseException, IOException {
+    <T> Attribute<T> convertAttribute(AttrProto.Attribute attribute) throws ParseException, IOException {
         Object value = convertValueFromProto(attribute);
         value = convertSpecialType(attribute, value);
         Set<String> sources = extractMetadata(attribute, AnchorType.SOURCE);

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AttributeConverter.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AttributeConverter.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.Set;
 
 import com.yoti.api.client.Attribute;
-import com.yoti.api.client.HumanProfile;
 import com.yoti.api.client.spi.remote.proto.AttrProto;
 import com.yoti.api.client.spi.remote.proto.AttrProto.Anchor;
 import com.yoti.api.client.spi.remote.util.AnchorCertificateParser;
@@ -66,8 +65,6 @@ class AttributeConverter {
         switch (attribute.getName()) {
             case HumanProfileAdapter.ATTRIBUTE_DOCUMENT_DETAILS:
                 return documentDetailsAttributeParser.parseFrom((String) value);
-            case HumanProfileAdapter.ATTRIBUTE_GENDER:
-                return HumanProfile.Gender.valueOf((String) value);
             default:
                 return value;
         }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AttributeListConverter.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AttributeListConverter.java
@@ -15,7 +15,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class AttributeListConverter {
+class AttributeListConverter {
 
     private static final Logger LOG = LoggerFactory.getLogger(AttributeListConverter.class);
 
@@ -25,11 +25,11 @@ public class AttributeListConverter {
         this.attributeConverter = attributeConverter;
     }
 
-    public static AttributeListConverter newInstance() {
+    static AttributeListConverter newInstance() {
         return new AttributeListConverter(AttributeConverter.newInstance());
     }
 
-    public List<Attribute<?>> parseAttributeList(byte[] attributeListBytes) throws ProfileException {
+    List<Attribute<?>> parseAttributeList(byte[] attributeListBytes) throws ProfileException {
         if (attributeListBytes == null || attributeListBytes.length == 0) {
             return Collections.emptyList();
         }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/DocumentDetailsAttributeParser.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/DocumentDetailsAttributeParser.java
@@ -6,7 +6,7 @@ import java.text.ParseException;
 import com.yoti.api.client.Date;
 import com.yoti.api.client.DocumentDetails;
 
-public class DocumentDetailsAttributeParser {
+class DocumentDetailsAttributeParser {
 
     private static final String MINIMUM_ACCEPTABLE = "([A-Za-z_]*) ([A-Za-z]{3}) ([A-Za-z0-9]{1}).*";
     private static final int TYPE_INDEX = 0;
@@ -15,7 +15,7 @@ public class DocumentDetailsAttributeParser {
     private static final int EXPIRATION_INDEX = 3;
     private static final int AUTHORITY_INDEX = 4;
 
-    public DocumentDetails parseFrom(String attribute) throws UnsupportedEncodingException, ParseException {
+    DocumentDetails parseFrom(String attribute) throws UnsupportedEncodingException, ParseException {
         if (attribute == null || !attribute.matches(MINIMUM_ACCEPTABLE)) {
             return null;
         }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/DocumentDetailsAttributeParser.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/DocumentDetailsAttributeParser.java
@@ -21,7 +21,7 @@ class DocumentDetailsAttributeParser {
         }
 
         String[] attributes = attribute.split(" ");
-        DocumentDetails.DocumentType documentType = DocumentDetails.DocumentType.valueOf(attributes[TYPE_INDEX]);
+        String documentType = attributes[TYPE_INDEX];
         String issuingCountry = attributes[COUNTRY_INDEX];
         String number = attributes[NUMBER_INDEX];
         Date expirationDate = getDateSafely(attributes, EXPIRATION_INDEX);

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/DocumentDetailsAttributeValue.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/DocumentDetailsAttributeValue.java
@@ -5,13 +5,13 @@ import com.yoti.api.client.DocumentDetails;
 
 final class DocumentDetailsAttributeValue implements DocumentDetails {
 
-    private final DocumentType type;
+    private final String type;
     private final String issuingCountry;
     private final Date expirationDate;
     private final String number;
     private final String authority;
 
-    public DocumentDetailsAttributeValue(DocumentType type, String issuingCountry, Date expirationDate, String number, String authority) {
+    public DocumentDetailsAttributeValue(String type, String issuingCountry, Date expirationDate, String number, String authority) {
         this.type = type;
         this.issuingCountry = issuingCountry;
         this.expirationDate = expirationDate;
@@ -20,7 +20,7 @@ final class DocumentDetailsAttributeValue implements DocumentDetails {
     }
 
     @Override
-    public DocumentType getType() {
+    public String getType() {
         return type;
     }
 

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/HumanProfileAdapter.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/HumanProfileAdapter.java
@@ -90,8 +90,8 @@ final class HumanProfileAdapter implements HumanProfile {
     }
 
     @Override
-    public Attribute<Gender> getGender() {
-        return wrapped.getAttribute(ATTRIBUTE_GENDER, Gender.class);
+    public Attribute<String> getGender() {
+        return wrapped.getAttribute(ATTRIBUTE_GENDER, String.class);
     }
 
     @Override

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ProfileReader.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ProfileReader.java
@@ -21,7 +21,7 @@ import com.yoti.api.client.spi.remote.proto.EncryptedDataProto;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 
-public class ProfileReader {
+class ProfileReader {
 
     private final AttributeListConverter attributeListConverter;
 
@@ -29,11 +29,11 @@ public class ProfileReader {
         this.attributeListConverter = attributeListConverter;
     }
 
-    public static ProfileReader newInstance() {
+    static ProfileReader newInstance() {
         return new ProfileReader(AttributeListConverter.newInstance());
     }
 
-    public Profile read(byte[] encryptedProfileBytes, Key secretKey) throws ProfileException {
+    Profile read(byte[] encryptedProfileBytes, Key secretKey) throws ProfileException {
         List<Attribute<?>> attributeList = new ArrayList<>();
         if (encryptedProfileBytes != null && encryptedProfileBytes.length > 0) {
             byte[] profileData = decryptProfile(encryptedProfileBytes, secretKey);

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ReceiptFetcher.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ReceiptFetcher.java
@@ -10,12 +10,12 @@ import com.yoti.api.client.ProfileException;
 import com.yoti.api.client.spi.remote.call.ProfileService;
 import com.yoti.api.client.spi.remote.call.Receipt;
 import com.yoti.api.client.spi.remote.call.RemoteProfileService;
-import com.yoti.api.client.spi.remote.util.Decryption;
+import com.yoti.api.client.spi.remote.util.DecryptionHelper;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ReceiptFetcher {
+class ReceiptFetcher {
 
     private static final Logger LOG = LoggerFactory.getLogger(ReceiptFetcher.class);
 
@@ -25,11 +25,11 @@ public class ReceiptFetcher {
         this.profileService = profileService;
     }
 
-    public static ReceiptFetcher newInstance() {
+    static ReceiptFetcher newInstance() {
         return new ReceiptFetcher(RemoteProfileService.newInstance());
     }
 
-    public Receipt fetch(String encryptedConnectToken, KeyPair keyPair, String appId) throws ProfileException {
+    Receipt fetch(String encryptedConnectToken, KeyPair keyPair, String appId) throws ProfileException {
         LOG.debug("Decrypting connect token: '{}'", encryptedConnectToken);
         String connectToken = decryptConnectToken(encryptedConnectToken, keyPair.getPrivate());
         LOG.debug("Connect token decrypted: '{}'", connectToken);
@@ -41,7 +41,7 @@ public class ReceiptFetcher {
     private String decryptConnectToken(String encryptedConnectToken, PrivateKey privateKey) throws ProfileException {
         try {
             byte[] byteValue = Base64.getUrlDecoder().decode(encryptedConnectToken);
-            byte[] decryptedToken = Decryption.decryptAsymmetric(byteValue, privateKey);
+            byte[] decryptedToken = DecryptionHelper.decryptAsymmetric(byteValue, privateKey);
             return new String(decryptedToken, DEFAULT_CHARSET);
         } catch (Exception e) {
             throw new ProfileException("Cannot decrypt connect token", e);

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/Receipt.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/Receipt.java
@@ -95,12 +95,12 @@ public final class Receipt {
         }
     }
 
-    public static enum Outcome {
+    public enum Outcome {
         SUCCESS(true), FAILURE(false);
 
         private final boolean successful;
 
-        private Outcome(boolean successful) {
+        Outcome(boolean successful) {
             this.successful = successful;
         }
 

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/factory/MessageFactory.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/factory/MessageFactory.java
@@ -5,9 +5,9 @@ import java.io.UnsupportedEncodingException;
 import static com.yoti.api.client.spi.remote.Base64.base64;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.DEFAULT_CHARSET;
 
-public class MessageFactory {
+class MessageFactory {
 
-    public byte[] create(String httpMethod, String path, byte[] body) {
+    byte[] create(String httpMethod, String path, byte[] body) {
         try {
             String message = httpMethod + "&" + path;
             if (body != null && body.length > 0) {

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/util/DecryptionHelper.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/util/DecryptionHelper.java
@@ -12,7 +12,7 @@ import javax.crypto.Cipher;
 
 import com.yoti.api.client.ProfileException;
 
-public class Decryption {
+public class DecryptionHelper {
 
     public static byte[] decryptAsymmetric(byte[] source, PrivateKey key) throws ProfileException {
         try {

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/AttributeConverterTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/AttributeConverterTest.java
@@ -154,10 +154,10 @@ public class AttributeConverterTest {
                 .setValue(ByteString.copyFromUtf8(GENDER_MALE))
                 .build();
 
-        Attribute<HumanProfile.Gender> result = testObj.convertAttribute(attribute);
+        Attribute<String> result = testObj.convertAttribute(attribute);
 
         assertEquals(ATTRIBUTE_GENDER, result.getName());
-        assertEquals(HumanProfile.Gender.MALE, result.getValue());
+        assertEquals(HumanProfile.GENDER_MALE, result.getValue());
     }
 
     @Test

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/DocumentDetailsAttributeParserTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/DocumentDetailsAttributeParserTest.java
@@ -1,17 +1,14 @@
 package com.yoti.api.client.spi.remote;
 
-import static com.yoti.api.client.DocumentDetails.DocumentType.AADHAAR;
-import static com.yoti.api.client.DocumentDetails.DocumentType.DRIVING_LICENCE;
-import static com.yoti.api.client.DocumentDetails.DocumentType.PASSPORT;
-import static com.yoti.api.client.DocumentDetails.DocumentType.PASS_CARD;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-import com.yoti.api.client.DocumentDetails;
-import org.junit.Test;
-
 import java.text.ParseException;
+
+import com.yoti.api.client.DocumentDetails;
+
+import org.junit.Test;
 
 public class DocumentDetailsAttributeParserTest {
 
@@ -41,7 +38,7 @@ public class DocumentDetailsAttributeParserTest {
         DocumentDetails result = testObj.parseFrom("PASSPORT GBR 1234abc");
 
         assertNotNull(result);
-        assertEquals(PASSPORT, result.getType());
+        assertEquals(DocumentDetails.DOCUMENT_TYPE_PASSPORT, result.getType());
         assertEquals("GBR", result.getIssuingCountry());
         assertEquals("1234abc", result.getDocumentNumber());
         assertNull(result.getExpirationDate());
@@ -53,7 +50,7 @@ public class DocumentDetailsAttributeParserTest {
         DocumentDetails result = testObj.parseFrom("AADHAAR IND 1234abc 2016-05-01");
 
         assertNotNull(result);
-        assertEquals(AADHAAR, result.getType());
+        assertEquals(DocumentDetails.DOCUMENT_TYPE_AADHAAR, result.getType());
         assertEquals("IND", result.getIssuingCountry());
         assertEquals("1234abc", result.getDocumentNumber());
         assertEquals("2016-05-01", result.getExpirationDate().toString());
@@ -65,7 +62,7 @@ public class DocumentDetailsAttributeParserTest {
         DocumentDetails result = testObj.parseFrom("DRIVING_LICENCE GBR 1234abc 2016-05-01 DVLA");
 
         assertNotNull(result);
-        assertEquals(DRIVING_LICENCE, result.getType());
+        assertEquals(DocumentDetails.DOCUMENT_TYPE_DRIVING_LICENCE, result.getType());
         assertEquals("GBR", result.getIssuingCountry());
         assertEquals("1234abc", result.getDocumentNumber());
         assertEquals("2016-05-01", result.getExpirationDate().toString());
@@ -77,16 +74,11 @@ public class DocumentDetailsAttributeParserTest {
         DocumentDetails result = testObj.parseFrom("PASS_CARD GBR 1234abc - DVLA");
 
         assertNotNull(result);
-        assertEquals(PASS_CARD, result.getType());
+        assertEquals(DocumentDetails.DOCUMENT_TYPE_PASS_CARD, result.getType());
         assertEquals("GBR", result.getIssuingCountry());
         assertEquals("1234abc", result.getDocumentNumber());
         assertNull(result.getExpirationDate());
         assertEquals("DVLA", result.getIssuingAuthority());
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void shouldFailOnInvalidType() throws Exception {
-        testObj.parseFrom(INVALID_ATTRIBUTE__TYPE);
     }
 
     @Test
@@ -107,4 +99,5 @@ public class DocumentDetailsAttributeParserTest {
 
         assertNull(result);
     }
+
 }


### PR DESCRIPTION
I've written quite a bit in the ticket.  In short...

We will not use Enums for attribute values.  If we start to return a new value for a given attribute, say a new _Gender_ type or a new _DocumentType_ then parsing that new value will cause an error.  Users of the SDK will be forced to upgrade in order to access the new value, and that's what we're trying to avoid.