### PR TITLE
SDK-1099: Update jackson-databind version number due to vulnerabilities

### DIFF
--- a/yoti-sdk-parent/pom.xml
+++ b/yoti-sdk-parent/pom.xml
@@ -102,7 +102,7 @@
     <!-- sdk dependency versions -->
     <slf4j.version>1.7.26</slf4j.version>
     <bouncy.castle.version>1.60</bouncy.castle.version>
-    <jackson.version>2.9.8</jackson.version>
+    <jackson.version>2.9.9.2</jackson.version>
     <google.protobuf.version>3.5.1</google.protobuf.version>
   
     <!-- spring versions -->


### PR DESCRIPTION
- Updated jackson library from 2.9.8 -> 2.9.9.2 due to vulnerabilities raised from OWASP.