### PR TITLE
 SDK-672: Start sending SDK version in the headers

### DIFF
--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/RemoteProfileService.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/RemoteProfileService.java
@@ -8,7 +8,9 @@ import static com.yoti.api.client.spi.remote.call.YotiConstants.DEFAULT_YOTI_API
 import static com.yoti.api.client.spi.remote.call.YotiConstants.DIGEST_HEADER;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.JAVA;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.PROPERTY_YOTI_API_URL;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.SDK_VERSION;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.YOTI_SDK_HEADER;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.YOTI_SDK_VERSION_HEADER;
 import static com.yoti.api.client.spi.remote.util.Validation.notNull;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
@@ -78,6 +80,7 @@ public final class RemoteProfileService implements ProfileService {
         headers.put(AUTH_KEY_HEADER, authKey);
         headers.put(DIGEST_HEADER, digest);
         headers.put(YOTI_SDK_HEADER, JAVA);
+        headers.put(YOTI_SDK_VERSION_HEADER, SDK_VERSION);
         headers.put(CONTENT_TYPE, CONTENT_TYPE_JSON);
 
         UrlConnector urlConnector = UrlConnector.get(apiUrl + resourcePath);

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/YotiConstants.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/YotiConstants.java
@@ -13,11 +13,13 @@ public final class YotiConstants {
     public static final String AUTH_KEY_HEADER = "X-Yoti-Auth-Key";
     public static final String DIGEST_HEADER = "X-Yoti-Auth-Digest";
     public static final String YOTI_SDK_HEADER = "X-Yoti-SDK";
+    public static final String YOTI_SDK_VERSION_HEADER = YOTI_SDK_HEADER + "-Version";
 
     public static final String CONTENT_TYPE = "Content-Type";
     public static final String CONTENT_TYPE_JSON = "application/json";
 
     public static final String JAVA = "Java";
+    public static final String SDK_VERSION = JAVA + "-2.2.0";
     public static final String BOUNCY_CASTLE_PROVIDER = "BC";
     public static final String SIGNATURE_ALGORITHM = "SHA256withRSA";
     public static final String ASYMMETRIC_CIPHER = "RSA/NONE/PKCS1Padding";

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/aml/RemoteAmlService.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/aml/RemoteAmlService.java
@@ -8,7 +8,9 @@ import static com.yoti.api.client.spi.remote.call.YotiConstants.DEFAULT_YOTI_API
 import static com.yoti.api.client.spi.remote.call.YotiConstants.DIGEST_HEADER;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.JAVA;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.PROPERTY_YOTI_API_URL;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.SDK_VERSION;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.YOTI_SDK_HEADER;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.YOTI_SDK_VERSION_HEADER;
 import static com.yoti.api.client.spi.remote.util.Validation.notNull;
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
@@ -67,6 +69,7 @@ public class RemoteAmlService {
             Map<String, String> headers = new HashMap<>();
             headers.put(DIGEST_HEADER, digest);
             headers.put(YOTI_SDK_HEADER, JAVA);
+            headers.put(YOTI_SDK_VERSION_HEADER, SDK_VERSION);
             headers.put(CONTENT_TYPE, CONTENT_TYPE_JSON);
 
             UrlConnector urlConnector = UrlConnector.get(apiUrl + resourcePath);

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/call/RemoteProfileServiceTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/call/RemoteProfileServiceTest.java
@@ -4,8 +4,10 @@ import static com.yoti.api.client.spi.remote.call.HttpMethod.HTTP_GET;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.AUTH_KEY_HEADER;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.DIGEST_HEADER;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.JAVA;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.SDK_VERSION;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.YOTI_API_PATH_PREFIX;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.YOTI_SDK_HEADER;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.YOTI_SDK_VERSION_HEADER;
 import static com.yoti.api.client.spi.remote.util.CryptoUtil.KEY_PAIR_PEM;
 import static com.yoti.api.client.spi.remote.util.CryptoUtil.base64;
 import static com.yoti.api.client.spi.remote.util.CryptoUtil.generateKeyPairFrom;
@@ -89,21 +91,10 @@ public class RemoteProfileServiceTest {
     }
 
     private void assertHeaders(Map<String, String> headers) throws Exception {
-        assertAuthKey(headers.get(AUTH_KEY_HEADER));
-        assertDigest(headers.get(DIGEST_HEADER));
-        assertYotiSDK(headers.get(YOTI_SDK_HEADER));
-    }
-
-    private void assertDigest(String digestValue) throws Exception {
-        assertEquals(SOME_SIGNATURE, digestValue);
-    }
-
-    private void assertAuthKey(String authKeyValue) {
-        assertEquals(base64(keyPair.getPublic().getEncoded()), authKeyValue);
-    }
-
-    private void assertYotiSDK(String sdkValue) {
-        assertEquals(JAVA, sdkValue);
+        assertEquals(base64(keyPair.getPublic().getEncoded()), headers.get(AUTH_KEY_HEADER));
+        assertEquals(SOME_SIGNATURE, headers.get(DIGEST_HEADER));
+        assertEquals(JAVA, headers.get(YOTI_SDK_HEADER));
+        assertEquals(SDK_VERSION, headers.get(YOTI_SDK_VERSION_HEADER));
     }
 
     private void assertUrl(UrlConnector urlConnector) throws MalformedURLException {

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/call/aml/RemoteAmlServiceTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/call/aml/RemoteAmlServiceTest.java
@@ -3,8 +3,10 @@ package com.yoti.api.client.spi.remote.call.aml;
 import static com.yoti.api.client.spi.remote.call.HttpMethod.HTTP_POST;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.DIGEST_HEADER;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.JAVA;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.SDK_VERSION;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.YOTI_API_PATH_PREFIX;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.YOTI_SDK_HEADER;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.YOTI_SDK_VERSION_HEADER;
 import static com.yoti.api.client.spi.remote.util.CryptoUtil.KEY_PAIR_PEM;
 import static com.yoti.api.client.spi.remote.util.CryptoUtil.generateKeyPairFrom;
 import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
@@ -81,6 +83,7 @@ public class RemoteAmlServiceTest {
         assertEquals(YOTI_API_PATH_PREFIX + GENERATED_PATH, getPath(urlConnectorCaptor.getValue()));
         assertEquals(SOME_SIGNATURE, headersCaptor.getValue().get(DIGEST_HEADER));
         assertEquals(JAVA, headersCaptor.getValue().get(YOTI_SDK_HEADER));
+        assertEquals(SDK_VERSION, headersCaptor.getValue().get(YOTI_SDK_VERSION_HEADER));
         assertSame(result, simpleAmlResultMock);
     }
 

--- a/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/YotiSandboxClient.java
+++ b/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/YotiSandboxClient.java
@@ -4,7 +4,9 @@ import static com.yoti.api.client.spi.remote.call.YotiConstants.CONTENT_TYPE;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.CONTENT_TYPE_JSON;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.DEFAULT_YOTI_HOST;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.JAVA;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.SDK_VERSION;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.YOTI_SDK_HEADER;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.YOTI_SDK_VERSION_HEADER;
 import static com.yoti.api.client.spi.remote.util.Validation.notNull;
 import static com.yoti.api.client.spi.remote.util.Validation.notNullOrEmpty;
 
@@ -75,6 +77,7 @@ public class YotiSandboxClient {
             Map<String, String> headers = new HashMap<>();
             headers.put(YotiConstants.DIGEST_HEADER, requestDigest);
             headers.put(YOTI_SDK_HEADER, JAVA);
+            headers.put(YOTI_SDK_VERSION_HEADER, SDK_VERSION);
             headers.put(CONTENT_TYPE, CONTENT_TYPE_JSON);
 
             UrlConnector urlConnector = UrlConnector.get(sandboxBasePath + requestPath);

--- a/yoti-sdk-sandbox/src/test/java/com.yoti.api.client.sandbox/YotiSandboxClientTest.java
+++ b/yoti-sdk-sandbox/src/test/java/com.yoti.api.client.sandbox/YotiSandboxClientTest.java
@@ -4,7 +4,9 @@ import static com.yoti.api.client.sandbox.YotiSandboxClient.YOTI_SANDBOX_PATH_PR
 import static com.yoti.api.client.spi.remote.call.HttpMethod.HTTP_POST;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.DIGEST_HEADER;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.JAVA;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.SDK_VERSION;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.YOTI_SDK_HEADER;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.YOTI_SDK_VERSION_HEADER;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -167,6 +169,7 @@ public class YotiSandboxClientTest {
         assertEquals(YOTI_SANDBOX_PATH_PREFIX + SOME_PATH, getPath(urlConnectorCaptor.getValue()));
         assertEquals(SOME_SIGNATURE, headersCaptor.getValue().get(DIGEST_HEADER));
         assertEquals(JAVA, headersCaptor.getValue().get(YOTI_SDK_HEADER));
+        assertEquals(SDK_VERSION, headersCaptor.getValue().get(YOTI_SDK_VERSION_HEADER));
         assertEquals(SOME_TOKEN, result);
     }
 


### PR DESCRIPTION
We will start sending an additional header, that allows us to see which _version_ of a given SDK people are using.

I did try to find a way of pulling the .jar version in at runtime, but it doesn't work reliably when the code is not in a jar.  I figured it's not really worth it.