### PR TITLE
SDK-631: Update browser.js to 2.2.0 in example project

### DIFF
--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ProfileReader.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ProfileReader.java
@@ -2,7 +2,6 @@ package com.yoti.api.client.spi.remote;
 
 import static javax.crypto.Cipher.DECRYPT_MODE;
 
-import static com.yoti.api.client.spi.remote.call.YotiConstants.BOUNCY_CASTLE_PROVIDER;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.SYMMETRIC_CIPHER;
 
 import java.security.GeneralSecurityException;
@@ -20,6 +19,7 @@ import com.yoti.api.client.spi.remote.proto.EncryptedDataProto;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 class ProfileReader {
 
@@ -61,7 +61,7 @@ class ProfileReader {
             throw new ProfileException("Receipt key IV must not be null.");
         }
         try {
-            Cipher cipher = Cipher.getInstance(SYMMETRIC_CIPHER, BOUNCY_CASTLE_PROVIDER);
+            Cipher cipher = Cipher.getInstance(SYMMETRIC_CIPHER, BouncyCastleProvider.PROVIDER_NAME);
             cipher.init(DECRYPT_MODE, secretKey, new IvParameterSpec(initVector.toByteArray()));
             return cipher.doFinal(encryptedData.getCipherText().toByteArray());
         } catch (GeneralSecurityException gse) {

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/YotiConstants.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/YotiConstants.java
@@ -1,5 +1,7 @@
 package com.yoti.api.client.spi.remote.call;
 
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+
 public final class YotiConstants {
 
     private YotiConstants() {}
@@ -20,7 +22,6 @@ public final class YotiConstants {
 
     public static final String JAVA = "Java";
     public static final String SDK_VERSION = JAVA + "-2.2.0";
-    public static final String BOUNCY_CASTLE_PROVIDER = "BC";
     public static final String SIGNATURE_ALGORITHM = "SHA256withRSA";
     public static final String ASYMMETRIC_CIPHER = "RSA/NONE/PKCS1Padding";
     public static final String SYMMETRIC_CIPHER = "AES/CBC/PKCS7Padding";

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/factory/SignedMessageFactory.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/factory/SignedMessageFactory.java
@@ -1,13 +1,14 @@
 package com.yoti.api.client.spi.remote.call.factory;
 
 import static com.yoti.api.client.spi.remote.Base64.base64;
-import static com.yoti.api.client.spi.remote.call.YotiConstants.BOUNCY_CASTLE_PROVIDER;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.SIGNATURE_ALGORITHM;
 
 import java.security.GeneralSecurityException;
 import java.security.PrivateKey;
 import java.security.SecureRandom;
 import java.security.Signature;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 public class SignedMessageFactory {
 
@@ -32,7 +33,7 @@ public class SignedMessageFactory {
     }
 
     private String signMessage(byte[] message, PrivateKey privateKey) throws GeneralSecurityException {
-        Signature signature = Signature.getInstance(SIGNATURE_ALGORITHM, BOUNCY_CASTLE_PROVIDER);
+        Signature signature = Signature.getInstance(SIGNATURE_ALGORITHM, BouncyCastleProvider.PROVIDER_NAME);
         signature.initSign(privateKey, new SecureRandom());
         signature.update(message);
         return base64(signature.sign());

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/util/DecryptionHelper.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/util/DecryptionHelper.java
@@ -3,7 +3,6 @@ package com.yoti.api.client.spi.remote.util;
 import static javax.crypto.Cipher.DECRYPT_MODE;
 
 import static com.yoti.api.client.spi.remote.call.YotiConstants.ASYMMETRIC_CIPHER;
-import static com.yoti.api.client.spi.remote.call.YotiConstants.BOUNCY_CASTLE_PROVIDER;
 
 import java.security.GeneralSecurityException;
 import java.security.PrivateKey;
@@ -12,11 +11,13 @@ import javax.crypto.Cipher;
 
 import com.yoti.api.client.ProfileException;
 
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+
 public class DecryptionHelper {
 
     public static byte[] decryptAsymmetric(byte[] source, PrivateKey key) throws ProfileException {
         try {
-            Cipher cipher = Cipher.getInstance(ASYMMETRIC_CIPHER, BOUNCY_CASTLE_PROVIDER);
+            Cipher cipher = Cipher.getInstance(ASYMMETRIC_CIPHER, BouncyCastleProvider.PROVIDER_NAME);
             cipher.init(DECRYPT_MODE, key);
             return cipher.doFinal(source);
         } catch (GeneralSecurityException gse) {

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/util/CryptoUtil.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/util/CryptoUtil.java
@@ -1,11 +1,12 @@
 package com.yoti.api.client.spi.remote.util;
 
 import static com.yoti.api.client.spi.remote.call.YotiConstants.ASYMMETRIC_CIPHER;
-import static com.yoti.api.client.spi.remote.call.YotiConstants.BOUNCY_CASTLE_PROVIDER;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.SIGNATURE_ALGORITHM;
 import static com.yoti.api.client.spi.remote.call.YotiConstants.SYMMETRIC_CIPHER;
 
 import com.yoti.api.client.spi.remote.Base64;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.PEMKeyPair;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
@@ -74,14 +75,14 @@ public class CryptoUtil {
     }
 
     public static EncryptionResult encryptSymmetric(byte[] data, Key key) throws GeneralSecurityException {
-        Cipher cipher = Cipher.getInstance(SYMMETRIC_CIPHER, BOUNCY_CASTLE_PROVIDER);
+        Cipher cipher = Cipher.getInstance(SYMMETRIC_CIPHER, BouncyCastleProvider.PROVIDER_NAME);
         cipher.init(Cipher.ENCRYPT_MODE, key);
 
         return new EncryptionResult(cipher.doFinal(data), cipher.getIV());
     }
 
     public static byte[] encryptAsymmetric(byte[] data, Key key) throws GeneralSecurityException {
-        Cipher cipher = Cipher.getInstance(ASYMMETRIC_CIPHER, BOUNCY_CASTLE_PROVIDER);
+        Cipher cipher = Cipher.getInstance(ASYMMETRIC_CIPHER, BouncyCastleProvider.PROVIDER_NAME);
         cipher.init(Cipher.ENCRYPT_MODE, key);
 
         return cipher.doFinal(data);
@@ -103,13 +104,13 @@ public class CryptoUtil {
     }
 
     public static Key generateSymmetricKey() throws GeneralSecurityException {
-        KeyGenerator keyGen = KeyGenerator.getInstance(SYMMETRIC_KEY_ALGO, BOUNCY_CASTLE_PROVIDER);
+        KeyGenerator keyGen = KeyGenerator.getInstance(SYMMETRIC_KEY_ALGO, BouncyCastleProvider.PROVIDER_NAME);
         keyGen.init(SYMMETRIC_LENGTH);
         return keyGen.generateKey();
     }
 
     public static void verifyMessage(byte[] message, PublicKey publicKey, byte[] receivedSignature) throws GeneralSecurityException {
-        Signature signature = Signature.getInstance(SIGNATURE_ALGORITHM, BOUNCY_CASTLE_PROVIDER);
+        Signature signature = Signature.getInstance(SIGNATURE_ALGORITHM, BouncyCastleProvider.PROVIDER_NAME);
         signature.initVerify(publicKey);
         signature.update(message);
         Assert.assertTrue(signature.verify(receivedSignature));

--- a/yoti-sdk-spring-boot-example/src/main/resources/templates/index.html
+++ b/yoti-sdk-spring-boot-example/src/main/resources/templates/index.html
@@ -5,7 +5,7 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
         <title>Home</title>
-        <script src="https://sdk.yoti.com/clients/browser.2.1.0.js"></script>
+        <script src="https://sdk.yoti.com/clients/browser.2.2.0.js"></script>
     </head>
     <body>
     <p th:text="${rememberMeId}"/>


### PR DESCRIPTION
The real change is bumping the browser.js version.
I've also sneaked in a change for using BouncyCastle's own definition of its provider (i.e. "BC")