### PR TITLE
SDK-387: Throw Exception for a malformed DocumentDetails attribute value

### DIFF
--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AttributeConverter.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AttributeConverter.java
@@ -59,7 +59,7 @@ class AttributeConverter {
             case JSON:
                 return JSON_MAPPER.readValue(attribute.getValue().toString(DEFAULT_CHARSET), Map.class);
             default:
-                LOG.error("Unknown type {} for attribute {}", attribute.getContentType(), attribute.getName());
+                LOG.warn("Unknown type {} for attribute {}.  Attempting to parse it as a String", attribute.getContentType(), attribute.getName());
                 return attribute.getValue().toString(DEFAULT_CHARSET);
         }
     }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AttributeListConverter.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AttributeListConverter.java
@@ -54,7 +54,7 @@ class AttributeListConverter {
             try {
                 parsedAttributes.add(attributeConverter.convertAttribute(attribute));
             } catch (IOException | ParseException e) {
-                LOG.warn("Cannot parse value for attribute '{}'", attribute.getName());
+                LOG.warn("Failed to parse attribute '{}'", attribute.getName());
             }
         }
         return parsedAttributes;

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/DocumentDetailsAttributeParser.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/DocumentDetailsAttributeParser.java
@@ -15,12 +15,11 @@ class DocumentDetailsAttributeParser {
     private static final int EXPIRATION_INDEX = 3;
     private static final int AUTHORITY_INDEX = 4;
 
-    DocumentDetails parseFrom(String attribute) throws UnsupportedEncodingException, ParseException {
-        if (attribute == null || !attribute.matches(MINIMUM_ACCEPTABLE)) {
-            return null;
+    DocumentDetails parseFrom(String attributeValue) throws UnsupportedEncodingException, ParseException {
+        if (attributeValue == null || !attributeValue.matches(MINIMUM_ACCEPTABLE)) {
+            throw new IllegalArgumentException("Unable to parse attribute value to a DocumentDetails");
         }
-
-        String[] attributes = attribute.split(" ");
+        String[] attributes = attributeValue.split(" ");
         String documentType = attributes[TYPE_INDEX];
         String issuingCountry = attributes[COUNTRY_INDEX];
         String number = attributes[NUMBER_INDEX];

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/aml/RemoteAmlService.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/aml/RemoteAmlService.java
@@ -81,7 +81,7 @@ public class RemoteAmlService {
         }
     }
 
-    private AmlException createExceptionFromStatusCode(ResourceException e) throws AmlException {
+    private AmlException createExceptionFromStatusCode(ResourceException e) {
         switch (e.getResponseCode()) {
             case HTTP_BAD_REQUEST:
                 return new AmlException("Failed validation:\n" + e.getResponseBody(), e);

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/DocumentDetailsAttributeParserTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/DocumentDetailsAttributeParserTest.java
@@ -12,25 +12,26 @@ import org.junit.Test;
 
 public class DocumentDetailsAttributeParserTest {
 
-    private static final String INVALID_ATTRIBUTE__TYPE = "XXXPORT GBR 1234abc 2016-05-01";
-    private static final String INVALID_ATTRIBUTE__NUMBER = "PASSPORT GBR $%^$%^£ 2016-05-01";
-    private static final String INVALID_ATTRIBUTE__COUNTRY = "PASSPORT 13 1234abc 2016-05-01";
-    private static final String INVALID_ATTRIBUTE__DATE = "PASSPORT GBR 1234abc" + " X016-05-01";
-
     DocumentDetailsAttributeParser testObj = new DocumentDetailsAttributeParser();
 
-    @Test
-    public void shouldReturnNullForNullAttribute() throws Exception {
-        DocumentDetails result = testObj.parseFrom(null);
-
-        assertNull(result);
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionForNullAttribute() throws Exception {
+        testObj.parseFrom(null);
     }
 
-    @Test
-    public void shouldReturnNullWhenAttributesAreMissing() throws Exception {
-        DocumentDetails result = testObj.parseFrom("PASSPORT GBR");
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionWhenAttributesAreMissing() throws Exception {
+        testObj.parseFrom("PASSPORT GBR");
+    }
 
-        assertNull(result);
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionForInvalidNumber() throws Exception {
+        testObj.parseFrom("PASSPORT GBR $%^$%^£ 2016-05-01");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionForInvalidCountry() throws Exception {
+        testObj.parseFrom("PASSPORT 13 1234abc 2016-05-01");
     }
 
     @Test
@@ -81,23 +82,9 @@ public class DocumentDetailsAttributeParserTest {
         assertEquals("DVLA", result.getIssuingAuthority());
     }
 
-    @Test
-    public void shouldFailOnInvalidNumber() throws Exception {
-        DocumentDetails result = testObj.parseFrom(INVALID_ATTRIBUTE__NUMBER);
-
-        assertNull(result);
-    }
-
     @Test(expected = ParseException.class)
-    public void shouldFailOnInvalidDate() throws Exception {
-        testObj.parseFrom(INVALID_ATTRIBUTE__DATE);
-    }
-
-    @Test
-    public void shouldFailOnInvalidCountry() throws Exception {
-        DocumentDetails result = testObj.parseFrom(INVALID_ATTRIBUTE__COUNTRY);
-
-        assertNull(result);
+    public void shouldThrowExceptionForInvalidDate() throws Exception {
+        testObj.parseFrom("PASSPORT GBR 1234abc" + " X016-05-01");
     }
 
 }


### PR DESCRIPTION
DocumentDetailsAttributeParsers shall throw an Exception if it receives a malformed DocumetDetails value that it cannot parse.
That Exception will be logged as a WARN by the AttributeListConverter.  The failed attribute is skipped, the Profile will have _null_ for the missing value.
Discussed further in the ticket.