### PR TITLE
SDK-422: New profile for deploying to /nxs/repository/maven-snaphosts/

### DIFF
--- a/yoti-sdk-parent/pom.xml
+++ b/yoti-sdk-parent/pom.xml
@@ -56,6 +56,10 @@
       <activation>
         <activeByDefault>false</activeByDefault>
       </activation>
+      <properties>
+        <gpg.skip>false</gpg.skip>
+        <dependency-check.skip>false</dependency-check.skip>
+      </properties>
       <distributionManagement>
         <snapshotRepository>
           <id>ossrh</id>
@@ -72,6 +76,10 @@
       <activation>
         <activeByDefault>false</activeByDefault>
       </activation>
+      <properties>
+        <gpg.skip>true</gpg.skip>
+        <dependency-check.skip>true</dependency-check.skip>
+      </properties>
       <distributionManagement>
         <snapshotRepository>
           <id>yoti-snapshots</id>

--- a/yoti-sdk-parent/pom.xml
+++ b/yoti-sdk-parent/pom.xml
@@ -50,17 +50,38 @@
     <url>http://github.com/getyoti/yoti-java-sdk.git</url>
   </scm>
   
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
-  
+  <profiles>
+    <profile>
+      <id>sonatype</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <distributionManagement>
+        <snapshotRepository>
+          <id>ossrh</id>
+          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+          <id>ossrh</id>
+          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+      </distributionManagement>
+    </profile>
+    <profile>
+      <id>nexus</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <distributionManagement>
+        <snapshotRepository>
+          <id>yoti-snapshots</id>
+          <name>yoti-snapshots</name>
+          <url>https://nxs/repository/maven-snaphosts/</url>
+        </snapshotRepository>
+      </distributionManagement>
+    </profile>
+  </profiles>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   


### PR DESCRIPTION
We shall have 2x profiles
- *nexus* for deploying to our internal nexus (use with -Dgpg.skip=true)
- *sonatype* for deploying signed JARs to public sonatype