### PR TITLE
SDK-1103: Support for JDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,3 +46,9 @@ jobs:
     - <<: *test-compatability
       dist: bionic
       jdk: openjdk10
+    - <<: *test-compatability
+      dist: bionic
+      jdk: openjdk11
+    - <<: *test-compatability
+      dist: bionic
+      jdk: oraclejdk11

--- a/yoti-sdk-parent/pom.xml
+++ b/yoti-sdk-parent/pom.xml
@@ -113,7 +113,7 @@
 
     <!-- test libraries -->
     <junit.version>4.12</junit.version>
-    <mockito.version>2.18.3</mockito.version>
+    <mockito.version>2.23.4</mockito.version>
     <hamcrest.version>1.3</hamcrest.version>
     <commons.lang3.version>3.7</commons.lang3.version>
 
@@ -132,7 +132,7 @@
     <mojo.signature.version>1.0</mojo.signature.version>
     <mojo.extra.rules.version>1.0-beta-7</mojo.extra.rules.version>
     <nexus.plugin.version>1.6.8</nexus.plugin.version>
-    <javadoc.plugin.version>3.0.1</javadoc.plugin.version>
+    <javadoc.plugin.version>3.1.0</javadoc.plugin.version>
     <gpg.plugin.version>1.6</gpg.plugin.version>
     
   </properties>


### PR DESCRIPTION
- Update javadoc plugin version 2.18.3 -> 2.23.4
- Update mockito plugin version 3.0.1 -> 3.1.0
- Tested with JDK 11 as problem was with generation of Javadocs