### PR TITLE
RELEASE-2.1.1: Bump bouncycastle to avoid CVE-2018-1000613

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,13 +102,13 @@ If you are using Maven, you need to add the following dependency:
 <dependency>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-impl</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
 </dependency>
 ```
 
 If you are using Gradle, here is the dependency to add:
 
-`compile group: 'com.yoti', name: 'yoti-sdk-impl', version: '2.1.0'`
+`compile group: 'com.yoti', name: 'yoti-sdk-impl', version: '2.1.1'`
 
 You will find all classes packaged under `com.yoti.api`
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk</artifactId>
   <packaging>pom</packaging>
-  <version>2.1.0</version>
+  <version>2.1.1</version>
   <name>Yoti SDK</name>
   <description>Java SDK for simple integration with the Yoti platform</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>

--- a/yoti-sdk-api/pom.xml
+++ b/yoti-sdk-api/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
 

--- a/yoti-sdk-impl/pom.xml
+++ b/yoti-sdk-impl/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
   

--- a/yoti-sdk-parent/pom.xml
+++ b/yoti-sdk-parent/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-parent</artifactId>
   <packaging>pom</packaging>
-  <version>2.1.0</version>
+  <version>2.1.1</version>
   <name>Yoti SDK Parent Pom</name>
   <description>Parent pom for the Java SDK projects</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>
@@ -101,7 +101,7 @@
     
     <!-- sdk dependency versions -->
     <slf4j.version>1.7.25</slf4j.version>
-    <bouncy.castle.version>1.59</bouncy.castle.version>
+    <bouncy.castle.version>1.60</bouncy.castle.version>
     <jackson.version>2.9.5</jackson.version>
     <google.protobuf.version>3.5.1</google.protobuf.version>
   

--- a/yoti-sdk-spring-boot-auto-config/README.md
+++ b/yoti-sdk-spring-boot-auto-config/README.md
@@ -18,7 +18,7 @@ If you are using Maven, you need to add the following dependencies:
 <dependency>
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-boot-auto-config</artifactId>
-  <version>2.1.0</version>
+  <version>2.1.1</version>
 </dependency>
 ```
 
@@ -26,7 +26,7 @@ If you are using Maven, you need to add the following dependencies:
 If you are using Gradle, here is the dependency to add:
 
 ```
-compile group: 'com.yoti', name: 'yoti-sdk-spring-boot-auto-config', version: '2.1.0'
+compile group: 'com.yoti', name: 'yoti-sdk-spring-boot-auto-config', version: '2.1.1'
 ```
 
 

--- a/yoti-sdk-spring-boot-auto-config/pom.xml
+++ b/yoti-sdk-spring-boot-auto-config/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
 

--- a/yoti-sdk-spring-boot-example/README.md
+++ b/yoti-sdk-spring-boot-example/README.md
@@ -16,7 +16,7 @@ Before you start, you'll need to create an Application in [Dashboard](https://ww
     <dependency>
       <groupId>com.yoti</groupId>
       <artifactId>yoti-sdk-impl</artifactId>
-      <version>2.1.0</version>
+      <version>2.1.1</version>
     </dependency>
 ```
 
@@ -28,8 +28,8 @@ Before you start, you'll need to create an Application in [Dashboard](https://ww
 1. Run `mvn clean package` to build the project.
 
 ## Running
-* You can run your server-app by executing `java -jar target/yoti-sdk-spring-boot-example-2.1.0.jar`
-  * If you are using Java 9, you can run the server-app as follows `java -jar target/yoti-sdk-spring-boot-example-2.1.0.jar --add-exports java.base/jdk.internal.ref=ALL-UNNAMED`
+* You can run your server-app by executing `java -jar target/yoti-sdk-spring-boot-example-2.1.1.jar`
+  * If you are using Java 9, you can run the server-app as follows `java -jar target/yoti-sdk-spring-boot-example-2.1.1.jar --add-exports java.base/jdk.internal.ref=ALL-UNNAMED`
 * Navigate to `https://localhost:8443`
 * You can then initiate a login using Yoti.  The Spring demo is listening for the response on `https://localhost:8443/login`.
 

--- a/yoti-sdk-spring-boot-example/pom.xml
+++ b/yoti-sdk-spring-boot-example/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-boot-example</artifactId>
 
-  <version>2.1.0</version>
+  <version>2.1.1</version>
 
   <name>Yoti Spring Boot Example</name>
   <parent>

--- a/yoti-sdk-spring-security/pom.xml
+++ b/yoti-sdk-spring-security/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
 


### PR DESCRIPTION
See SDK-616.  We _may_ need a patch release.  I am waiting to find out if I need to go ahead with it, or not - but I'd like to have everything ready.

There will be no SNAPSHOT for this one.  I've built + tested locally.