### PR TITLE
SDK-854: Only allow string attributes to have empty value

### DIFF
--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AttributeConverter.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/AttributeConverter.java
@@ -54,6 +54,11 @@ class AttributeConverter {
     }
 
     private Object convertValue(ContentTypeProto.ContentType contentType, ByteString value) throws ParseException, IOException {
+        boolean isInvalid = (contentType != ContentTypeProto.ContentType.STRING && value.isEmpty());
+        if (isInvalid) {
+            throw new ParseException("Only STRING attributes can have an empty value", 0);
+        }
+
         switch (contentType) {
             case STRING:
                 return value.toString(DEFAULT_CHARSET);

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/AttributeConverterTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/AttributeConverterTest.java
@@ -289,7 +289,7 @@ public class AttributeConverterTest {
     }
 
     @Test(expected = Exception.class)
-    public void shouldNotParseNonStringAttributeWithEmptyValue() throws Exception {
+    public void shouldNotParseDateWithEmptyValue() throws Exception {
         AttrProto.Attribute attribute = AttrProto.Attribute.newBuilder()
                 .setContentType(ContentTypeProto.ContentType.DATE)
                 .setName(SOME_ATTRIBUTE_NAME)
@@ -297,6 +297,61 @@ public class AttributeConverterTest {
                 .build();
 
         Attribute<Date> result = testObj.convertAttribute(attribute);
+    }
+
+    @Test(expected = Exception.class)
+    public void shouldNotParseJpegAttributeWithEmptyValue() throws Exception {
+        AttrProto.Attribute attribute = AttrProto.Attribute.newBuilder()
+                .setContentType(ContentTypeProto.ContentType.JPEG)
+                .setName(SOME_ATTRIBUTE_NAME)
+                .setValue(ByteString.copyFromUtf8(EMPTY_STRING))
+                .build();
+
+        Attribute<JpegAttributeValue> result = testObj.convertAttribute(attribute);
+    }
+
+    @Test(expected = Exception.class)
+    public void shouldNotParsePngAttributeWithEmptyValue() throws Exception {
+        AttrProto.Attribute attribute = AttrProto.Attribute.newBuilder()
+                .setContentType(ContentTypeProto.ContentType.PNG)
+                .setName(SOME_ATTRIBUTE_NAME)
+                .setValue(ByteString.copyFromUtf8(EMPTY_STRING))
+                .build();
+
+        Attribute<PngAttributeValue> result = testObj.convertAttribute(attribute);
+    }
+
+    @Test(expected = Exception.class)
+    public void shouldNotParseJsonAttributeWithEmptyValue() throws Exception {
+        AttrProto.Attribute attribute = AttrProto.Attribute.newBuilder()
+                .setContentType(ContentTypeProto.ContentType.JSON)
+                .setName(SOME_ATTRIBUTE_NAME)
+                .setValue(ByteString.copyFromUtf8(EMPTY_STRING))
+                .build();
+
+        Attribute<Map> result = testObj.convertAttribute(attribute);
+    }
+
+    @Test(expected = Exception.class)
+    public void shouldNotParseMultiValueAttributeWithEmptyValue() throws Exception {
+        AttrProto.Attribute attribute = AttrProto.Attribute.newBuilder()
+                .setContentType(ContentTypeProto.ContentType.MULTI_VALUE)
+                .setName(SOME_ATTRIBUTE_NAME)
+                .setValue(ByteString.copyFromUtf8(EMPTY_STRING))
+                .build();
+
+        Attribute<List<Object>> result = testObj.convertAttribute(attribute);
+    }
+
+    @Test(expected = Exception.class)
+    public void shouldNotParseIntAttributeWithEmptyValue() throws Exception {
+        AttrProto.Attribute attribute = AttrProto.Attribute.newBuilder()
+                .setContentType(ContentTypeProto.ContentType.INT)
+                .setName(SOME_ATTRIBUTE_NAME)
+                .setValue(ByteString.copyFromUtf8(EMPTY_STRING))
+                .build();
+
+        Attribute<Integer> result = testObj.convertAttribute(attribute);
     }
 
     private static AttrProto.MultiValue createMultiValueTestData() {

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/AttributeConverterTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/AttributeConverterTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.security.cert.CertificateException;
+import java.text.ParseException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -288,7 +289,7 @@ public class AttributeConverterTest {
         assertEquals(EMPTY_STRING, result.getValue());
     }
 
-    @Test(expected = Exception.class)
+    @Test(expected = ParseException.class)
     public void shouldNotParseDateWithEmptyValue() throws Exception {
         AttrProto.Attribute attribute = AttrProto.Attribute.newBuilder()
                 .setContentType(ContentTypeProto.ContentType.DATE)
@@ -299,7 +300,7 @@ public class AttributeConverterTest {
         Attribute<Date> result = testObj.convertAttribute(attribute);
     }
 
-    @Test(expected = Exception.class)
+    @Test(expected = ParseException.class)
     public void shouldNotParseJpegAttributeWithEmptyValue() throws Exception {
         AttrProto.Attribute attribute = AttrProto.Attribute.newBuilder()
                 .setContentType(ContentTypeProto.ContentType.JPEG)
@@ -310,7 +311,7 @@ public class AttributeConverterTest {
         Attribute<JpegAttributeValue> result = testObj.convertAttribute(attribute);
     }
 
-    @Test(expected = Exception.class)
+    @Test(expected = ParseException.class)
     public void shouldNotParsePngAttributeWithEmptyValue() throws Exception {
         AttrProto.Attribute attribute = AttrProto.Attribute.newBuilder()
                 .setContentType(ContentTypeProto.ContentType.PNG)
@@ -321,7 +322,7 @@ public class AttributeConverterTest {
         Attribute<PngAttributeValue> result = testObj.convertAttribute(attribute);
     }
 
-    @Test(expected = Exception.class)
+    @Test(expected = ParseException.class)
     public void shouldNotParseJsonAttributeWithEmptyValue() throws Exception {
         AttrProto.Attribute attribute = AttrProto.Attribute.newBuilder()
                 .setContentType(ContentTypeProto.ContentType.JSON)
@@ -332,7 +333,7 @@ public class AttributeConverterTest {
         Attribute<Map> result = testObj.convertAttribute(attribute);
     }
 
-    @Test(expected = Exception.class)
+    @Test(expected = ParseException.class)
     public void shouldNotParseMultiValueAttributeWithEmptyValue() throws Exception {
         AttrProto.Attribute attribute = AttrProto.Attribute.newBuilder()
                 .setContentType(ContentTypeProto.ContentType.MULTI_VALUE)
@@ -343,7 +344,7 @@ public class AttributeConverterTest {
         Attribute<List<Object>> result = testObj.convertAttribute(attribute);
     }
 
-    @Test(expected = Exception.class)
+    @Test(expected = ParseException.class)
     public void shouldNotParseIntAttributeWithEmptyValue() throws Exception {
         AttrProto.Attribute attribute = AttrProto.Attribute.newBuilder()
                 .setContentType(ContentTypeProto.ContentType.INT)

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/AttributeConverterTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/AttributeConverterTest.java
@@ -44,6 +44,7 @@ public class AttributeConverterTest {
     private static final String SOME_DATE_VALUE = "1980-08-05";
     private static final byte[] SOME_IMAGE_BYTES = "someImageBytes".getBytes();
     private static final String GENDER_MALE = "MALE";
+    private static final String EMPTY_STRING = "";
     public static final Integer SOME_INT_VALUE = 123;
 
     @InjectMocks AttributeConverter testObj;
@@ -271,6 +272,31 @@ public class AttributeConverterTest {
         List<Object> list = result.getValue();
         assertThat(list.size(), is(1));
         assertImageValue(list.get(0), "image/png", SOME_IMAGE_BYTES);
+    }
+
+    @Test
+    public void shouldParseStringAttributeWithEmptyValue() throws Exception {
+        AttrProto.Attribute attribute = AttrProto.Attribute.newBuilder()
+                .setContentType(ContentTypeProto.ContentType.STRING)
+                .setName(SOME_ATTRIBUTE_NAME)
+                .setValue(ByteString.copyFromUtf8(""))
+                .build();
+
+        Attribute<String> result = testObj.convertAttribute(attribute);
+
+        assertEquals(SOME_ATTRIBUTE_NAME, result.getName());
+        assertEquals(EMPTY_STRING, result.getValue());
+    }
+
+    @Test(expected = Exception.class)
+    public void shouldNotParseNonStringAttributeWithEmptyValue() throws Exception {
+        AttrProto.Attribute attribute = AttrProto.Attribute.newBuilder()
+                .setContentType(ContentTypeProto.ContentType.DATE)
+                .setName(SOME_ATTRIBUTE_NAME)
+                .setValue(ByteString.copyFromUtf8(EMPTY_STRING))
+                .build();
+
+        Attribute<Date> result = testObj.convertAttribute(attribute);
     }
 
     private static AttrProto.MultiValue createMultiValueTestData() {


### PR DESCRIPTION
- Update AttributeConverter to throw a ParseException if the attribute content type is not a string, and has an empty value field.
- Write tests to support this functionality for each attribute content type