### PR TITLE
SDK-864: Add support for parsing INT attribute values

### DIFF
--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AttributeConverter.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AttributeConverter.java
@@ -67,6 +67,8 @@ class AttributeConverter {
                 return JSON_MAPPER.readValue(value.toString(DEFAULT_CHARSET), Map.class);
             case MULTI_VALUE:
                 return convertMultiValue(value);
+            case INT:
+                return Integer.parseInt(value.toString(DEFAULT_CHARSET));
             default:
                 LOG.warn("Unknown type '{}', attempting to parse it as a String", contentType);
                 return value.toString(DEFAULT_CHARSET);

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/AttributeConverterTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/AttributeConverterTest.java
@@ -44,6 +44,7 @@ public class AttributeConverterTest {
     private static final String SOME_DATE_VALUE = "1980-08-05";
     private static final byte[] SOME_IMAGE_BYTES = "someImageBytes".getBytes();
     private static final String GENDER_MALE = "MALE";
+    public static final Integer SOME_INT_VALUE = 123;
 
     @InjectMocks AttributeConverter testObj;
 
@@ -272,12 +273,6 @@ public class AttributeConverterTest {
         assertImageValue(list.get(0), "image/png", SOME_IMAGE_BYTES);
     }
 
-    private static void assertImageValue(Object result, String mimeType, byte[] content) {
-        Image image = (Image) result;
-        assertThat(image.getMimeType(), is(mimeType));
-        assertThat(image.getContent(), is(content));
-    }
-
     private static AttrProto.MultiValue createMultiValueTestData() {
         AttrProto.MultiValue.Value jpgImageValue = createMultiValueValue(ContentTypeProto.ContentType.JPEG, ByteString.copyFrom(SOME_IMAGE_BYTES));
         AttrProto.MultiValue inner = createMultiValue(jpgImageValue);
@@ -298,6 +293,26 @@ public class AttributeConverterTest {
         return AttrProto.MultiValue.newBuilder()
                 .addAllValues(asList(values))
                 .build();
+    }
+
+    private static void assertImageValue(Object result, String mimeType, byte[] content) {
+        Image image = (Image) result;
+        assertThat(image.getMimeType(), is(mimeType));
+        assertThat(image.getContent(), is(content));
+    }
+
+    @Test
+    public void shouldParseAnIntValue() throws Exception {
+        AttrProto.Attribute attribute = AttrProto.Attribute.newBuilder()
+                .setContentType(ContentTypeProto.ContentType.INT)
+                .setName(SOME_ATTRIBUTE_NAME)
+                .setValue(ByteString.copyFromUtf8(String.valueOf(SOME_INT_VALUE)))
+                .build();
+
+        Attribute<Integer> result = testObj.convertAttribute(attribute);
+
+        assertEquals(SOME_ATTRIBUTE_NAME, result.getName());
+        assertEquals(SOME_INT_VALUE, result.getValue());
     }
 
     private static <T> void assertListContains(List<T> result, List<T> expected) {


### PR DESCRIPTION
We just parse the value from _byte[]_ to _String_ to _Integer_.

Note that if we get an _empty_ value (protobuf equivalent to null), this will fail.  That's what I'd expect.  If they mean to give us 0 (zero), they should give us 0.  Giving us _empty_ is no good.