### PR TITLE
SDK-573: Introduce List<AgeVerification>

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,13 +190,18 @@ try {
         String rememberMeId = activityDetails.getRememberMeId();
         String base64Selfie = activityDetails.getBase64Selfie();
         Attribute<Image> selfie = profile.getSelfie();
-        Image selfieValue = selfie.getValue();
+        if (selfie != null) {
+            Image selfieValue = selfie.getValue();
+        }
         Attribute<String> fullName = profile.getFullName();
         Attribute<String> givenNames = profile.getGivenNames();
         Attribute<String> familyName = profile.getFamilyName();
         Attribute<String> phoneNumber = profile.getPhoneNumber();
         Attribute<String> emailAddress = profile.getEmailAddress();
-        Boolean isAgeVerified = profile.isAgeVerified();
+        AgeVerification over18Verification = profile.findAgeOverVerification(18);
+        if (over18Verification != null) {
+            boolean isAgedOver18 = over18Verification.getResult();
+        }
         Attribute<Date> dateOfBirth = profile.getDateOfBirth();
         Attribute<String> gender = profile.getGender();
         Attribute<String> postalAddress = profile.getPostalAddress();

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/AgeVerification.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/AgeVerification.java
@@ -1,0 +1,36 @@
+package com.yoti.api.client;
+
+/**
+ * Wraps an 'Age Verify/Condition' attribute to provide behaviour specific to verifying someone's age
+ */
+public interface AgeVerification {
+
+    /**
+     * The type of age check performed, as specified on dashboard.  Currently this might be 'age_over' or 'age_under'
+     *
+     * @return The type of age check performed
+     */
+    String getCheckPerformed();
+
+    /**
+     * The age that was that checked, as specified on dashboard.
+     *
+     * @return The age that was that checked
+     */
+    int getAgeVerified();
+
+    /**
+     * Whether or not the profile passed the age check
+     *
+     * @return The result of the age check.
+     */
+    boolean getResult();
+
+    /**
+     * The wrapped profile attribute.  Use this if you need access to the underlying List of {@link Anchor}s
+     *
+     * @return The wrapped profile attribute
+     */
+    Attribute<String> getAttribute();
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/AgeVerification.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/AgeVerification.java
@@ -6,7 +6,7 @@ package com.yoti.api.client;
 public interface AgeVerification {
 
     /**
-     * The type of age check performed, as specified on dashboard.  Currently this might be 'age_over' or 'age_under'
+     * The type of age check performed, as specified on dashboard. Currently this might be 'age_over' or 'age_under'
      *
      * @return The type of age check performed
      */
@@ -27,7 +27,7 @@ public interface AgeVerification {
     boolean getResult();
 
     /**
-     * The wrapped profile attribute.  Use this if you need access to the underlying List of {@link Anchor}s
+     * The wrapped profile attribute. Use this if you need access to the underlying List of {@link Anchor}s
      *
      * @return The wrapped profile attribute
      */

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/Anchor.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/Anchor.java
@@ -4,7 +4,7 @@ import java.security.cert.X509Certificate;
 import java.util.List;
 
 /**
- * Anchors represent where, when and how a profile {@link Attribute} value was acquired or verified.  For example, Attributes sourced from a backing
+ * Anchors represent where, when and how, a profile {@link Attribute} value was acquired or verified. For example, Attributes sourced from a backing
  * document such as a Passport will have a signed, timestamped anchor identifying that source
  */
 public interface Anchor {

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/Anchor.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/Anchor.java
@@ -3,6 +3,10 @@ package com.yoti.api.client;
 import java.security.cert.X509Certificate;
 import java.util.List;
 
+/**
+ * Anchors represent where, when and how a profile {@link Attribute} value was acquired or verified.  For example, Attributes sourced from a backing
+ * document such as a Passport will have a signed, timestamped anchor identifying that source
+ */
 public interface Anchor {
 
     /**

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/ApplicationProfile.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/ApplicationProfile.java
@@ -2,8 +2,6 @@ package com.yoti.api.client;
 
 /**
  * Profile of an application with convenience methods to access well-known attributes.
- *
- *
  */
 public interface ApplicationProfile extends Profile {
 

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/HumanProfile.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/HumanProfile.java
@@ -64,7 +64,7 @@ public interface HumanProfile extends Profile {
     AgeVerification findAgeUnderVerification(int age);
 
     /**
-     * @deprecated  Did the user pass the age verification check?  From SDK 2.1 onwards use getAgeVerifications(), findAgeOverVerification(int age)
+     * @deprecated Did the user pass the age verification check?  From SDK 2.1 onwards use getAgeVerifications(), findAgeOverVerification(int age)
      * or findAgeUnderVerification(int age)
      *
      * @return <code>TRUE</code> if they passed, <code>FALSE</code> if they failed, <code>null</code> if there was no check

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/HumanProfile.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/HumanProfile.java
@@ -1,9 +1,10 @@
 package com.yoti.api.client;
 
+import java.util.List;
 import java.util.Map;
 
 /**
- * Profile of an human user with convenience methods to access well-known attributes.
+ * Profile of a human user with convenience methods to access well-known attributes.
  */
 public interface HumanProfile extends Profile {
 
@@ -41,10 +42,34 @@ public interface HumanProfile extends Profile {
     Attribute<Date> getDateOfBirth();
 
     /**
-     * Did the user pass the age verification check?
+     * Finds all the 'Age Over' and 'Age Under' derived attributes returned with the profile, and returns them wrapped in {@link AgeVerification}
+     * objects
+     *
+     * @return A list of all the {@link AgeVerification} objects returned for this profile
+     */
+    List<AgeVerification> getAgeVerifications();
+
+    /**
+     * Searches for an {@link AgeVerification} corresponding to an 'Age Over' check for the given age
+     *
+     * @return age_over {@link AgeVerification} for the given age, or <code>null</code> if no match was found
+     */
+    AgeVerification findAgeOverVerification(int age);
+
+    /**
+     * Searches for an {@link AgeVerification} corresponding to an 'Age Under' check for the given age
+     *
+     * @return age_under {@link AgeVerification} for the given age, or <code>null</code> if no match was found
+     */
+    AgeVerification findAgeUnderVerification(int age);
+
+    /**
+     * @deprecated  Did the user pass the age verification check?  From SDK 2.1 onwards use getAgeVerifications(), findAgeOverVerification(int age)
+     * or findAgeUnderVerification(int age)
      *
      * @return <code>TRUE</code> if they passed, <code>FALSE</code> if they failed, <code>null</code> if there was no check
      */
+    @Deprecated
     Boolean isAgeVerified();
 
     /**

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/Profile.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/Profile.java
@@ -1,6 +1,7 @@
 package com.yoti.api.client;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Yoti profile for a connect token and application. You can get a hold of one of these by using a {@link YotiClient}.
@@ -8,17 +9,17 @@ import java.util.Collection;
 public interface Profile {
 
     /**
-     * Return typed attribute value for a key.
+     * Return typed {@link Attribute} object for a key.
      *
      * @param <T> the type parameter indicating the type of the returned value
      * @param name attribute name
      * @param clazz attribute type
-     * @return typed attribute, null if attribute type is not assignable from the specified class
+     * @return typed attribute, null if it is not present in the profile
      */
     <T> Attribute<T> getAttribute(String name, Class<T> clazz);
 
     /**
-     * Returns the attribute object for the key
+     * Returns the {@link Attribute} object for the key
      *
      * @param name
      * @return the attribute object, null if it is not present in the profile
@@ -26,19 +27,29 @@ public interface Profile {
     Attribute getAttribute(String name);
 
     /**
-     * Return the value of the first attribute with a name starting with <code>name</code>
+     * Return a list of all the {@link Attribute} with a name starting with <code>name</code>
      *
      * @param <T>   the type parameter indicating the type of the returned value
      * @param name  attribute name
      * @param clazz attribute type
-     * @return typed attribute value, null if there was no match or attribute type is not assignable from the specified class
+     * @return typed attribute value, <code>null</code> if there was no match
+     */
+    <T> List<Attribute<T>> findAttributesStartingWith(String name, Class<T> clazz);
+
+    /**
+     * Return the first {@link Attribute} with a name starting with <code>name</code>
+     *
+     * @param <T>   the type parameter indicating the type of the returned value
+     * @param name  attribute name
+     * @param clazz attribute type
+     * @return typed attribute value, <code>null</code> if there was no match
      */
     <T> Attribute<T> findAttributeStartingWith(String name, Class<T> clazz);
 
     /**
      * Return all attributes for the profile.
      *
-     * @return an unsorted collection of attributes
+     * @return an unsorted collection of {@link Attribute}
      */
     Collection<Attribute<?>> getAttributes();
 

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/Profile.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/Profile.java
@@ -27,7 +27,7 @@ public interface Profile {
     Attribute getAttribute(String name);
 
     /**
-     * Return a list of all the {@link Attribute} with a name starting with <code>name</code>
+     * Return a list of all the {@link Attribute}s with a name starting with <code>name</code>
      *
      * @param <T>   the type parameter indicating the type of the returned value
      * @param name  attribute name
@@ -47,9 +47,9 @@ public interface Profile {
     <T> Attribute<T> findAttributeStartingWith(String name, Class<T> clazz);
 
     /**
-     * Return all attributes for the profile.
+     * Return all {@link Attribute}s for the profile.
      *
-     * @return an unsorted collection of {@link Attribute}
+     * @return an unsorted collection of {@link Attribute}s
      */
     Collection<Attribute<?>> getAttributes();
 

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ApplicationProfileAdapter.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ApplicationProfileAdapter.java
@@ -1,6 +1,7 @@
 package com.yoti.api.client.spi.remote;
 
 import java.util.Collection;
+import java.util.List;
 
 import com.yoti.api.attributes.AttributeConstants;
 import com.yoti.api.client.ApplicationProfile;
@@ -31,6 +32,11 @@ public final class ApplicationProfileAdapter implements ApplicationProfile {
     @Override
     public <T> Attribute<T> getAttribute(String name, Class<T> clazz) {
         return wrapped.getAttribute(name, clazz);
+    }
+
+    @Override
+    public <T> List<Attribute<T>> findAttributesStartingWith(String name, Class<T> clazz) {
+        return wrapped.findAttributesStartingWith(name, clazz);
     }
 
     @Override

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SimpleAgeVerification.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SimpleAgeVerification.java
@@ -1,0 +1,47 @@
+package com.yoti.api.client.spi.remote;
+
+import static java.lang.Boolean.parseBoolean;
+
+import com.yoti.api.client.AgeVerification;
+import com.yoti.api.client.Attribute;
+import com.yoti.api.client.spi.remote.util.Validation;
+
+public class SimpleAgeVerification implements AgeVerification {
+
+    private final Attribute<String> derivedAttribute;
+    private final int ageVerified;
+    private final String checkPerformed;
+    private final boolean result;
+
+    public SimpleAgeVerification(Attribute<String> derivedAttribute) {
+        Validation.notNull(derivedAttribute, "derivedAttribute");
+        Validation.matchesPattern(derivedAttribute.getName(), "[^:]+:(?!.*:)[0-9]+", "attribute.name");
+        this.derivedAttribute = derivedAttribute;
+
+        String[] split = derivedAttribute.getName().split(":");
+        this.checkPerformed = split[0];
+        this.ageVerified = Integer.parseInt(split[1]);
+        this.result = parseBoolean(derivedAttribute.getValue());
+    }
+
+    @Override
+    public int getAgeVerified() {
+        return ageVerified;
+    }
+
+    @Override
+    public String getCheckPerformed() {
+        return checkPerformed;
+    }
+
+    @Override
+    public boolean getResult() {
+        return result;
+    }
+
+    @Override
+    public Attribute<String> getAttribute() {
+        return derivedAttribute;
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SimpleProfile.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SimpleProfile.java
@@ -2,6 +2,7 @@ package com.yoti.api.client.spi.remote;
 
 import static java.util.Collections.unmodifiableMap;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -44,6 +45,19 @@ final class SimpleProfile implements Profile {
     public Attribute getAttribute(String name) {
         ensureName(name);
         return protectedAttributes.get(name);
+    }
+
+    @Override
+    public <T> List<Attribute<T>> findAttributesStartingWith(String name, Class<T> clazz) {
+        ensureName(name);
+        List<Attribute<T>> matches = new ArrayList<>();
+        for (Map.Entry<String, Attribute<?>> entry : protectedAttributes.entrySet()) {
+            if (entry.getKey().startsWith(name)) {
+                Attribute<T> value = castSafely(clazz, entry.getValue());
+                matches.add(value);
+            }
+        }
+        return matches;
     }
 
     @Override

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/util/Validation.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/util/Validation.java
@@ -51,4 +51,10 @@ public class Validation {
         notGreaterThan(value, maxLimit, name);
     }
 
+    public static void matchesPattern(String value, String regex, String name) {
+        if (value == null || ! value.matches(regex)) {
+            throw new IllegalArgumentException(format("'%s' value '%s' does not match format '%s'", name, value, regex));
+        }
+    }
+
 }

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/DocumentDetailsAttributeParserTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/DocumentDetailsAttributeParserTest.java
@@ -71,6 +71,18 @@ public class DocumentDetailsAttributeParserTest {
     }
 
     @Test
+    public void shouldIgnoreAThirdOptionalAttribute() throws Exception {
+        DocumentDetails result = testObj.parseFrom("DRIVING_LICENCE GBR 1234abc 2016-05-01 DVLA someThirdAttribute");
+
+        assertNotNull(result);
+        assertEquals(DocumentDetails.DOCUMENT_TYPE_DRIVING_LICENCE, result.getType());
+        assertEquals("GBR", result.getIssuingCountry());
+        assertEquals("1234abc", result.getDocumentNumber());
+        assertEquals("2016-05-01", result.getExpirationDate().toString());
+        assertEquals("DVLA", result.getIssuingAuthority());
+    }
+
+    @Test
     public void shouldParseWhenOneOptionalAttributeIsMissing() throws Exception {
         DocumentDetails result = testObj.parseFrom("PASS_CARD GBR 1234abc - DVLA");
 

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/HumanProfileAdapterTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/HumanProfileAdapterTest.java
@@ -1,10 +1,25 @@
 package com.yoti.api.client.spi.remote;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.EMPTY_LIST;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.isOneOf;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.HashSet;
+import java.util.List;
+
+import com.yoti.api.attributes.AttributeConstants.HumanProfileAttributes;
+import com.yoti.api.client.AgeVerification;
+import com.yoti.api.client.Attribute;
 import com.yoti.api.client.Profile;
 
 import org.junit.Test;
@@ -22,6 +37,13 @@ public class HumanProfileAdapterTest {
     @InjectMocks HumanProfileAdapter testObj;
 
     @Mock Profile profileMock;
+
+    Attribute<String> ageUnder18Attribute = new SimpleAttribute<>("age_under:18", "false");
+    Attribute<String> ageUnder21Attribute = new SimpleAttribute<>("age_under:21", "true");
+    Attribute<String> ageOver18Attribute = new SimpleAttribute<>("age_over:18", "true");
+    Attribute<String> ageOver21Attribute = new SimpleAttribute<>("age_over:21", "false");
+    List<Attribute<String>> ageUnderAttributes = asList(ageUnder18Attribute, ageUnder21Attribute);
+    List<Attribute<String>> ageOverAttributes = asList(ageOver18Attribute, ageOver21Attribute);
 
     @Test
     public void isAgeVerified_shouldReturnNullWhenBothAttributesAreMissing() {
@@ -57,6 +79,82 @@ public class HumanProfileAdapterTest {
         Boolean result = testObj.isAgeVerified();
 
         assertTrue(result);
+    }
+
+    @Test
+    public void getAgeVerifications_shouldBeNullSafe() {
+        when(profileMock.findAttributesStartingWith(HumanProfileAttributes.AGE_UNDER, String.class)).thenReturn(EMPTY_LIST);
+        when(profileMock.findAttributesStartingWith(HumanProfileAttributes.AGE_OVER, String.class)).thenReturn(EMPTY_LIST);
+
+        List<AgeVerification> result = testObj.getAgeVerifications();
+
+        assertThat(result, hasSize(0));
+    }
+
+    @Test
+    public void getAgeVerifications_shouldOnlySearchWrappedProfileOnce() {
+        when(profileMock.findAttributesStartingWith(HumanProfileAttributes.AGE_UNDER, String.class)).thenReturn(ageUnderAttributes);
+        when(profileMock.findAttributesStartingWith(HumanProfileAttributes.AGE_OVER, String.class)).thenReturn(ageOverAttributes);
+
+        testObj.getAgeVerifications();
+        List<AgeVerification> result = testObj.getAgeVerifications();
+
+        assertThat(result, hasSize(4));
+        assertThat(new HashSet<>(result), hasSize(4));
+        assertThat(result.get(0).getAttribute(), isOneOf(ageUnder18Attribute, ageUnder21Attribute, ageOver18Attribute, ageOver21Attribute));
+        assertThat(result.get(1).getAttribute(), isOneOf(ageUnder18Attribute, ageUnder21Attribute, ageOver18Attribute, ageOver21Attribute));
+        assertThat(result.get(2).getAttribute(), isOneOf(ageUnder18Attribute, ageUnder21Attribute, ageOver18Attribute, ageOver21Attribute));
+        assertThat(result.get(3).getAttribute(), isOneOf(ageUnder18Attribute, ageUnder21Attribute, ageOver18Attribute, ageOver21Attribute));
+        verify(profileMock, times(1)).findAttributesStartingWith(HumanProfileAttributes.AGE_UNDER, String.class);
+        verify(profileMock, times(1)).findAttributesStartingWith(HumanProfileAttributes.AGE_OVER, String.class);
+    }
+
+    @Test
+    public void findAgeOverVerification_returnsNullForNoMatch() {
+        when(profileMock.findAttributesStartingWith(HumanProfileAttributes.AGE_UNDER, String.class)).thenReturn(EMPTY_LIST);
+        when(profileMock.findAttributesStartingWith(HumanProfileAttributes.AGE_OVER, String.class)).thenReturn(EMPTY_LIST);
+
+        testObj.findAgeOverVerification(18);
+        AgeVerification result = testObj.findAgeOverVerification(18);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void findAgeOverVerification_shouldOnlySearchWrappedProfileOnce() {
+        when(profileMock.findAttributesStartingWith(HumanProfileAttributes.AGE_UNDER, String.class)).thenReturn(ageUnderAttributes);
+        when(profileMock.findAttributesStartingWith(HumanProfileAttributes.AGE_OVER, String.class)).thenReturn(ageOverAttributes);
+
+        testObj.findAgeOverVerification(18);
+        AgeVerification result = testObj.findAgeOverVerification(18);
+
+        assertSame(ageOver18Attribute, result.getAttribute());
+        verify(profileMock, times(1)).findAttributesStartingWith(HumanProfileAttributes.AGE_UNDER, String.class);
+        verify(profileMock, times(1)).findAttributesStartingWith(HumanProfileAttributes.AGE_OVER, String.class);
+    }
+
+    @Test
+    public void findAgeUnderVerification_returnsNullForNoMatch() {
+        when(profileMock.findAttributesStartingWith(HumanProfileAttributes.AGE_UNDER, String.class)).thenReturn(EMPTY_LIST);
+        when(profileMock.findAttributesStartingWith(HumanProfileAttributes.AGE_OVER, String.class)).thenReturn(EMPTY_LIST);
+
+        testObj.findAgeOverVerification(18);
+        AgeVerification result = testObj.findAgeUnderVerification(18);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void findAgeUnderVerification_shouldOnlySearchWrappedProfileOnce() {
+        when(profileMock.findAttributesStartingWith(HumanProfileAttributes.AGE_UNDER, String.class)).thenReturn(ageUnderAttributes);
+        when(profileMock.findAttributesStartingWith(HumanProfileAttributes.AGE_OVER, String.class)).thenReturn(ageOverAttributes);
+
+        testObj.findAgeUnderVerification(18);
+        AgeVerification result = testObj.findAgeUnderVerification(18);
+
+        assertSame(ageUnder18Attribute, result.getAttribute());
+        verify(profileMock, times(1)).findAttributesStartingWith(HumanProfileAttributes.AGE_UNDER, String.class);
+        verify(profileMock, times(1)).findAttributesStartingWith(HumanProfileAttributes.AGE_OVER, String.class);
     }
 
 }

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/SimpleAgeVerificationTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/SimpleAgeVerificationTest.java
@@ -1,0 +1,51 @@
+package com.yoti.api.client.spi.remote;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import com.yoti.api.client.Attribute;
+
+import org.hamcrest.core.StringContains;
+import org.junit.Test;
+
+public class SimpleAgeVerificationTest {
+
+    @Test
+    public void shouldFailForAttributeNamesThatDontMatchThePattern() {
+        assertExceptionForMalformedAttributeName("");
+        assertExceptionForMalformedAttributeName(":");
+        assertExceptionForMalformedAttributeName(":18");
+        assertExceptionForMalformedAttributeName("age_over:");
+        assertExceptionForMalformedAttributeName("age_over:not_int");
+        assertExceptionForMalformedAttributeName(":age_over:18");
+        assertExceptionForMalformedAttributeName("age_over::18");
+        assertExceptionForMalformedAttributeName("age_over:18:");
+        assertExceptionForMalformedAttributeName("age_over:18:21");
+    }
+
+    private static void assertExceptionForMalformedAttributeName(String attName) {
+        try {
+            Attribute<String> attribute = new SimpleAttribute<>(attName, null);
+            new SimpleAgeVerification(attribute);
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), StringContains.containsString("attribute.name"));
+            assertThat(e.getMessage(), StringContains.containsString(attName));
+            return;
+        }
+
+        fail("Expected an Exception");
+    }
+
+    @Test
+    public void shouldParseWellFormedAgeDerivation() {
+        Attribute<String> attribute = new SimpleAttribute<>("any_string_here:21", "true");
+
+        SimpleAgeVerification result = new SimpleAgeVerification(attribute);
+
+        assertEquals(result.getCheckPerformed(), "any_string_here");
+        assertEquals(result.getAgeVerified(), 21);
+        assertEquals(result.getResult(), true);
+    }
+
+}

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/SimpleProfileTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/SimpleProfileTest.java
@@ -85,6 +85,47 @@ public class SimpleProfileTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
+    public void findAttributesStartingWith_shouldThrowExceptionForNullAttributeName() {
+        SimpleProfile profile = new SimpleProfile(asAttributeList(SOME_KEY, INTEGER_VALUE));
+
+        profile.findAttributesStartingWith(null, Integer.class);
+    }
+
+    @Test
+    public void findAttributesStartingWith_shouldReturnEmptyListWhenNoMatches() {
+        SimpleProfile profile = new SimpleProfile(asAttributeList(SOME_KEY, INTEGER_VALUE));
+
+        List<Attribute<Integer>> result = profile.findAttributesStartingWith(STARTS_WITH, Integer.class);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void findAttributesStartingWith_shouldThrowExceptionForMismatchingType() {
+        SimpleProfile profile = new SimpleProfile(asAttributeList(STARTS_WITH, INTEGER_VALUE));
+
+        try {
+            profile.findAttributesStartingWith(STARTS_WITH, String.class);
+        } catch (ClassCastException e) {
+            assertTrue(e.getMessage().contains("java.lang.String"));
+            assertTrue(e.getMessage().contains("java.lang.Integer"));
+            return;
+        }
+
+        fail("Expected an exception");
+    }
+
+    @Test
+    public void findAttributesStartingWith_shouldReturnTypedValuesForMatchingKey() {
+        SimpleProfile profile = new SimpleProfile(asAttributeList(STARTS_WITH + ":restOfKey", INTEGER_VALUE));
+
+        List<Attribute<Integer>> result = profile.findAttributesStartingWith(STARTS_WITH, Integer.class);
+
+        assertEquals(result.size(), 1);
+        assertEquals(INTEGER_VALUE, result.get(0).getValue());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
     public void findAttributeStartingWith_shouldThrowExceptionForNullAttributeName() {
         SimpleProfile profile = new SimpleProfile(asAttributeList(SOME_KEY, INTEGER_VALUE));
 

--- a/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/profile/request/YotiTokenRequest.java
+++ b/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/profile/request/YotiTokenRequest.java
@@ -11,7 +11,7 @@ import com.yoti.api.client.Date;
 import com.yoti.api.client.DocumentDetails;
 import com.yoti.api.client.sandbox.profile.request.attribute.SandboxAnchor;
 import com.yoti.api.client.sandbox.profile.request.attribute.SandboxAttribute;
-import com.yoti.api.client.sandbox.profile.request.attribute.derivation.AgeVerification;
+import com.yoti.api.client.sandbox.profile.request.attribute.derivation.SandboxAgeVerification;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.bouncycastle.util.encoders.Base64;
@@ -108,8 +108,8 @@ public class YotiTokenRequest {
             return withAttribute(sandboxAttribute);
         }
 
-        public YotiTokenRequestBuilder withAgeVerification(AgeVerification ageVerification) {
-            return withAttribute(ageVerification.toAttribute());
+        public YotiTokenRequestBuilder withAgeVerification(SandboxAgeVerification sandboxAgeVerification) {
+            return withAttribute(sandboxAgeVerification.toAttribute());
         }
 
         public YotiTokenRequestBuilder withGender(String value) {

--- a/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/profile/request/attribute/derivation/SandboxAgeVerification.java
+++ b/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/profile/request/attribute/derivation/SandboxAgeVerification.java
@@ -10,13 +10,13 @@ import com.yoti.api.client.sandbox.profile.request.attribute.SandboxAttribute;
 import com.yoti.api.client.spi.remote.DateValue;
 import com.yoti.api.client.spi.remote.util.Validation;
 
-public class AgeVerification {
+public class SandboxAgeVerification {
 
     private final Date dateOfBirth;
     private final String supportedAgeDerivation;
     private final List<SandboxAnchor> anchors;
 
-    private AgeVerification(Date dateOfBirth, String supportedAgeDerivation, List<SandboxAnchor> anchors) {
+    private SandboxAgeVerification(Date dateOfBirth, String supportedAgeDerivation, List<SandboxAnchor> anchors) {
         Validation.notNull(dateOfBirth, "dateOfBirth");
         Validation.notNullOrEmpty(supportedAgeDerivation, "derivation");
 
@@ -34,17 +34,17 @@ public class AgeVerification {
                 .build();
     }
 
-    public static AgeVerificationBuilder builder() {
-        return new AgeVerificationBuilder();
+    public static SandboxAgeVerificationBuilder builder() {
+        return new SandboxAgeVerificationBuilder();
     }
 
-    public static class AgeVerificationBuilder {
+    public static class SandboxAgeVerificationBuilder {
 
         private Date dateOfBirth;
         private String derivation;
         private List<SandboxAnchor> anchors = Collections.emptyList();
 
-        public AgeVerificationBuilder withDateOfBirth(String value) {
+        public SandboxAgeVerificationBuilder withDateOfBirth(String value) {
             try {
                 this.dateOfBirth = DateValue.parseFrom(value);
                 return this;
@@ -53,35 +53,35 @@ public class AgeVerification {
             }
         }
 
-        public AgeVerificationBuilder withDateOfBirth(Date value) {
+        public SandboxAgeVerificationBuilder withDateOfBirth(Date value) {
             Validation.notNull(value, "dateOfBirth");
             this.dateOfBirth = value;
             return this;
         }
 
-        public AgeVerificationBuilder withAgeOver(int value) {
+        public SandboxAgeVerificationBuilder withAgeOver(int value) {
             return withDerivation(AttributeConstants.HumanProfileAttributes.AGE_OVER + value);
         }
 
-        public AgeVerificationBuilder withAgeUnder(int value) {
+        public SandboxAgeVerificationBuilder withAgeUnder(int value) {
             return withDerivation(AttributeConstants.HumanProfileAttributes.AGE_UNDER + value);
         }
 
-        public AgeVerificationBuilder withDerivation(String value) {
+        public SandboxAgeVerificationBuilder withDerivation(String value) {
             Validation.notNullOrEmpty(value, "derivation");
             this.derivation = value;
             return this;
         }
 
-        public AgeVerificationBuilder withAnchors(List<SandboxAnchor> anchors) {
+        public SandboxAgeVerificationBuilder withAnchors(List<SandboxAnchor> anchors) {
             Validation.notNull(anchors, "anchors");
             this.anchors = anchors;
             return this;
         }
 
-        public AgeVerification build() {
+        public SandboxAgeVerification build() {
             try {
-                return new AgeVerification(dateOfBirth, derivation, anchors);
+                return new SandboxAgeVerification(dateOfBirth, derivation, anchors);
             } catch (Exception e) {
                 throw new IllegalStateException(e);
             }

--- a/yoti-sdk-sandbox/src/test/java/com.yoti.api.client.sandbox/profile/request/YotiTokenRequestTest.java
+++ b/yoti-sdk-sandbox/src/test/java/com.yoti.api.client.sandbox/profile/request/YotiTokenRequestTest.java
@@ -15,7 +15,7 @@ import com.yoti.api.attributes.AttributeConstants.HumanProfileAttributes;
 import com.yoti.api.client.DocumentDetails;
 import com.yoti.api.client.sandbox.profile.request.attribute.SandboxAnchor;
 import com.yoti.api.client.sandbox.profile.request.attribute.SandboxAttribute;
-import com.yoti.api.client.sandbox.profile.request.attribute.derivation.AgeVerification;
+import com.yoti.api.client.sandbox.profile.request.attribute.derivation.SandboxAgeVerification;
 import com.yoti.api.client.spi.remote.DateValue;
 import com.yoti.api.client.spi.remote.DocumentDetailsAttributeValue;
 
@@ -228,12 +228,12 @@ public class YotiTokenRequestTest {
 
     @Test
     public void shouldCreateRequestWithAgeUnderVerification() {
-        AgeVerification ageVerification = AgeVerification.builder()
+        SandboxAgeVerification sandboxAgeVerification = SandboxAgeVerification.builder()
                 .withDateOfBirth(DOB_UNDER_18)
                 .withAgeUnder(18)
                 .build();
         YotiTokenRequest yotiTokenRequest = YotiTokenRequest.builder()
-                .withAgeVerification(ageVerification)
+                .withAgeVerification(sandboxAgeVerification)
                 .build();
 
         List<SandboxAttribute> result = yotiTokenRequest.getSandboxAttributes();
@@ -244,12 +244,12 @@ public class YotiTokenRequestTest {
 
     @Test
     public void shouldCreateRequestWithAgeOverVerification() {
-        AgeVerification ageVerification = AgeVerification.builder()
+        SandboxAgeVerification sandboxAgeVerification = SandboxAgeVerification.builder()
                 .withDateOfBirth(DOB_OVER_18)
                 .withAgeOver(18)
                 .build();
         YotiTokenRequest yotiTokenRequest = YotiTokenRequest.builder()
-                .withAgeVerification(ageVerification)
+                .withAgeVerification(sandboxAgeVerification)
                 .build();
 
         List<SandboxAttribute> result = yotiTokenRequest.getSandboxAttributes();

--- a/yoti-sdk-sandbox/src/test/java/com/yoti/api/client/sandbox/profile/request/attribute/derivation/SandboxAgeVerificationTest.java
+++ b/yoti-sdk-sandbox/src/test/java/com/yoti/api/client/sandbox/profile/request/attribute/derivation/SandboxAgeVerificationTest.java
@@ -17,14 +17,14 @@ import com.yoti.api.client.spi.remote.DateValue;
 
 import org.junit.Test;
 
-public class AgeVerificationTest {
+public class SandboxAgeVerificationTest {
 
     private static final String VALID_DATE_STRING = "1980-08-05";
 
     @Test
     public void shouldErrorForBadDateOfBirth() {
         try {
-            AgeVerification.builder()
+            SandboxAgeVerification.builder()
                     .withDateOfBirth("2011-15-35")
                     .build();
         } catch (IllegalArgumentException e) {
@@ -39,7 +39,7 @@ public class AgeVerificationTest {
     @Test
     public void shouldErrorForNullAnchors() {
         try {
-            AgeVerification.builder()
+            SandboxAgeVerification.builder()
                     .withAnchors(null);
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), containsString("'anchors' must not be null"));
@@ -52,7 +52,7 @@ public class AgeVerificationTest {
     @Test
     public void shouldErrorForMissingDateOfBirth() {
         try {
-            AgeVerification.builder().build();
+            SandboxAgeVerification.builder().build();
         } catch (IllegalStateException e) {
             assertThat(e.getMessage(), containsString("'dateOfBirth' must not be null"));
             return;
@@ -64,7 +64,7 @@ public class AgeVerificationTest {
     @Test
     public void shouldErrorForMissingDerivation() {
         try {
-            AgeVerification.builder()
+            SandboxAgeVerification.builder()
                     .withDateOfBirth(VALID_DATE_STRING)
                     .build();
         } catch (IllegalStateException e) {
@@ -77,7 +77,7 @@ public class AgeVerificationTest {
 
     @Test
     public void shouldParseDateOfBirthSuccessfully() {
-        AgeVerification result = AgeVerification.builder()
+        SandboxAgeVerification result = SandboxAgeVerification.builder()
                 .withDateOfBirth(VALID_DATE_STRING)
                 .withAgeOver(7)
                 .build();
@@ -87,7 +87,7 @@ public class AgeVerificationTest {
 
     @Test
     public void shouldCreateAgeOverSandboxAttribute() throws Exception {
-        SandboxAttribute result = AgeVerification.builder()
+        SandboxAttribute result = SandboxAgeVerification.builder()
                 .withDateOfBirth(DateValue.parseFrom(VALID_DATE_STRING))
                 .withAgeOver(21)
                 .build()
@@ -102,7 +102,7 @@ public class AgeVerificationTest {
 
     @Test
     public void shouldCreateAgeUnderSandboxAttribute() throws Exception {
-        SandboxAttribute result = AgeVerification.builder()
+        SandboxAttribute result = SandboxAgeVerification.builder()
                 .withDateOfBirth(DateValue.parseFrom(VALID_DATE_STRING))
                 .withAgeUnder(16)
                 .build()
@@ -118,7 +118,7 @@ public class AgeVerificationTest {
     @Test
     public void shouldCreateAgeVerificationWithAnchors() throws Exception{
         SandboxAnchor sandboxAnchor = SandboxAnchor.builder().build();
-        SandboxAttribute result = AgeVerification.builder()
+        SandboxAttribute result = SandboxAgeVerification.builder()
                 .withDateOfBirth(DateValue.parseFrom(VALID_DATE_STRING))
                 .withAgeUnder(16)
                 .withAnchors(asList(sandboxAnchor))


### PR DESCRIPTION
What do we think of this approach....?

We've decided we want to add support for multiple age-derived-attributes (age_over + age_under) now.  So we have a new _AgeVerification_ interface, and the _HumanProfile_ will now return a list of those wrapping all the age-derived-attributes that it can find.  There are also two helper methods to sweeten it, _findAgeOverVerification(int age)_ and _findAgeUnderVerification(int age)_.

The real meat of this change can be found in _AgeVerification_, _HumanProfile_ and _HumanProfileAdapter_.

Introducing _AgeVerification_ to the api package prompts us to rename the class we already have in the sandbox: _AgeVerification_ > _SandboxAgeVerification_.  This is not a breaking change, since none of the sandbox code has been released yet.  But it will require a change in the _connect-api-sandbox_ Integration tests - coming very soon.

When updating the README and the JAVADOC I notices a few other problems hanging over from the Java SDK v2 change.  I've taken the opportunity to fix them now.

Finally, although we don't have any spec for it, I think it would be prudent to prove that our implementation of DocumentDetails does break if we start receiving a 6th parameter.  So there's a unit test for that too.