### PR TITLE
Release 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,13 +102,13 @@ If you are using Maven, you need to add the following dependency:
 <dependency>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-impl</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
 </dependency>
 ```
 
 If you are using Gradle, here is the dependency to add:
 
-`compile group: 'com.yoti', name: 'yoti-sdk-impl', version: '2.0.0'`
+`compile group: 'com.yoti', name: 'yoti-sdk-impl', version: '2.1.0'`
 
 You will find all classes packaged under `com.yoti.api`
 

--- a/README.md
+++ b/README.md
@@ -185,9 +185,9 @@ so can use it to determine whether a user is new to you.  For example:
 ActivityDetails activityDetails;
 try {
     activityDetails = client.getActivityDetails(token);
-    Optional<YourAppUserClass> user = yourUserSearchMethod(activityDetails.getUserId());
+    Optional<YourAppUserClass> user = yourUserSearchMethod(activityDetails.getRememberMeId());
     if (user.isPresent()) {
-        String userId = activityDetails.getUserId();
+        String rememberMeId = activityDetails.getRememberMeId();
         String base64Selfie = activityDetails.getBase64Selfie();
         Attribute<Image> selfie = profile.getSelfie();
         Image selfieValue = selfie.getValue();
@@ -210,7 +210,7 @@ try {
 }
 ```
 
-Where `yourUserSearchMethod` is a method in your app that finds the user for the given userId.
+Where `yourUserSearchMethod` is a method in your app that finds the user for the given rememberMeId.
 Regardless of whether the user is new to your app, Yoti will always provide the profile.  So you don't necessarily need to store it.
 
 ### Attributes

--- a/README.md
+++ b/README.md
@@ -188,15 +188,21 @@ try {
     Optional<YourAppUserClass> user = yourUserSearchMethod(activityDetails.getRememberMeId());
     if (user.isPresent()) {
         String rememberMeId = activityDetails.getRememberMeId();
-        String base64Selfie = activityDetails.getBase64Selfie();
+
         Attribute<Image> selfie = profile.getSelfie();
-        Image selfieValue = selfie.getValue();
+        if (selfie != null) {
+            Image selfieValue = selfie.getValue();
+            String base64Selfie = selfieValue.getBase64Content();
+        }
         Attribute<String> fullName = profile.getFullName();
         Attribute<String> givenNames = profile.getGivenNames();
         Attribute<String> familyName = profile.getFamilyName();
         Attribute<String> phoneNumber = profile.getPhoneNumber();
         Attribute<String> emailAddress = profile.getEmailAddress();
-        Boolean isAgeVerified = profile.isAgeVerified();
+        AgeVerification over18Verification = profile.findAgeOverVerification(18);
+        if (over18Verification != null) {
+            boolean isAgedOver18 = over18Verification.getResult();
+        }
         Attribute<Date> dateOfBirth = profile.getDateOfBirth();
         Attribute<String> gender = profile.getGender();
         Attribute<String> postalAddress = profile.getPostalAddress();

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk</artifactId>
   <packaging>pom</packaging>
-  <version>2.0.0</version>
+  <version>2.1.0-SNAPSHOT</version>
   <name>Yoti SDK</name>
   <description>Java SDK for simple integration with the Yoti platform</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk</artifactId>
   <packaging>pom</packaging>
-  <version>2.1.0-SNAPSHOT</version>
+  <version>2.1.0</version>
   <name>Yoti SDK</name>
   <description>Java SDK for simple integration with the Yoti platform</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>

--- a/yoti-sdk-api/pom.xml
+++ b/yoti-sdk-api/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.0</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
 

--- a/yoti-sdk-api/pom.xml
+++ b/yoti-sdk-api/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
 

--- a/yoti-sdk-api/src/main/java/com/yoti/api/attributes/AttributeConstants.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/attributes/AttributeConstants.java
@@ -22,6 +22,12 @@ public final class AttributeConstants {
         public static final String SELFIE = "selfie";
         public static final String EMAIL_ADDRESS = "email_address";
         public static final String DOCUMENT_DETAILS = "document_details";
+
+        public static final class Keys {
+
+            public static final String FORMATTED_ADDRESS = "formatted_address";
+        }
+
     }
 
     public static final class ApplicationProfileAttributes {

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/ActivityDetails.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/ActivityDetails.java
@@ -55,10 +55,12 @@ public interface ActivityDetails {
     String getReceiptId();
     
     /**
-     * JPEG selfie in Base64 string
-     * 
+     * @deprecated From v2.1 onwards you should use getUserProfile().getSelfie()
+     * JPEG selfie in Base64 string.
+     *
      * @return JPEG selfie image in Base64 string format
      */
+    @Deprecated
     String getBase64Selfie();
 
 }

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/ActivityDetails.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/ActivityDetails.java
@@ -23,13 +23,22 @@ public interface ActivityDetails {
     ApplicationProfile getApplicationProfile();
 
     /**
-     * Return the user ID, which is a unique, stable identifier for a user in the context of an application/user
+     * Deprecated.  Please use getRememberMeId() instead.
+     *
+     * @return user ID.
+     */
+    @Deprecated
+    String getUserId();
+
+    /**
+     * Return the remember-me ID, which is a unique, stable identifier for a user in the context of an application/user
      * interaction. You can be use it to identify returning users. Note that it is different for the same user in
      * different applications.
      *
      * @return user ID.
      */
-    String getUserId();
+    String getRememberMeId();
+
 
     /**
      * Time and date of the activity.

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/Image.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/Image.java
@@ -5,6 +5,7 @@ package com.yoti.api.client;
  *
  */
 public interface Image {
+
     /**
      * Get mime type of the content.
      *
@@ -18,4 +19,12 @@ public interface Image {
      * @return image as byte[]
      */
     byte[] getContent();
+
+    /**
+     * Base64 encoded image
+     *
+     * @return image as Base64 encoded String
+     */
+    String getBase64Content();
+
 }

--- a/yoti-sdk-impl/pom.xml
+++ b/yoti-sdk-impl/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.0</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
   

--- a/yoti-sdk-impl/pom.xml
+++ b/yoti-sdk-impl/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
   

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AddressTransformer.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AddressTransformer.java
@@ -1,0 +1,42 @@
+package com.yoti.api.client.spi.remote;
+
+import java.util.Map;
+
+import com.yoti.api.attributes.AttributeConstants.HumanProfileAttributes;
+import com.yoti.api.client.Attribute;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class AddressTransformer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AttributeListConverter.class);
+
+    private AddressTransformer() {}
+
+    static final AddressTransformer newInstance() {
+        return new AddressTransformer();
+    }
+
+    public Attribute<String> transform(Attribute<?> structuredAddress) {
+        Attribute<String> transformedAddress = null;
+        try {
+            Attribute<Map<?, ?>> address = (Attribute<Map<?, ?>>) structuredAddress;
+            if (address.getValue() != null) {
+                Object formattedAddress = address.getValue().get(HumanProfileAttributes.Keys.FORMATTED_ADDRESS);
+                if (formattedAddress != null) {
+                    transformedAddress = new SimpleAttribute(HumanProfileAttributes.POSTAL_ADDRESS,
+                            String.valueOf(formattedAddress),
+                            structuredAddress.getSources(),
+                            structuredAddress.getVerifiers(),
+                            structuredAddress.getAnchors());
+                }
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to transform attribute '{}' in place of missing '{}' due to '{}'", structuredAddress.getName(),
+                    HumanProfileAttributes.POSTAL_ADDRESS, e.getMessage());
+        }
+        return transformedAddress;
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AddressTransformer.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AddressTransformer.java
@@ -18,22 +18,22 @@ class AddressTransformer {
         return new AddressTransformer();
     }
 
-    public Attribute<String> transform(Attribute<?> structuredAddress) {
+    Attribute<String> transform(Attribute<?> structuredPostalAddress) {
         Attribute<String> transformedAddress = null;
         try {
-            Attribute<Map<?, ?>> address = (Attribute<Map<?, ?>>) structuredAddress;
-            if (address.getValue() != null) {
-                Object formattedAddress = address.getValue().get(HumanProfileAttributes.Keys.FORMATTED_ADDRESS);
+            if (structuredPostalAddress.getValue() != null) {
+                final Map<?, ?> structuredAddressValue = (Map<?, ?>) structuredPostalAddress.getValue();
+                final Object formattedAddress = structuredAddressValue.get(HumanProfileAttributes.Keys.FORMATTED_ADDRESS);
                 if (formattedAddress != null) {
                     transformedAddress = new SimpleAttribute(HumanProfileAttributes.POSTAL_ADDRESS,
                             String.valueOf(formattedAddress),
-                            structuredAddress.getSources(),
-                            structuredAddress.getVerifiers(),
-                            structuredAddress.getAnchors());
+                            structuredPostalAddress.getSources(),
+                            structuredPostalAddress.getVerifiers(),
+                            structuredPostalAddress.getAnchors());
                 }
             }
         } catch (Exception e) {
-            LOG.warn("Failed to transform attribute '{}' in place of missing '{}' due to '{}'", structuredAddress.getName(),
+            LOG.warn("Failed to transform attribute '{}' in place of missing '{}' due to '{}'", structuredPostalAddress.getName(),
                     HumanProfileAttributes.POSTAL_ADDRESS, e.getMessage());
         }
         return transformedAddress;

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AttributeListConverter.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AttributeListConverter.java
@@ -68,9 +68,9 @@ class AttributeListConverter {
 
     private void ensurePostalAddress(List<Attribute<?>> attributes) {
         if (findAttribute(POSTAL_ADDRESS, attributes) == null) {
-            Attribute<?> structuredAddress = findAttribute(STRUCTURED_POSTAL_ADDRESS, attributes);
-            if (structuredAddress != null) {
-                Attribute<String> transformedAddress = addressTransformer.transform(structuredAddress);
+            Attribute<?> structuredPostalAddress = findAttribute(STRUCTURED_POSTAL_ADDRESS, attributes);
+            if (structuredPostalAddress != null) {
+                Attribute<String> transformedAddress = addressTransformer.transform(structuredPostalAddress);
                 if (transformedAddress != null) {
                     LOG.debug("Substituting '{}' in place of missing '{}'", STRUCTURED_POSTAL_ADDRESS, POSTAL_ADDRESS);
                     attributes.add(transformedAddress);

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ImageAttributeValue.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ImageAttributeValue.java
@@ -1,10 +1,11 @@
 package com.yoti.api.client.spi.remote;
 
+import static org.bouncycastle.util.encoders.Base64.toBase64String;
+
 import com.yoti.api.client.Image;
 
 /**
  * Image attribute values.
- *
  */
 abstract class ImageAttributeValue implements Image {
 
@@ -24,9 +25,9 @@ abstract class ImageAttributeValue implements Image {
     @Override
     public abstract byte[] getContent();
 
-    protected byte[] newArray(byte[] source) {
-        byte[] result = new byte[source.length];
-        System.arraycopy(source, 0, result, 0, source.length);
-        return result;
+    @Override
+    public String getBase64Content() {
+        return String.format("data:%s;base64,%s", getMimeType(), toBase64String(getContent()));
     }
+
 }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/JpegAttributeValue.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/JpegAttributeValue.java
@@ -11,7 +11,7 @@ final class JpegAttributeValue extends ImageAttributeValue {
     private final byte[] content;
 
     public JpegAttributeValue(byte[] content) {
-        this.content = newArray(content);
+        this.content = content;
     }
 
     @Override
@@ -21,6 +21,7 @@ final class JpegAttributeValue extends ImageAttributeValue {
 
     @Override
     public byte[] getContent() {
-        return newArray(content);
+        return content.clone();
     }
+
 }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/PngAttributeValue.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/PngAttributeValue.java
@@ -11,7 +11,7 @@ final class PngAttributeValue extends ImageAttributeValue {
     private final byte[] content;
 
     public PngAttributeValue(byte[] content) {
-        this.content = newArray(content);
+        this.content = content;
     }
 
     @Override
@@ -21,6 +21,7 @@ final class PngAttributeValue extends ImageAttributeValue {
 
     @Override
     public byte[] getContent() {
-        return newArray(content);
+        return content.clone();
     }
+
 }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SimpleActivityDetails.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SimpleActivityDetails.java
@@ -64,6 +64,7 @@ final class SimpleActivityDetails implements ActivityDetails {
     }
     
     @Override
+    @Deprecated
     public String getBase64Selfie() {
         return base64Selfie;
     }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SimpleActivityDetails.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SimpleActivityDetails.java
@@ -11,15 +11,15 @@ import com.yoti.api.client.Profile;
 
 final class SimpleActivityDetails implements ActivityDetails {
 
-    private final String userId;
+    private final String rememberMeId;
     private final ApplicationProfile applicationProfile;
     private final HumanProfile userProfile;
     private final Date timestamp;
     private final String receiptId;
     private final String base64Selfie;
 
-    public SimpleActivityDetails(String userId, Profile userProfile, Profile applicationProfile, Date timestamp, byte[] receiptId) {
-        this.userId = notNull(userId, "User id");
+    public SimpleActivityDetails(String rememberMeId, Profile userProfile, Profile applicationProfile, Date timestamp, byte[] receiptId) {
+        this.rememberMeId = notNull(rememberMeId, "Remember Me id");
         this.userProfile = HumanProfileAdapter.wrap(notNull(userProfile, "User profile"));
         this.applicationProfile = ApplicationProfileAdapter.wrap(notNull(applicationProfile, "Application profile"));
         this.timestamp = notNull(timestamp, "Timestamp");
@@ -43,8 +43,14 @@ final class SimpleActivityDetails implements ActivityDetails {
     }
 
     @Override
+    @Deprecated
     public String getUserId() {
-        return userId;
+        return getRememberMeId();
+    }
+
+    @Override
+    public String getRememberMeId() {
+        return rememberMeId;
     }
 
     @Override

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/ActivityDetailsFactoryTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/ActivityDetailsFactoryTest.java
@@ -5,6 +5,7 @@ import static com.yoti.api.client.spi.remote.util.CryptoUtil.generateKeyPairFrom
 import static com.yoti.api.client.spi.remote.util.CryptoUtil.generateSymmetricKey;
 
 import static org.bouncycastle.util.encoders.Base64.decode;
+import static org.bouncycastle.util.encoders.Base64.toBase64String;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
@@ -52,8 +53,8 @@ public class ActivityDetailsFactoryTest {
     private static final DateFormat RFC3339_FORMAT = new SimpleDateFormat(RFC3339_PATTERN);
     private static final String VALID_TIMESTAMP = RFC3339_FORMAT.format(DATE);
 
-    private static final String SOME_USER_ID_STRING = "aBase64EncodedUserId";
-    private static final byte[] SOME_USER_ID_BYTES = decode(SOME_USER_ID_STRING);
+    private static final String SOME_REMEMBER_ME_ID_STRING = toBase64String("aBase64EncodedRememberMeId".getBytes());
+    private static final byte[] SOME_REMEMBER_ME_ID_BYTES = decode(SOME_REMEMBER_ME_ID_STRING);
     private static final String ENCODED_RECEIPT_STRING = "base64EncodedReceipt";
     private static final byte[] DECODED_RECEIPT_BYTES = decode(ENCODED_RECEIPT_STRING);
 
@@ -128,7 +129,7 @@ public class ActivityDetailsFactoryTest {
         Receipt receipt = new Receipt.Builder()
                 .withWrappedReceiptKey(validReceiptKey)
                 .withTimestamp(VALID_TIMESTAMP)
-                .withRememberMeId(SOME_USER_ID_BYTES)
+                .withRememberMeId(SOME_REMEMBER_ME_ID_BYTES)
                 .withProfile(PROFILE_CONTENT)
                 .withOtherPartyProfile(OTHER_PROFILE_CONTENT)
                 .withReceiptId(DECODED_RECEIPT_BYTES)
@@ -140,7 +141,8 @@ public class ActivityDetailsFactoryTest {
 
         assertSame(otherProfileMock, getWrappedProfile(result.getUserProfile()));
         assertSame(profileMock, getWrappedProfile(result.getApplicationProfile()));
-        assertEquals(SOME_USER_ID_STRING, result.getUserId());
+        assertEquals(SOME_REMEMBER_ME_ID_STRING, result.getRememberMeId());
+        assertEquals(SOME_REMEMBER_ME_ID_STRING, result.getUserId());
         assertEquals(ENCODED_RECEIPT_STRING, result.getReceiptId());
         assertEquals(DATE, result.getTimestamp());
     }

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/AddressTransformerTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/AddressTransformerTest.java
@@ -1,0 +1,80 @@
+package com.yoti.api.client.spi.remote;
+
+import static java.util.Arrays.asList;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.yoti.api.attributes.AttributeConstants.HumanProfileAttributes;
+import com.yoti.api.client.Anchor;
+import com.yoti.api.client.Attribute;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AddressTransformerTest {
+
+    private static final String SOME_FORMATTED_ADDRESS = "someFormattedAddress";
+
+    @InjectMocks AddressTransformer testObj;
+
+    @Mock Attribute<Map> structuredAddressMock;
+    @Mock Attribute<Object> badAttributeMock;
+    @Mock Anchor sourceAnchorMock;
+    @Mock Anchor verifierAnchorMock;
+
+    @Test
+    public void shouldReturnNullWhenAddressValueIsNull() {
+        Attribute<String> result = testObj.transform(structuredAddressMock);
+
+        assertThat(result, is(nullValue()));
+    }
+
+    @Test
+    public void shouldReturnNullWhenFormattedAddressIsNull() {
+        when(structuredAddressMock.getValue()).thenReturn(new HashMap());
+
+        Attribute<String> result = testObj.transform(structuredAddressMock);
+
+        assertThat(result, is(nullValue()));
+    }
+
+    @Test
+    public void shouldReturnNullWhenTheresAnException() {
+        when(badAttributeMock.getValue()).thenReturn(new Object());
+
+        Attribute<String> result = testObj.transform(badAttributeMock);
+
+        assertThat(result, is(nullValue()));
+    }
+
+    @Test
+    public void shouldReturnTransformedAddress() {
+        Map<String, String> addressMap = new HashMap<>();
+        addressMap.put(HumanProfileAttributes.Keys.FORMATTED_ADDRESS, SOME_FORMATTED_ADDRESS);
+        when(structuredAddressMock.getValue()).thenReturn(addressMap);
+        when(structuredAddressMock.getSources()).thenReturn(asList(sourceAnchorMock));
+        when(structuredAddressMock.getVerifiers()).thenReturn(asList(verifierAnchorMock));
+        when(structuredAddressMock.getAnchors()).thenReturn(asList(sourceAnchorMock, verifierAnchorMock));
+
+        Attribute<String> result = testObj.transform(structuredAddressMock);
+
+        assertThat(result.getName(), Matchers.is(HumanProfileAttributes.POSTAL_ADDRESS));
+        assertThat(result.getValue(), is(SOME_FORMATTED_ADDRESS));
+        assertThat(result.getSources(), hasItems(sourceAnchorMock));
+        assertThat(result.getVerifiers(), hasItems(verifierAnchorMock));
+        assertThat(result.getAnchors(), hasItems(sourceAnchorMock, verifierAnchorMock));
+    }
+
+}

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/AttributeListConverterTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/AttributeListConverterTest.java
@@ -6,13 +6,16 @@ import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.text.ParseException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import com.yoti.api.attributes.AttributeConstants;
 import com.yoti.api.client.Attribute;
 import com.yoti.api.client.Date;
 import com.yoti.api.client.ProfileException;
@@ -20,6 +23,7 @@ import com.yoti.api.client.spi.remote.proto.AttrProto;
 import com.yoti.api.client.spi.remote.proto.AttributeListProto;
 
 import com.google.protobuf.InvalidProtocolBufferException;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -45,20 +49,31 @@ public class AttributeListConverterTest {
             .setName(JSON_ATTRIBUTE_NAME)
             .build();
 
-    private static final byte[] PROFILE_DATA = AttributeListProto.AttributeList.newBuilder()
-            .addAttributes(STRING_ATTRIBUTE_PROTO)
-            .addAttributes(DATE_ATTRIBUTE_PROTO)
-            .addAttributes(JSON_ATTRIBUTE_PROTO)
-            .build()
-            .toByteArray();
+    private static final AttrProto.Attribute POSTAL_ADDRESS_PROTO = AttrProto.Attribute.newBuilder()
+            .setName(AttributeConstants.HumanProfileAttributes.POSTAL_ADDRESS)
+            .build();
+
+    private static final AttrProto.Attribute STRUCTURED_ADDRESS_PROTO = AttrProto.Attribute.newBuilder()
+            .setName(AttributeConstants.HumanProfileAttributes.STRUCTURED_POSTAL_ADDRESS)
+            .build();
+
+    private static final byte[] PROFILE_DATA = createProfileData(STRING_ATTRIBUTE_PROTO, DATE_ATTRIBUTE_PROTO, JSON_ATTRIBUTE_PROTO);
 
     @InjectMocks AttributeListConverter testObj;
 
     @Mock AttributeConverter attributeConverterMock;
+    @Mock AddressTransformer addressTransformerMock;
 
     @Mock Attribute<String> stringAttributeMock;
     @Mock Attribute<Date> dateAttributeMock;
     @Mock Attribute<Map> jsonAttributeMock;
+    @Mock Attribute<String> postalAddressMock;
+    @Mock Attribute<Map> structuredAddressMock;
+
+    @Before
+    public void setUp() throws Exception {
+        when(structuredAddressMock.getName()).thenReturn(AttributeConstants.HumanProfileAttributes.STRUCTURED_POSTAL_ADDRESS);
+    }
 
     @Test
     public void shouldReturnEmptyListForNullProfileData() throws Exception {
@@ -107,6 +122,59 @@ public class AttributeListConverterTest {
 
         assertThat(result, hasSize(1));
         assertThat(result, hasItem(stringAttributeMock));
+    }
+
+    @Test
+    public void shouldNotSubstituteStructuredAddressWhenPostalAddressIsPresent() throws Exception {
+        when(attributeConverterMock.<String>convertAttribute(POSTAL_ADDRESS_PROTO)).thenReturn(postalAddressMock);
+
+        List<Attribute<?>> result = testObj.parseAttributeList(createProfileData(POSTAL_ADDRESS_PROTO));
+
+        assertThat(result, hasSize(1));
+        assertThat(result, hasItem(postalAddressMock));
+        verifyZeroInteractions(addressTransformerMock);
+    }
+
+    @Test
+    public void shouldNotSubstituteStructuredAddressWhenItsNotPresent() throws Exception {
+        when(attributeConverterMock.<String>convertAttribute(STRING_ATTRIBUTE_PROTO)).thenReturn(stringAttributeMock);
+        when(attributeConverterMock.<Date>convertAttribute(DATE_ATTRIBUTE_PROTO)).thenReturn(dateAttributeMock);
+        when(attributeConverterMock.<Map>convertAttribute(JSON_ATTRIBUTE_PROTO)).thenReturn(jsonAttributeMock);
+
+        List<Attribute<?>> result = testObj.parseAttributeList(PROFILE_DATA);
+
+        assertThat(result, hasSize(3));
+        assertThat(result, hasItems(stringAttributeMock, dateAttributeMock, jsonAttributeMock));
+        verifyZeroInteractions(addressTransformerMock);
+    }
+
+    @Test
+    public void shouldSubstituteStructuredAddressForMissingPostalAddress() throws Exception {
+        when(attributeConverterMock.<Map>convertAttribute(STRUCTURED_ADDRESS_PROTO)).thenReturn(structuredAddressMock);
+        when(addressTransformerMock.transform(structuredAddressMock)).thenReturn(postalAddressMock);
+
+        List<Attribute<?>> result = testObj.parseAttributeList(createProfileData(STRUCTURED_ADDRESS_PROTO));
+
+        assertThat(result, hasSize(2));
+        assertThat(result, hasItems(structuredAddressMock, postalAddressMock));
+    }
+
+    @Test
+    public void shouldNotAddNullTransformedAddress() throws Exception {
+        when(attributeConverterMock.<Map>convertAttribute(STRUCTURED_ADDRESS_PROTO)).thenReturn(structuredAddressMock);
+        when(addressTransformerMock.transform(structuredAddressMock)).thenReturn(null);
+
+        List<Attribute<?>> result = testObj.parseAttributeList(createProfileData(STRUCTURED_ADDRESS_PROTO));
+
+        assertThat(result, hasSize(1));
+        assertThat(result, hasItem(structuredAddressMock));
+    }
+
+    private static byte[] createProfileData(AttrProto.Attribute... attributes) {
+        return AttributeListProto.AttributeList.newBuilder()
+                .addAllAttributes(Arrays.asList(attributes))
+                .build()
+                .toByteArray();
     }
 
 }

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/JpegAttributeValueTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/JpegAttributeValueTest.java
@@ -1,0 +1,31 @@
+package com.yoti.api.client.spi.remote;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+import org.junit.Test;
+
+public class JpegAttributeValueTest {
+
+    private static final byte[] IMAGE_DATA = new byte[] { 0, 1, 2, 3 };
+
+    JpegAttributeValue testObj = new JpegAttributeValue(IMAGE_DATA);
+
+    @Test
+    public void shouldReturnCopyOfTheData() {
+        byte[] result = testObj.getContent();
+
+        assertArrayEquals(IMAGE_DATA, result);
+        assertNotSame(IMAGE_DATA, result);
+    }
+
+    @Test
+    public void shouldReturnBase64Selfie() {
+        String result = testObj.getBase64Content();
+
+        String base64Data = Base64.getEncoder().encodeToString(IMAGE_DATA);
+        assertEquals("data:image/jpeg;base64," + base64Data, result);
+    }
+
+}

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/PngAttributeValueTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/PngAttributeValueTest.java
@@ -1,0 +1,31 @@
+package com.yoti.api.client.spi.remote;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+import org.junit.Test;
+
+public class PngAttributeValueTest {
+
+    private static final byte[] IMAGE_DATA = new byte[] { 0, 1, 2, 3 };
+
+    PngAttributeValue testObj = new PngAttributeValue(IMAGE_DATA);
+
+    @Test
+    public void shouldReturnCopyOfTheData() {
+        byte[] result = testObj.getContent();
+
+        assertArrayEquals(IMAGE_DATA, result);
+        assertNotSame(IMAGE_DATA, result);
+    }
+
+    @Test
+    public void shouldReturnBase64Selfie() {
+        String result = testObj.getBase64Content();
+
+        String base64Data = Base64.getEncoder().encodeToString(IMAGE_DATA);
+        assertEquals("data:image/png;base64," + base64Data, result);
+    }
+
+}

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/SimpleActivityDetailsTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/SimpleActivityDetailsTest.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.Date;
 
 import com.yoti.api.client.Attribute;
+import com.yoti.api.client.Image;
 import com.yoti.api.client.Profile;
 
 import org.bouncycastle.util.encoders.Base64;
@@ -81,13 +82,14 @@ public class SimpleActivityDetailsTest {
 
     @Test
     public void shouldReturnBase64SelfieIfSelfieSet() {
-        Attribute selfie = new SimpleAttribute("selfie", new JpegAttributeValue(SOME_SELFIE_BYTES));
+        Attribute<Image> selfie = new SimpleAttribute("selfie", new JpegAttributeValue(SOME_SELFIE_BYTES));
         SimpleProfile profile = new SimpleProfile(Collections.<Attribute<?>>singletonList(selfie));
 
         SimpleActivityDetails result = new SimpleActivityDetails(REMEMBER_ME_ID, profile, APP_PROFILE, TIMESTAMP, RECEIPT_ID);
 
         String expected = "data:image/jpeg;base64," + Base64.toBase64String(SOME_SELFIE_BYTES);
         assertEquals(expected, result.getBase64Selfie());
+        assertEquals(selfie.getValue().getBase64Content(), result.getBase64Selfie());
     }
 
     @Test
@@ -99,4 +101,5 @@ public class SimpleActivityDetailsTest {
 
         assertEquals("", result.getBase64Selfie());
     }
+
 }

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/SimpleActivityDetailsTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/SimpleActivityDetailsTest.java
@@ -14,7 +14,7 @@ import org.mockito.Mockito;
 
 public class SimpleActivityDetailsTest {
 
-    private static final String USER_ID = "YmFkYWRhZGEtZGFkYWJhZGEK";
+    private static final String REMEMBER_ME_ID = "YmFkYWRhZGEtZGFkYWJhZGEK";
     private static final Profile USER_PROFILE = Mockito.mock(Profile.class);
     private static final Profile APP_PROFILE = Mockito.mock(Profile.class);
     private static final Profile USER_PROFILE_WRAPPER = HumanProfileAdapter.wrap(USER_PROFILE);
@@ -31,50 +31,51 @@ public class SimpleActivityDetailsTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldFailConstructionForNullUserProfile() {
-        new SimpleActivityDetails(USER_ID, null, APP_PROFILE, TIMESTAMP, RECEIPT_ID);
+        new SimpleActivityDetails(REMEMBER_ME_ID, null, APP_PROFILE, TIMESTAMP, RECEIPT_ID);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldFailConstructionForNullAppProfile() {
-        new SimpleActivityDetails(USER_ID, USER_PROFILE, null, TIMESTAMP, RECEIPT_ID);
+        new SimpleActivityDetails(REMEMBER_ME_ID, USER_PROFILE, null, TIMESTAMP, RECEIPT_ID);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldFailConstructionForNullTimestamp() {
-        new SimpleActivityDetails(USER_ID, USER_PROFILE, APP_PROFILE, null, RECEIPT_ID);
+        new SimpleActivityDetails(REMEMBER_ME_ID, USER_PROFILE, APP_PROFILE, null, RECEIPT_ID);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldFailConstructionForNullReceiptId() {
-        new SimpleActivityDetails(USER_ID, USER_PROFILE, APP_PROFILE, TIMESTAMP, null);
+        new SimpleActivityDetails(REMEMBER_ME_ID, USER_PROFILE, APP_PROFILE, TIMESTAMP, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldFailConstructionForNullProfile() {
-        new SimpleActivityDetails(USER_ID, null, APP_PROFILE, TIMESTAMP, RECEIPT_ID);
+        new SimpleActivityDetails(REMEMBER_ME_ID, null, APP_PROFILE, TIMESTAMP, RECEIPT_ID);
     }
 
     @Test
     public void shouldReturnUserId() {
-        SimpleActivityDetails s = new SimpleActivityDetails(USER_ID, USER_PROFILE, APP_PROFILE, TIMESTAMP, RECEIPT_ID);
-        assertEquals(USER_ID, s.getUserId());
+        SimpleActivityDetails s = new SimpleActivityDetails(REMEMBER_ME_ID, USER_PROFILE, APP_PROFILE, TIMESTAMP, RECEIPT_ID);
+        assertEquals(REMEMBER_ME_ID, s.getRememberMeId());
+        assertEquals(REMEMBER_ME_ID, s.getUserId());
     }
 
     @Test
     public void shouldReturnUserProfile() {
-        SimpleActivityDetails s = new SimpleActivityDetails(USER_ID, USER_PROFILE, APP_PROFILE, TIMESTAMP, RECEIPT_ID);
+        SimpleActivityDetails s = new SimpleActivityDetails(REMEMBER_ME_ID, USER_PROFILE, APP_PROFILE, TIMESTAMP, RECEIPT_ID);
         assertEquals(USER_PROFILE_WRAPPER, s.getUserProfile());
     }
 
     @Test
     public void shouldReturnAppProfile() {
-        SimpleActivityDetails s = new SimpleActivityDetails(USER_ID, APP_PROFILE, APP_PROFILE, TIMESTAMP, RECEIPT_ID);
+        SimpleActivityDetails s = new SimpleActivityDetails(REMEMBER_ME_ID, APP_PROFILE, APP_PROFILE, TIMESTAMP, RECEIPT_ID);
         assertEquals(APP_PROFILE_WRAPPER, s.getApplicationProfile());
     }
 
     @Test
     public void shouldReturnReceiptId() {
-        SimpleActivityDetails s = new SimpleActivityDetails(USER_ID, USER_PROFILE, APP_PROFILE, TIMESTAMP, RECEIPT_ID);
+        SimpleActivityDetails s = new SimpleActivityDetails(REMEMBER_ME_ID, USER_PROFILE, APP_PROFILE, TIMESTAMP, RECEIPT_ID);
         assertEquals(RECEIPT_ID_STRING, s.getReceiptId());
     }
 
@@ -83,7 +84,7 @@ public class SimpleActivityDetailsTest {
         Attribute selfie = new SimpleAttribute("selfie", new JpegAttributeValue(SOME_SELFIE_BYTES));
         SimpleProfile profile = new SimpleProfile(Collections.<Attribute<?>>singletonList(selfie));
 
-        SimpleActivityDetails result = new SimpleActivityDetails(USER_ID, profile, APP_PROFILE, TIMESTAMP, RECEIPT_ID);
+        SimpleActivityDetails result = new SimpleActivityDetails(REMEMBER_ME_ID, profile, APP_PROFILE, TIMESTAMP, RECEIPT_ID);
 
         String expected = "data:image/jpeg;base64," + Base64.toBase64String(SOME_SELFIE_BYTES);
         assertEquals(expected, result.getBase64Selfie());
@@ -94,7 +95,7 @@ public class SimpleActivityDetailsTest {
         Attribute familyName = new SimpleAttribute("family_name", "Smith");
         SimpleProfile profile = new SimpleProfile(Collections.<Attribute<?>>singletonList(familyName));
 
-        SimpleActivityDetails result = new SimpleActivityDetails(USER_ID, profile, APP_PROFILE, TIMESTAMP, RECEIPT_ID);
+        SimpleActivityDetails result = new SimpleActivityDetails(REMEMBER_ME_ID, profile, APP_PROFILE, TIMESTAMP, RECEIPT_ID);
 
         assertEquals("", result.getBase64Selfie());
     }

--- a/yoti-sdk-parent/pom.xml
+++ b/yoti-sdk-parent/pom.xml
@@ -56,6 +56,10 @@
       <activation>
         <activeByDefault>false</activeByDefault>
       </activation>
+      <properties>
+        <gpg.skip>false</gpg.skip>
+        <dependency-check.skip>false</dependency-check.skip>
+      </properties>
       <distributionManagement>
         <snapshotRepository>
           <id>ossrh</id>
@@ -72,6 +76,10 @@
       <activation>
         <activeByDefault>false</activeByDefault>
       </activation>
+      <properties>
+        <gpg.skip>true</gpg.skip>
+        <dependency-check.skip>true</dependency-check.skip>
+      </properties>
       <distributionManagement>
         <snapshotRepository>
           <id>yoti-snapshots</id>

--- a/yoti-sdk-parent/pom.xml
+++ b/yoti-sdk-parent/pom.xml
@@ -50,17 +50,38 @@
     <url>http://github.com/getyoti/yoti-java-sdk.git</url>
   </scm>
   
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
-  
+  <profiles>
+    <profile>
+      <id>sonatype</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <distributionManagement>
+        <snapshotRepository>
+          <id>ossrh</id>
+          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+          <id>ossrh</id>
+          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+      </distributionManagement>
+    </profile>
+    <profile>
+      <id>nexus</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <distributionManagement>
+        <snapshotRepository>
+          <id>yoti-snapshots</id>
+          <name>yoti-snapshots</name>
+          <url>https://nxs/repository/maven-snaphosts/</url>
+        </snapshotRepository>
+      </distributionManagement>
+    </profile>
+  </profiles>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   

--- a/yoti-sdk-parent/pom.xml
+++ b/yoti-sdk-parent/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-parent</artifactId>
   <packaging>pom</packaging>
-  <version>2.1.0-SNAPSHOT</version>
+  <version>2.1.0</version>
   <name>Yoti SDK Parent Pom</name>
   <description>Parent pom for the Java SDK projects</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>

--- a/yoti-sdk-parent/pom.xml
+++ b/yoti-sdk-parent/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-parent</artifactId>
   <packaging>pom</packaging>
-  <version>2.0.0</version>
+  <version>2.1.0-SNAPSHOT</version>
   <name>Yoti SDK Parent Pom</name>
   <description>Parent pom for the Java SDK projects</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>

--- a/yoti-sdk-spring-boot-auto-config/README.md
+++ b/yoti-sdk-spring-boot-auto-config/README.md
@@ -18,7 +18,7 @@ If you are using Maven, you need to add the following dependencies:
 <dependency>
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-boot-auto-config</artifactId>
-  <version>2.0.0</version>
+  <version>2.1.0</version>
 </dependency>
 ```
 
@@ -26,7 +26,7 @@ If you are using Maven, you need to add the following dependencies:
 If you are using Gradle, here is the dependency to add:
 
 ```
-compile group: 'com.yoti', name: 'yoti-sdk-spring-boot-auto-config', version: '2.0.0'
+compile group: 'com.yoti', name: 'yoti-sdk-spring-boot-auto-config', version: '2.1.0'
 ```
 
 

--- a/yoti-sdk-spring-boot-auto-config/pom.xml
+++ b/yoti-sdk-spring-boot-auto-config/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.0</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
 

--- a/yoti-sdk-spring-boot-auto-config/pom.xml
+++ b/yoti-sdk-spring-boot-auto-config/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
 

--- a/yoti-sdk-spring-boot-example/README.md
+++ b/yoti-sdk-spring-boot-example/README.md
@@ -16,7 +16,7 @@ Before you start, you'll need to create an Application in [Dashboard](https://ww
     <dependency>
       <groupId>com.yoti</groupId>
       <artifactId>yoti-sdk-impl</artifactId>
-      <version>2.0.0</version>
+      <version>2.1.0</version>
     </dependency>
 ```
 
@@ -28,8 +28,8 @@ Before you start, you'll need to create an Application in [Dashboard](https://ww
 1. Run `mvn clean package` to build the project.
 
 ## Running
-* You can run your server-app by executing `java -jar target/yoti-sdk-spring-boot-example-2.0.0.jar`
-  * If you are using Java 9, you can run the server-app as follows `java -jar target/yoti-sdk-spring-boot-example-2.0.0.jar --add-exports java.base/jdk.internal.ref=ALL-UNNAMED`
+* You can run your server-app by executing `java -jar target/yoti-sdk-spring-boot-example-2.1.0.jar`
+  * If you are using Java 9, you can run the server-app as follows `java -jar target/yoti-sdk-spring-boot-example-2.1.0.jar --add-exports java.base/jdk.internal.ref=ALL-UNNAMED`
 * Navigate to `https://localhost:8443`
 * You can then initiate a login using Yoti.  The Spring demo is listening for the response on `https://localhost:8443/login`.
 

--- a/yoti-sdk-spring-boot-example/pom.xml
+++ b/yoti-sdk-spring-boot-example/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-boot-example</artifactId>
 
-  <version>2.0.0</version>
+  <version>2.1.0-SNAPSHOT</version>
 
   <name>Yoti Spring Boot Example</name>
   <parent>
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>com.yoti</groupId>
       <artifactId>yoti-sdk-spring-boot-auto-config</artifactId>
-      <version>2.0.0</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/yoti-sdk-spring-boot-example/pom.xml
+++ b/yoti-sdk-spring-boot-example/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-boot-example</artifactId>
 
-  <version>2.1.0-SNAPSHOT</version>
+  <version>2.1.0</version>
 
   <name>Yoti Spring Boot Example</name>
   <parent>

--- a/yoti-sdk-spring-boot-example/src/main/java/com/yoti/api/examples/springboot/YotiLoginController.java
+++ b/yoti-sdk-spring-boot-example/src/main/java/com/yoti/api/examples/springboot/YotiLoginController.java
@@ -65,7 +65,7 @@ public class YotiLoginController {
         }
 
         // load activityDetails into ui model
-        model.addAttribute("userId", activityDetails.getUserId());
+        model.addAttribute("rememberMeId", activityDetails.getRememberMeId());
         model.addAttribute("base64Selfie", activityDetails.getBase64Selfie());
 
         // load humanProfile data into ui model

--- a/yoti-sdk-spring-boot-example/src/main/java/com/yoti/api/examples/springboot/YotiLoginController.java
+++ b/yoti-sdk-spring-boot-example/src/main/java/com/yoti/api/examples/springboot/YotiLoginController.java
@@ -7,6 +7,7 @@ import com.yoti.api.client.Anchor;
 import com.yoti.api.client.Attribute;
 import com.yoti.api.client.DateTime;
 import com.yoti.api.client.HumanProfile;
+import com.yoti.api.client.Image;
 import com.yoti.api.client.ProfileException;
 import com.yoti.api.client.YotiClient;
 import com.yoti.api.spring.YotiClientProperties;
@@ -66,9 +67,11 @@ public class YotiLoginController {
 
         // load activityDetails into ui model
         model.addAttribute("rememberMeId", activityDetails.getRememberMeId());
-        model.addAttribute("base64Selfie", activityDetails.getBase64Selfie());
 
         // load humanProfile data into ui model
+        Attribute<Image> selfie = humanProfile.getSelfie();
+        model.addAttribute("base64Selfie", selfie == null ? "" : selfie.getValue().getBase64Content());
+
         addAttributeToModel(model, humanProfile.getFamilyName());
         addAttributeToModel(model, humanProfile.getGivenNames());
         addAttributeToModel(model, humanProfile.getFullName());

--- a/yoti-sdk-spring-boot-example/src/main/resources/templates/index.html
+++ b/yoti-sdk-spring-boot-example/src/main/resources/templates/index.html
@@ -8,7 +8,7 @@
         <script src="https://sdk.yoti.com/clients/browser.2.1.0.js"></script>
     </head>
     <body>
-    <p th:text="${userId}"/>
+    <p th:text="${rememberMeId}"/>
     <!-- This span will create the Yoti button -->
     <span data-th-attr="data-yoti-application-id=${applicationId}">
         Use Yoti

--- a/yoti-sdk-spring-boot-example/src/main/resources/templates/profile.html
+++ b/yoti-sdk-spring-boot-example/src/main/resources/templates/profile.html
@@ -14,7 +14,7 @@
                 <th>Verifiers</th>
             <tr>
                 <td>User ID:</td>
-                <td><p th:text="${userId}"/></td>
+                <td><p th:text="${rememberMeId}"/></td>
             </tr>
             <tr>
                 <td>Selfie:</td>

--- a/yoti-sdk-spring-security/README.md
+++ b/yoti-sdk-spring-security/README.md
@@ -25,14 +25,14 @@ If you are using Maven, you need to add the following dependencies:
 <dependency>
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-security</artifactId>
-  <version>2.0.0</version>
+  <version>2.1.0</version>
 </dependency>
 ```
 
 If you are using Gradle, here is the dependency to add:
 
 ```
-compile group: 'com.yoti', name: 'yoti-sdk-spring-security', version: '2.0.0'
+compile group: 'com.yoti', name: 'yoti-sdk-spring-security', version: '2.1.0'
 ```
 
 ### Provide a `YotiClient` instance

--- a/yoti-sdk-spring-security/pom.xml
+++ b/yoti-sdk-spring-security/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.0</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
 

--- a/yoti-sdk-spring-security/pom.xml
+++ b/yoti-sdk-spring-security/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
 


### PR DESCRIPTION
We want to a release for Java SDK 2.1, as we want to get the change to structured-postal-address / postal-address out there.

We do not want to release sandbox yet, so we are not merging from _DEVELOPMENT_.  This is a _new_branch specific release 2.1, with commits that have been reviewed/merged to _DEVELOPMENT_ already.

I've created a temporary CI pipeline specific to this branch here: https://ccm/teams/yoti-sdk/pipelines/java_sdk_release_2.1

I've included:
- The change for structured-postal-address & postal-address
- Rename userId > rememberMeId
- Newly standardised approach to _Image_ objects

I have not included:
- Sandbox module, and all the many changes that went along with it
- Support for multiple age verifications