### PR TITLE
SDK-573: Fix sandbox code to allow multiple derivations of an attribute

### DIFF
--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/AgeVerification.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/AgeVerification.java
@@ -10,14 +10,14 @@ public interface AgeVerification {
      *
      * @return The type of age check performed
      */
-    String getCheckPerformed();
+    String getCheckType();
 
     /**
      * The age that was that checked, as specified on dashboard.
      *
      * @return The age that was that checked
      */
-    int getAgeVerified();
+    int getAge();
 
     /**
      * Whether or not the profile passed the age check

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SimpleAgeVerification.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SimpleAgeVerification.java
@@ -25,12 +25,12 @@ public class SimpleAgeVerification implements AgeVerification {
     }
 
     @Override
-    public int getAgeVerified() {
+    public int getAge() {
         return ageVerified;
     }
 
     @Override
-    public String getCheckPerformed() {
+    public String getCheckType() {
         return checkPerformed;
     }
 

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/SimpleAgeVerificationTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/SimpleAgeVerificationTest.java
@@ -43,8 +43,8 @@ public class SimpleAgeVerificationTest {
 
         SimpleAgeVerification result = new SimpleAgeVerification(attribute);
 
-        assertEquals(result.getCheckPerformed(), "any_string_here");
-        assertEquals(result.getAgeVerified(), 21);
+        assertEquals(result.getCheckType(), "any_string_here");
+        assertEquals(result.getAge(), 21);
         assertEquals(result.getResult(), true);
     }
 

--- a/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/profile/request/YotiTokenRequest.java
+++ b/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/profile/request/YotiTokenRequest.java
@@ -54,7 +54,8 @@ public class YotiTokenRequest {
         }
 
         public YotiTokenRequestBuilder withAttribute(SandboxAttribute sandboxAttribute) {
-            attributes.put(sandboxAttribute.getName(), sandboxAttribute);
+            String key = sandboxAttribute.getDerivation() != null ? sandboxAttribute.getDerivation() : sandboxAttribute.getName();
+            attributes.put(key, sandboxAttribute);
             return this;
         }
 

--- a/yoti-sdk-sandbox/src/test/java/com.yoti.api.client.sandbox/profile/request/YotiTokenRequestTest.java
+++ b/yoti-sdk-sandbox/src/test/java/com.yoti.api.client.sandbox/profile/request/YotiTokenRequestTest.java
@@ -4,7 +4,6 @@ import static org.bouncycastle.util.encoders.Base64.toBase64String;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.util.Arrays;
@@ -47,13 +46,19 @@ public class YotiTokenRequestTest {
     private static final List<SandboxAnchor> anchors = Arrays.asList(SandboxAnchor.builder().build());
 
     @Test
-    public void shouldAddAnAttribute() {
-        YotiTokenRequest yotiTokenRequest = YotiTokenRequest.builder()
-                .withAttribute(SOME_ATTRIBUTE)
+    public void shouldAddAttributes() {
+        SandboxAttribute otherAttribute = SandboxAttribute.builder()
+                .withName("otherAttributeName")
                 .build();
 
-        assertEquals(1, yotiTokenRequest.getSandboxAttributes().size());
-        assertEquals(SOME_ATTRIBUTE_NAME, yotiTokenRequest.getSandboxAttributes().get(0).getName());
+        YotiTokenRequest yotiTokenRequest = YotiTokenRequest.builder()
+                .withAttribute(SOME_ATTRIBUTE)
+                .withAttribute(otherAttribute)
+                .build();
+
+        assertThat(yotiTokenRequest.getSandboxAttributes(), hasSize(2));
+        assertThat(yotiTokenRequest.getSandboxAttributes(), hasItem(SOME_ATTRIBUTE));
+        assertThat(yotiTokenRequest.getSandboxAttributes(), hasItem(otherAttribute));
     }
 
     @Test
@@ -78,8 +83,25 @@ public class YotiTokenRequestTest {
                 .withAttribute(SOME_ATTRIBUTE)
                 .build();
 
-        assertEquals(1, yotiTokenRequest.getSandboxAttributes().size());
-        assertEquals(SOME_ATTRIBUTE_NAME, yotiTokenRequest.getSandboxAttributes().get(0).getName());
+        assertThat(yotiTokenRequest.getSandboxAttributes(), hasSize(1));
+        assertThat(yotiTokenRequest.getSandboxAttributes(), hasItem(SOME_ATTRIBUTE));
+    }
+
+    @Test
+    public void shouldAllowSameAttributeWithDifferingDerivationNames() {
+        SandboxAttribute derivationAttribute = SandboxAttribute.builder()
+                .withName(SOME_ATTRIBUTE_NAME)
+                .withDerivation("derivation1")
+                .build();
+
+        YotiTokenRequest yotiTokenRequest = YotiTokenRequest.builder()
+                .withAttribute(SOME_ATTRIBUTE)
+                .withAttribute(derivationAttribute)
+                .build();
+
+        assertThat(yotiTokenRequest.getSandboxAttributes(), hasSize(2));
+        assertThat(yotiTokenRequest.getSandboxAttributes(), hasItem(SOME_ATTRIBUTE));
+        assertThat(yotiTokenRequest.getSandboxAttributes(), hasItem(derivationAttribute));
     }
 
     @Test


### PR DESCRIPTION
We also need a little change in the SDK sandbox code.
I've explained in the SDK-573 ticket.