### PR TITLE
SDK-1095: Fix Auth Types

### DIFF
--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/shareurl/policy/DynamicPolicyBuilder.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/shareurl/policy/DynamicPolicyBuilder.java
@@ -87,6 +87,8 @@ public abstract class DynamicPolicyBuilder {
 
     public abstract DynamicPolicyBuilder withWantedAuthType(int wantedAuthType);
 
+    public abstract DynamicPolicyBuilder withWantedAuthType(int wantedAuthType, boolean enabled);
+
     public abstract DynamicPolicyBuilder withWantedRememberMe(boolean wantedRememberMe);
 
     public abstract DynamicPolicyBuilder withWantedRememberMeOptional(boolean wantedRememberMeOptional);

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilder.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilder.java
@@ -186,6 +186,8 @@ public class SimpleDynamicPolicyBuilder extends DynamicPolicyBuilder {
     public DynamicPolicyBuilder withSelfieAuthorisation(boolean enabled) {
         if (enabled) {
             return withWantedAuthType(SELFIE_AUTH_TYPE);
+        } else {
+            this.wantedAuthTypes.remove(SELFIE_AUTH_TYPE);
         }
         return this;
     }
@@ -200,6 +202,8 @@ public class SimpleDynamicPolicyBuilder extends DynamicPolicyBuilder {
     public DynamicPolicyBuilder withPinAuthorisation(boolean enabled) {
         if (enabled) {
             return withWantedAuthType(PIN_AUTH_TYPE);
+        } else {
+            this.wantedAuthTypes.remove(PIN_AUTH_TYPE);
         }
         return this;
     }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilder.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilder.java
@@ -184,12 +184,7 @@ public class SimpleDynamicPolicyBuilder extends DynamicPolicyBuilder {
 
     @Override
     public DynamicPolicyBuilder withSelfieAuthorisation(boolean enabled) {
-        if (enabled) {
-            return withWantedAuthType(SELFIE_AUTH_TYPE);
-        } else {
-            this.wantedAuthTypes.remove(SELFIE_AUTH_TYPE);
-        }
-        return this;
+        return this.withWantedAuthType(SELFIE_AUTH_TYPE, enabled);
     }
 
     @Override
@@ -200,18 +195,23 @@ public class SimpleDynamicPolicyBuilder extends DynamicPolicyBuilder {
 
     @Override
     public DynamicPolicyBuilder withPinAuthorisation(boolean enabled) {
-        if (enabled) {
-            return withWantedAuthType(PIN_AUTH_TYPE);
-        } else {
-            this.wantedAuthTypes.remove(PIN_AUTH_TYPE);
-        }
-        return this;
+        return this.withWantedAuthType(PIN_AUTH_TYPE, enabled);
     }
 
     @Override
     public DynamicPolicyBuilder withWantedAuthType(int wantedAuthType) {
         this.wantedAuthTypes.add(wantedAuthType);
         return this;
+    }
+
+    @Override
+    public DynamicPolicyBuilder withWantedAuthType(int wantedAuthType, boolean enabled) {
+        if (enabled) {
+            return this.withWantedAuthType(wantedAuthType);
+        } else {
+            this.wantedAuthTypes.remove(wantedAuthType);
+            return this;
+        }
     }
 
     @Override

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilderTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilderTest.java
@@ -183,7 +183,7 @@ public class SimpleDynamicPolicyBuilderTest {
     }
 
     @Test
-    public void buildWithRememberMeFlags() {
+    public void buildsWithRememberMeFlags() {
         DynamicPolicy result = new SimpleDynamicPolicyBuilder()
                 .withWantedRememberMe(true)
                 .withWantedRememberMeOptional(true)
@@ -194,7 +194,7 @@ public class SimpleDynamicPolicyBuilderTest {
     }
 
     @Test
-    public void buildWithSelfieAuthorisationEnabledThenDisabled() {
+    public void buildsWithSelfieAuthorisationEnabledThenDisabled() {
         DynamicPolicy result = new SimpleDynamicPolicyBuilder()
                 .withSelfieAuthorisation(true)
                 .withSelfieAuthorisation(false)
@@ -204,7 +204,7 @@ public class SimpleDynamicPolicyBuilderTest {
     }
 
     @Test
-    public void buildWithSelfieAuthorisationDisabledThenEnabled() {
+    public void buildsWithSelfieAuthorisationDisabledThenEnabled() {
         DynamicPolicy result = new SimpleDynamicPolicyBuilder()
                 .withSelfieAuthorisation(false)
                 .withSelfieAuthorisation(true)
@@ -214,7 +214,7 @@ public class SimpleDynamicPolicyBuilderTest {
     }
 
     @Test
-    public void buildWithPinAuthorisationEnabledThenDisabled() {
+    public void buildsWithPinAuthorisationEnabledThenDisabled() {
         DynamicPolicy result = new SimpleDynamicPolicyBuilder()
                 .withPinAuthorisation(true)
                 .withPinAuthorisation(false)
@@ -224,7 +224,7 @@ public class SimpleDynamicPolicyBuilderTest {
     }
 
     @Test
-    public void buildWithPinAuthorisationDisabledThenEnabled() {
+    public void buildsWithPinAuthorisationDisabledThenEnabled() {
         DynamicPolicy result = new SimpleDynamicPolicyBuilder()
                 .withPinAuthorisation(false)
                 .withPinAuthorisation(true)
@@ -233,7 +233,23 @@ public class SimpleDynamicPolicyBuilderTest {
         assertThat(result.getWantedAuthTypes(), hasItem(2));
     }
 
+    @Test
+    public void buildsWithSelfieAuthorisationDisabled() {
+        DynamicPolicy result = new SimpleDynamicPolicyBuilder()
+                .withSelfieAuthorisation(false)
+                .build();
 
+        assertThat(result.getWantedAuthTypes(), hasItem(1));
+    }
+
+    @Test
+    public void builsdWithPinAuthorisationDisabled() {
+        DynamicPolicy result = new SimpleDynamicPolicyBuilder()
+                .withPinAuthorisation(false)
+                .build();
+
+        assertThat(result.getWantedAuthTypes(), hasItem(2));
+    }
 
     private static class WantedAttributeMatcher extends TypeSafeDiagnosingMatcher<WantedAttribute> {
 

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilderTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilderTest.java
@@ -19,6 +19,7 @@ import static com.yoti.api.attributes.AttributeConstants.HumanProfileAttributes.
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -190,6 +191,26 @@ public class SimpleDynamicPolicyBuilderTest {
 
         assertTrue(result.isWantedRememberMe());
         assertTrue(result.isWantedRememberMeOptional());
+    }
+
+    @Test
+    public void buildWithSelfieAuthorisationEnabledThenDisabled() {
+        DynamicPolicy result = new SimpleDynamicPolicyBuilder()
+                .withSelfieAuthorisation(true)
+                .withSelfieAuthorisation(false)
+                .build();
+
+        assertThat(result.getWantedAuthTypes(), not(hasItem(1)));
+    }
+
+    @Test
+    public void buildWithPinAuthorisationEnabledThenDisabled() {
+        DynamicPolicy result = new SimpleDynamicPolicyBuilder()
+                .withPinAuthorisation(true)
+                .withPinAuthorisation(false)
+                .build();
+
+        assertThat(result.getWantedAuthTypes(), not(hasItem(2)));
     }
 
     private static class WantedAttributeMatcher extends TypeSafeDiagnosingMatcher<WantedAttribute> {

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilderTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilderTest.java
@@ -204,6 +204,16 @@ public class SimpleDynamicPolicyBuilderTest {
     }
 
     @Test
+    public void buildWithSelfieAuthorisationDisabledThenEnabled() {
+        DynamicPolicy result = new SimpleDynamicPolicyBuilder()
+                .withSelfieAuthorisation(false)
+                .withSelfieAuthorisation(true)
+                .build();
+
+        assertThat(result.getWantedAuthTypes(), hasItem(1));
+    }
+
+    @Test
     public void buildWithPinAuthorisationEnabledThenDisabled() {
         DynamicPolicy result = new SimpleDynamicPolicyBuilder()
                 .withPinAuthorisation(true)
@@ -212,6 +222,18 @@ public class SimpleDynamicPolicyBuilderTest {
 
         assertThat(result.getWantedAuthTypes(), not(hasItem(2)));
     }
+
+    @Test
+    public void buildWithPinAuthorisationDisabledThenEnabled() {
+        DynamicPolicy result = new SimpleDynamicPolicyBuilder()
+                .withPinAuthorisation(false)
+                .withPinAuthorisation(true)
+                .build();
+
+        assertThat(result.getWantedAuthTypes(), hasItem(2));
+    }
+
+
 
     private static class WantedAttributeMatcher extends TypeSafeDiagnosingMatcher<WantedAttribute> {
 

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilderTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilderTest.java
@@ -30,6 +30,9 @@ import org.junit.Test;
 
 public class SimpleDynamicPolicyBuilderTest {
 
+    private static final int EXPECTED_SELFIE_AUTH_TYPE = 1;
+    private static final int EXPECTED_PIN_AUTH_TYPE = 2;
+
     @Test
     public void ensuresAnAttributeCanOnlyExistOnce() {
         WantedAttribute wantedAttribute = WantedAttributeBuilder.newInstance()
@@ -157,7 +160,7 @@ public class SimpleDynamicPolicyBuilderTest {
                 .build();
 
         assertThat(result.getWantedAuthTypes(), Matchers.hasSize(3));
-        assertThat(result.getWantedAuthTypes(), hasItems(1, 2, 99));
+        assertThat(result.getWantedAuthTypes(), hasItems(EXPECTED_SELFIE_AUTH_TYPE, EXPECTED_PIN_AUTH_TYPE, 99));
     }
 
     @Test
@@ -169,7 +172,7 @@ public class SimpleDynamicPolicyBuilderTest {
                 .build();
 
         assertThat(result.getWantedAuthTypes(), Matchers.hasSize(3));
-        assertThat(result.getWantedAuthTypes(), hasItems(1, 2, 99));
+        assertThat(result.getWantedAuthTypes(), hasItems(EXPECTED_SELFIE_AUTH_TYPE, EXPECTED_PIN_AUTH_TYPE, 99));
     }
 
     @Test
@@ -200,7 +203,8 @@ public class SimpleDynamicPolicyBuilderTest {
                 .withSelfieAuthorisation(false)
                 .build();
 
-        assertThat(result.getWantedAuthTypes(), not(hasItem(1)));
+        assertThat(result.getWantedAuthTypes(), not(hasItem(EXPECTED_SELFIE_AUTH_TYPE)));
+        assertThat(result.getWantedAuthTypes(), Matchers.hasSize(0));
     }
 
     @Test
@@ -210,7 +214,8 @@ public class SimpleDynamicPolicyBuilderTest {
                 .withSelfieAuthorisation(true)
                 .build();
 
-        assertThat(result.getWantedAuthTypes(), hasItem(1));
+        assertThat(result.getWantedAuthTypes(), hasItem(EXPECTED_SELFIE_AUTH_TYPE));
+        assertThat(result.getWantedAuthTypes(), Matchers.hasSize(1));
     }
 
     @Test
@@ -220,7 +225,8 @@ public class SimpleDynamicPolicyBuilderTest {
                 .withPinAuthorisation(false)
                 .build();
 
-        assertThat(result.getWantedAuthTypes(), not(hasItem(2)));
+        assertThat(result.getWantedAuthTypes(), not(hasItem(EXPECTED_PIN_AUTH_TYPE)));
+        assertThat(result.getWantedAuthTypes(), Matchers.hasSize(0));
     }
 
     @Test
@@ -230,7 +236,8 @@ public class SimpleDynamicPolicyBuilderTest {
                 .withPinAuthorisation(true)
                 .build();
 
-        assertThat(result.getWantedAuthTypes(), hasItem(2));
+        assertThat(result.getWantedAuthTypes(), hasItem(EXPECTED_PIN_AUTH_TYPE));
+        assertThat(result.getWantedAuthTypes(), Matchers.hasSize(1));
     }
 
     @Test
@@ -239,7 +246,8 @@ public class SimpleDynamicPolicyBuilderTest {
                 .withSelfieAuthorisation(false)
                 .build();
 
-        assertThat(result.getWantedAuthTypes(), not(hasItem(1)));
+        assertThat(result.getWantedAuthTypes(), not(hasItem(EXPECTED_SELFIE_AUTH_TYPE)));
+        assertThat(result.getWantedAuthTypes(), Matchers.hasSize(0));
     }
 
     @Test
@@ -248,7 +256,8 @@ public class SimpleDynamicPolicyBuilderTest {
                 .withPinAuthorisation(false)
                 .build();
 
-        assertThat(result.getWantedAuthTypes(), not(hasItem(2)));
+        assertThat(result.getWantedAuthTypes(), not(hasItem(EXPECTED_PIN_AUTH_TYPE)));
+        assertThat(result.getWantedAuthTypes(), Matchers.hasSize(0));
     }
 
     private static class WantedAttributeMatcher extends TypeSafeDiagnosingMatcher<WantedAttribute> {

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilderTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilderTest.java
@@ -243,7 +243,7 @@ public class SimpleDynamicPolicyBuilderTest {
     }
 
     @Test
-    public void builsdWithPinAuthorisationDisabled() {
+    public void buildsWithPinAuthorisationDisabled() {
         DynamicPolicy result = new SimpleDynamicPolicyBuilder()
                 .withPinAuthorisation(false)
                 .build();

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilderTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilderTest.java
@@ -239,7 +239,7 @@ public class SimpleDynamicPolicyBuilderTest {
                 .withSelfieAuthorisation(false)
                 .build();
 
-        assertThat(result.getWantedAuthTypes(), hasItem(1));
+        assertThat(result.getWantedAuthTypes(), not(hasItem(1)));
     }
 
     @Test
@@ -248,7 +248,7 @@ public class SimpleDynamicPolicyBuilderTest {
                 .withPinAuthorisation(false)
                 .build();
 
-        assertThat(result.getWantedAuthTypes(), hasItem(2));
+        assertThat(result.getWantedAuthTypes(), not(hasItem(2)));
     }
 
     private static class WantedAttributeMatcher extends TypeSafeDiagnosingMatcher<WantedAttribute> {


### PR DESCRIPTION
- Update the logic in withSelfieAuthorisation and withPinAuthorisation to allow the user to set to false
- Write unit tests to support chaining these methods gives the desired outcome (as well as checking no exceptions are raised if set to false without first turning it on)