### PR TITLE
SDK-460: Fix display of sources and verifiers

### DIFF
--- a/yoti-sdk-spring-boot-example/src/main/resources/templates/fragments.html
+++ b/yoti-sdk-spring-boot-example/src/main/resources/templates/fragments.html
@@ -2,10 +2,12 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head/>
 <body>
-    <div class="" th:fragment="anchor">
-
-        Hello!
-
+<td th:fragment="anchorDisplay(anchors)">
+    <div th:each="anchor : ${anchors}" style="border: 1px solid grey; display:inline-block; margin-bottom=0" >
+        <p style="line-height:0"><i>Type:</i> <span th:text="${anchor.type}"/></p>
+        <p style="line-height:0"><i>Value:</i> <span th:text="${anchor.value}"/></p>
+        <p style="line-height:0"><i>SubType:</i> <span th:text="${anchor.subType}"/></p>
+        <p style="line-height:0"><i>Timestamp:</i> <span th:text="${anchor.signedTimestamp.timestamp.date}"/>, <span th:text="${anchor.signedTimestamp.timestamp.time}"/></p>
     </div>
 </body>
 </html>


### PR DESCRIPTION
This is an easy fix, but I don't know how this has happened.  The original story was SDK-391, and that even has a screen shot displaying sources + verifiers.

My best guess is this change somehow got lost in a merge/rebase before the old SNAPSHOT branch was merged to master.