### PR TITLE
SDK-538: Add .equals() and .hashCode() to the time Value Objects

### DIFF
--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/DateTimeValue.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/DateTimeValue.java
@@ -43,4 +43,28 @@ public class DateTimeValue implements DateTime {
         return String.format("DateTimeValue{date=%s,time=%s}", date, time);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DateTimeValue that = (DateTimeValue) o;
+
+        if (date != null ? !date.equals(that.date) : that.date != null) {
+            return false;
+        }
+        return time != null ? time.equals(that.time) : that.time == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = date != null ? date.hashCode() : 0;
+        result = 31 * result + (time != null ? time.hashCode() : 0);
+        return result;
+    }
+
 }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/DateValue.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/DateValue.java
@@ -74,4 +74,32 @@ public final class DateValue implements Date {
         return format("%04d-%02d-%02d", year, month, day);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DateValue dateValue = (DateValue) o;
+
+        if (year != dateValue.year) {
+            return false;
+        }
+        if (month != dateValue.month) {
+            return false;
+        }
+        return day == dateValue.day;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = year;
+        result = 31 * result + month;
+        result = 31 * result + day;
+        return result;
+    }
+
 }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SignedTimestampValue.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SignedTimestampValue.java
@@ -21,4 +21,33 @@ public class SignedTimestampValue implements SignedTimestamp {
         return timestamp;
     }
 
+    @Override
+    public String toString() {
+        return String.format("SignedTimestampValue{version=%s, timestamp=%s}", version, timestamp);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        SignedTimestampValue that = (SignedTimestampValue) o;
+
+        if (version != that.version) {
+            return false;
+        }
+        return timestamp != null ? timestamp.equals(that.timestamp) : that.timestamp == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = version;
+        result = 31 * result + (timestamp != null ? timestamp.hashCode() : 0);
+        return result;
+    }
+
 }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/TimeValue.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/TimeValue.java
@@ -5,6 +5,8 @@ import static java.util.Calendar.MILLISECOND;
 import static java.util.Calendar.MINUTE;
 import static java.util.Calendar.SECOND;
 
+import static com.yoti.api.client.spi.remote.util.Validation.notGreaterThan;
+
 import java.util.Calendar;
 
 import com.yoti.api.client.Time;
@@ -24,6 +26,8 @@ public class TimeValue implements Time {
     }
 
     public static TimeValue from(Calendar calendar, int microsecond) {
+        notGreaterThan(microsecond, 999, "microsecond");
+
         return new TimeValue(calendar.get(HOUR_OF_DAY),
                 calendar.get(MINUTE),
                 calendar.get(SECOND),
@@ -53,6 +57,38 @@ public class TimeValue implements Time {
     @Override
     public String toString() {
         return String.format("%02d:%02d:%02d.%06d", hour, minute, second, microsecond);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        TimeValue timeValue = (TimeValue) o;
+
+        if (hour != timeValue.hour) {
+            return false;
+        }
+        if (minute != timeValue.minute) {
+            return false;
+        }
+        if (second != timeValue.second) {
+            return false;
+        }
+        return microsecond == timeValue.microsecond;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = hour;
+        result = 31 * result + minute;
+        result = 31 * result + second;
+        result = 31 * result + microsecond;
+        return result;
     }
 
 }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/util/Validation.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/util/Validation.java
@@ -1,5 +1,7 @@
 package com.yoti.api.client.spi.remote.util;
 
+import static java.lang.String.format;
+
 public class Validation {
 
     public static <T> T notNull(T value, String name) {
@@ -16,6 +18,12 @@ public class Validation {
     public static void notNullOrEmpty(String value, String name) {
         if (isNullOrEmpty(value)) {
             throw new IllegalArgumentException(name + " must not be empty or null");
+        }
+    }
+
+    public static void notGreaterThan(long value, long limit, String name) {
+        if (value > limit) {
+            throw new IllegalArgumentException(format("'%s' value '%s' is greater than '%s'", name, value, limit));
         }
     }
 

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/DateTimeValueTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/DateTimeValueTest.java
@@ -1,6 +1,8 @@
 package com.yoti.api.client.spi.remote;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -31,7 +33,7 @@ public class DateTimeValueTest {
     public void from_shouldWorkForAnActualTimeWithMicros() throws Exception {
         TimeZone utcTimeZone = TimeZone.getTimeZone("UTC");
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MMM-dd HH:mm:ss");
-        simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        simpleDateFormat.setTimeZone(utcTimeZone);
         Calendar calendar = GregorianCalendar.getInstance(utcTimeZone);
         calendar.setTime(simpleDateFormat.parse("1980-Aug-05 13:15:45"));
         long microseconds = calendar.getTimeInMillis() * 1000;
@@ -47,6 +49,53 @@ public class DateTimeValueTest {
         assertEquals(15, result.getTime().getMinute());
         assertEquals(45, result.getTime().getSecond());
         assertEquals(123456, result.getTime().getMicrosecond());
+    }
+
+    @Test
+    public void equals_returnsFalseWhenComparedToNull() {
+        DateTime dateTime = DateTimeValue.from(123456789);
+
+        assertFalse(dateTime.equals(null));
+    }
+
+    @Test
+    public void equals_shouldBeReflexive() {
+        DateTime dateTime = DateTimeValue.from(123456789);
+
+        assertTrue(dateTime.equals(dateTime));
+        assertTrue(dateTime.hashCode() == dateTime.hashCode());
+    }
+
+    @Test
+    public void equals_shouldBeSymmetricWhenValuesMatch() {
+        DateTime dateTime1 = DateTimeValue.from(123456789);
+        DateTime dateTime2 = DateTimeValue.from(123456789);
+
+        assertTrue(dateTime1.equals(dateTime2));
+        assertTrue(dateTime2.equals(dateTime1));
+        assertTrue(dateTime1.hashCode() == dateTime2.hashCode());
+    }
+
+    @Test
+    public void equals_shouldBeSymmetricWhenValuesDoNotMatch() {
+        DateTime dateTime1 = DateTimeValue.from(987654321);
+        DateTime dateTime2 = DateTimeValue.from(123456789);
+
+        assertFalse(dateTime1.equals(dateTime2));
+        assertFalse(dateTime2.equals(dateTime1));
+    }
+
+    @Test
+    public void equals_shouldBeTransitive() {
+        DateTime dateTime1 = DateTimeValue.from(123456789);
+        DateTime dateTime2 = DateTimeValue.from(123456789);
+        DateTime dateTime3 = DateTimeValue.from(123456789);
+
+        assertTrue(dateTime1.equals(dateTime2));
+        assertTrue(dateTime1.equals(dateTime3));
+        assertTrue(dateTime2.equals(dateTime3));
+        assertTrue(dateTime1.hashCode() == dateTime2.hashCode());
+        assertTrue(dateTime2.hashCode() == dateTime3.hashCode());
     }
 
 }

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/DateValueTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/DateValueTest.java
@@ -1,8 +1,9 @@
 package com.yoti.api.client.spi.remote;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import java.io.UnsupportedEncodingException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -26,35 +27,35 @@ public class DateValueTest {
 
         DateValue result = DateValue.from(calendar);
 
-        assertDate(result);
+        assertDate(result, 2016, 12, 1);
     }
 
     @Test
-    public void parseFrom_shouldParseValidString() throws UnsupportedEncodingException, ParseException {
+    public void parseFrom_shouldParseValidString() throws Exception {
         DateValue result = DateValue.parseFrom(VALID_DATE_STRING);
 
-        assertDate(result);
+        assertDate(result, 2016, 12, 1);
     }
 
     @Test
-    public void parseFrom_shouldParseValidArray() throws UnsupportedEncodingException, ParseException {
+    public void parseFrom_shouldParseValidArray() throws Exception {
         DateValue result = DateValue.parseFrom(VALID_DATE_STRING.getBytes("UTF-8"));
 
-        assertDate(result);
+        assertDate(result, 2016, 12, 1);
     }
 
     @Test(expected = ParseException.class)
-    public void parseFrom_shouldNotParseInvalidDateFormat() throws UnsupportedEncodingException, ParseException {
+    public void parseFrom_shouldNotParseInvalidDateFormat() throws Exception {
         DateValue.parseFrom(INVALID_DATE_FORMAT_STRING);
     }
 
     @Test(expected = ParseException.class)
-    public void parseFrom_shouldNotParseInvalidDateValue() throws UnsupportedEncodingException, ParseException {
+    public void parseFrom_shouldNotParseInvalidDateValue() throws Exception {
         DateValue.parseFrom(INVALID_DATE_VALUE_STRING);
     }
 
     @Test
-    public void toString_shouldFormatDateCorrectly() throws UnsupportedEncodingException, ParseException {
+    public void toString_shouldFormatDateCorrectly() throws Exception {
         DateValue date = DateValue.parseFrom(VALID_DATE_STRING);
 
         String result = date.toString();
@@ -62,10 +63,57 @@ public class DateValueTest {
         assertEquals(VALID_DATE_STRING, result);
     }
 
-    private void assertDate(Date date) {
-        assertEquals(2016, date.getYear());
-        assertEquals(12, date.getMonth());
-        assertEquals(1, date.getDay());
+    @Test
+    public void equals_returnsFalseWhenComparedToNull() throws Exception {
+        DateValue dateValue = DateValue.parseFrom(VALID_DATE_STRING);
+
+        assertFalse(dateValue.equals(null));
+    }
+
+    @Test
+    public void equals_shouldBeReflexive() throws Exception {
+        DateValue dateValue = DateValue.parseFrom(VALID_DATE_STRING);
+
+        assertTrue(dateValue.equals(dateValue));
+        assertTrue(dateValue.hashCode() == dateValue.hashCode());
+    }
+
+    @Test
+    public void equals_shouldBeSymmetricWhenValuesMatch() throws Exception {
+        DateValue date1 = DateValue.parseFrom(VALID_DATE_STRING);
+        DateValue date2 = DateValue.parseFrom(VALID_DATE_STRING);
+
+        assertTrue(date1.equals(date2));
+        assertTrue(date2.equals(date1));
+        assertTrue(date1.hashCode() == date2.hashCode());
+    }
+
+    @Test
+    public void equals_shouldBeSymmetricWhenValuesDoNotMatch() throws Exception {
+        DateValue dateTime1 = DateValue.parseFrom(VALID_DATE_STRING);
+        DateValue dateTime2 = DateValue.parseFrom("2017-03-31");
+
+        assertFalse(dateTime1.equals(dateTime2));
+        assertFalse(dateTime2.equals(dateTime1));
+    }
+
+    @Test
+    public void equals_shouldBeTransitive() throws Exception {
+        DateValue dateTime1 = DateValue.parseFrom(VALID_DATE_STRING);
+        DateValue dateTime2 = DateValue.parseFrom(VALID_DATE_STRING);
+        DateValue dateTime3 = DateValue.parseFrom(VALID_DATE_STRING);
+
+        assertTrue(dateTime1.equals(dateTime2));
+        assertTrue(dateTime1.equals(dateTime3));
+        assertTrue(dateTime2.equals(dateTime3));
+        assertTrue(dateTime1.hashCode() == dateTime2.hashCode());
+        assertTrue(dateTime2.hashCode() == dateTime3.hashCode());
+    }
+
+    private static void assertDate(Date actualDate, int expectedYear, int expectedMonth, int expectedDay) {
+        assertEquals(expectedYear, actualDate.getYear());
+        assertEquals(expectedMonth, actualDate.getMonth());
+        assertEquals(expectedDay, actualDate.getDay());
     }
 
 }

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/SignedTimestampValueTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/SignedTimestampValueTest.java
@@ -1,0 +1,62 @@
+package com.yoti.api.client.spi.remote;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.yoti.api.client.DateTime;
+
+import org.junit.Test;
+
+public class SignedTimestampValueTest {
+
+    private static final DateTime DATE_TIME_1 = DateTimeValue.from(123456789);
+    private static final DateTime DATE_TIME_2 = DateTimeValue.from(987654321);
+
+    @Test
+    public void equals_returnsFalseWhenComparedToNull() {
+        SignedTimestampValue signedTimestampValue = new SignedTimestampValue(1, DATE_TIME_1);
+
+        assertFalse(signedTimestampValue.equals(null));
+    }
+
+    @Test
+    public void equals_shouldBeReflexive() {
+        SignedTimestampValue signedTimestampValue = new SignedTimestampValue(1, DATE_TIME_1);
+
+        assertTrue(signedTimestampValue.equals(signedTimestampValue));
+        assertTrue(signedTimestampValue.hashCode() == signedTimestampValue.hashCode());
+    }
+
+    @Test
+    public void equals_shouldBeSymmetricWhenValuesMatch() {
+        SignedTimestampValue signedTimestampValue1 = new SignedTimestampValue(1, DATE_TIME_1);
+        SignedTimestampValue signedTimestampValue2 = new SignedTimestampValue(1, DATE_TIME_1);
+
+        assertTrue(signedTimestampValue1.equals(signedTimestampValue2));
+        assertTrue(signedTimestampValue2.equals(signedTimestampValue1));
+        assertTrue(signedTimestampValue1.hashCode() == signedTimestampValue2.hashCode());
+    }
+
+    @Test
+    public void equals_shouldBeSymmetricWhenValuesDoNotMatch() {
+        SignedTimestampValue signedTimestampValue1 = new SignedTimestampValue(1, DATE_TIME_1);
+        SignedTimestampValue signedTimestampValue2 = new SignedTimestampValue(1, DATE_TIME_2);
+
+        assertFalse(signedTimestampValue1.equals(signedTimestampValue2));
+        assertFalse(signedTimestampValue2.equals(signedTimestampValue1));
+    }
+
+    @Test
+    public void equals_shouldBeTransitive() {
+        SignedTimestampValue signedTimestampValue1 = new SignedTimestampValue(1, DATE_TIME_1);
+        SignedTimestampValue signedTimestampValue2 = new SignedTimestampValue(1, DATE_TIME_1);
+        SignedTimestampValue signedTimestampValue3 = new SignedTimestampValue(1, DATE_TIME_1);
+
+        assertTrue(signedTimestampValue1.equals(signedTimestampValue2));
+        assertTrue(signedTimestampValue1.equals(signedTimestampValue3));
+        assertTrue(signedTimestampValue2.equals(signedTimestampValue3));
+        assertTrue(signedTimestampValue1.hashCode() == signedTimestampValue2.hashCode());
+        assertTrue(signedTimestampValue2.hashCode() == signedTimestampValue3.hashCode());
+    }
+
+}

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/TimeValueTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/TimeValueTest.java
@@ -1,0 +1,112 @@
+package com.yoti.api.client.spi.remote;
+
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class TimeValueTest {
+
+    private static final TimeZone UTC_TIME_ZONE = TimeZone.getTimeZone("UTC");
+
+    private Calendar calendar;
+
+    @Before
+    public void setUp() throws Exception {
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MMM-dd HH:mm:ss:SSS");
+        simpleDateFormat.setTimeZone(UTC_TIME_ZONE);
+        calendar = GregorianCalendar.getInstance(UTC_TIME_ZONE);
+        calendar.setTime(simpleDateFormat.parse("1980-Aug-05 13:15:45:123"));
+    }
+
+    @Test
+    public void from_createsValueSuccessfully() {
+        TimeValue result = TimeValue.from(calendar, 999);
+
+        assertEquals(13, result.getHour());
+        assertEquals(15, result.getMinute());
+        assertEquals(45, result.getSecond());
+        assertEquals(123999, result.getMicrosecond());
+    }
+
+    @Test
+    public void from_ensuresMicrosecondsValueNotGreaterThan999() {
+        try {
+            TimeValue.from(calendar, 1000);
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("microsecond"));
+            assertThat(e.getMessage(), containsString("1000"));
+            assertThat(e.getMessage(), containsString("999"));
+            return;
+        }
+
+        fail("Expected an Exception");
+    }
+
+    @Test
+    public void toString_shouldFormatDateCorrectly() {
+        TimeValue timeValue = TimeValue.from(calendar, 999);
+
+        String result = timeValue.toString();
+
+        assertEquals("13:15:45.123999", result);
+    }
+
+    @Test
+    public void equals_returnsFalseWhenComparedToNull() {
+        TimeValue timeValue = TimeValue.from(calendar, 999);
+
+        assertFalse(timeValue.equals(null));
+    }
+
+    @Test
+    public void equals_shouldBeReflexive() {
+        TimeValue timeValue = TimeValue.from(calendar, 999);
+
+        assertTrue(timeValue.equals(timeValue));
+        assertTrue(timeValue.hashCode() == timeValue.hashCode());
+    }
+
+    @Test
+    public void equals_shouldBeSymmetricWhenValuesMatch() {
+        TimeValue timeValue1 = TimeValue.from(calendar, 999);
+        TimeValue timeValue2 = TimeValue.from(calendar, 999);
+
+        assertTrue(timeValue1.equals(timeValue2));
+        assertTrue(timeValue2.equals(timeValue1));
+        assertTrue(timeValue1.hashCode() == timeValue2.hashCode());
+    }
+
+    @Test
+    public void equals_shouldBeSymmetricWhenValuesDoNotMatch() {
+        TimeValue timeValue1 = TimeValue.from(calendar, 999);
+        TimeValue timeValue2 = TimeValue.from(calendar, 123);
+
+        assertFalse(timeValue1.equals(timeValue2));
+        assertFalse(timeValue2.equals(timeValue1));
+    }
+
+    @Test
+    public void equals_shouldBeTransitive() {
+        TimeValue timeValue1 = TimeValue.from(calendar, 999);
+        TimeValue timeValue2 = TimeValue.from(calendar, 999);
+        TimeValue timeValue3 = TimeValue.from(calendar, 999);
+
+        assertTrue(timeValue1.equals(timeValue2));
+        assertTrue(timeValue1.equals(timeValue3));
+        assertTrue(timeValue2.equals(timeValue3));
+        assertTrue(timeValue1.hashCode() == timeValue2.hashCode());
+        assertTrue(timeValue2.hashCode() == timeValue3.hashCode());
+    }
+
+}


### PR DESCRIPTION
Added _.equals()_ and _.hashCode()_ to:
- SignedTimestampValue
- DateTimeValue
- DateValue
- TimeValue

TBH the methods are added to make testing easier/cleaner.  But since they are Value Objects it makes sense to do it anyway.

Also start validating the _microseconds_ value passed to the constructor of _TimeValue_.  Technically this is a breaking change, but nobody using the SDK at the moment has any reason at all to create a _TimeValue_ object, so I think its reasonable.