### PR TITLE
SDK-1101: Add dependency-check suppression for spring-security

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,27 +14,27 @@ jobs:
   include:
     - state: Test
       jdk: oraclejdk8
-      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true
+      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -Dowasp.dependency.check.cve.update.limit=6
       script:
         - ./mvnw test -B
     - &test-compatability
       stage: Compatability
       jdk: oraclejdk8
       os: linux
-      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true
+      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -Dowasp.dependency.check.cve.update.limit=6
       script:
         - ./mvnw test -B
     - <<: *test-compatability
       # Only the api and implementation need testing with Java 1.7
       dist: precise
       jdk: oraclejdk7
-      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -pl !yoti-sdk-spring-boot-example
+      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -pl !yoti-sdk-spring-boot-example -Dowasp.dependency.check.cve.update.limit=6
       script:
         - ./mvnw test -B -pl yoti-sdk-api,yoti-sdk-impl
     - <<: *test-compatability
       dist: precise
       jdk: openjdk7
-      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -pl !yoti-sdk-spring-boot-example
+      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -pl !yoti-sdk-spring-boot-example -Dowasp.dependency.check.cve.update.limit=6
       script:
         - ./mvnw test -B -pl yoti-sdk-api,yoti-sdk-impl
     - <<: *test-compatability

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
     $HOME/.m2
 
 env:
-  - JAVA_TOOL_OPTIONS=-Dhttps.protocols=TLSv1.2
+  - JAVA_TOOL_OPTIONS=-Dhttps.protocols=TLSv1.2 -Ddependency-check.skip=true
 
 git:
   depth: 3
@@ -14,27 +14,27 @@ jobs:
   include:
     - state: Test
       jdk: oraclejdk8
-      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -Dowasp.dependency.check.cve.update.limit=1
+      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true
       script:
         - ./mvnw test -B
     - &test-compatability
       stage: Compatability
       jdk: oraclejdk8
       os: linux
-      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -Dowasp.dependency.check.cve.update.limit=1
+      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true
       script:
         - ./mvnw test -B
     - <<: *test-compatability
       # Only the api and implementation need testing with Java 1.7
       dist: precise
       jdk: oraclejdk7
-      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -pl !yoti-sdk-spring-boot-example -Dowasp.dependency.check.cve.update.limit=1
+      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -pl yoti-sdk-api,yoti-sdk-impl
       script:
         - ./mvnw test -B -pl yoti-sdk-api,yoti-sdk-impl
     - <<: *test-compatability
       dist: precise
       jdk: openjdk7
-      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -pl !yoti-sdk-spring-boot-example -Dowasp.dependency.check.cve.update.limit=1
+      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -pl yoti-sdk-api,yoti-sdk-impl
       script:
         - ./mvnw test -B -pl yoti-sdk-api,yoti-sdk-impl
     - <<: *test-compatability

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,27 +14,27 @@ jobs:
   include:
     - state: Test
       jdk: oraclejdk8
-      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -Ddependency-check.skip=true
+      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true
       script:
         - ./mvnw test -B
     - &test-compatability
       stage: Compatability
       jdk: oraclejdk8
       os: linux
-      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -Ddependency-check.skip=true
+      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true
       script:
         - ./mvnw test -B
     - <<: *test-compatability
       # Only the api and implementation need testing with Java 1.7
       dist: precise
       jdk: oraclejdk7
-      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -Ddependency-check.skip=true -pl !yoti-sdk-spring-boot-example
+      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -pl !yoti-sdk-spring-boot-example
       script:
         - ./mvnw test -B -pl yoti-sdk-api,yoti-sdk-impl
     - <<: *test-compatability
       dist: precise
       jdk: openjdk7
-      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -Ddependency-check.skip=true -pl !yoti-sdk-spring-boot-example
+      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -pl !yoti-sdk-spring-boot-example
       script:
         - ./mvnw test -B -pl yoti-sdk-api,yoti-sdk-impl
     - <<: *test-compatability

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
     $HOME/.m2
 
 env:
-  - JAVA_TOOL_OPTIONS=-Dhttps.protocols=TLSv1.2 -Ddependency-check.skip=true
+  - JAVA_TOOL_OPTIONS=-Dhttps.protocols=TLSv1.2
 
 git:
   depth: 3
@@ -14,29 +14,29 @@ jobs:
   include:
     - state: Test
       jdk: oraclejdk8
-      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true
+      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -Ddependency-check.skip=true
       script:
-        - ./mvnw test -B
+        - ./mvnw test -B -Ddependency-check.skip=true
     - &test-compatability
       stage: Compatability
       jdk: oraclejdk8
       os: linux
-      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true
+      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -Ddependency-check.skip=true
       script:
-        - ./mvnw test -B
+        - ./mvnw test -B -Ddependency-check.skip=true
     - <<: *test-compatability
       # Only the api and implementation need testing with Java 1.7
       dist: precise
       jdk: oraclejdk7
-      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -pl yoti-sdk-api,yoti-sdk-impl
+      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -pl yoti-sdk-api,yoti-sdk-impl -Ddependency-check.skip=true
       script:
-        - ./mvnw test -B -pl yoti-sdk-api,yoti-sdk-impl
+        - ./mvnw test -B -pl yoti-sdk-api,yoti-sdk-impl -Ddependency-check.skip=true
     - <<: *test-compatability
       dist: precise
       jdk: openjdk7
-      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -pl yoti-sdk-api,yoti-sdk-impl
+      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -pl yoti-sdk-api,yoti-sdk-impl -Ddependency-check.skip=true
       script:
-        - ./mvnw test -B -pl yoti-sdk-api,yoti-sdk-impl
+        - ./mvnw test -B -pl yoti-sdk-api,yoti-sdk-impl -Ddependency-check.skip=true
     - <<: *test-compatability
       jdk: openjdk8
     - <<: *test-compatability

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,27 +14,27 @@ jobs:
   include:
     - state: Test
       jdk: oraclejdk8
-      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -Dowasp.dependency.check.cve.update.limit=6
+      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -Dowasp.dependency.check.cve.update.limit=1
       script:
         - ./mvnw test -B
     - &test-compatability
       stage: Compatability
       jdk: oraclejdk8
       os: linux
-      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -Dowasp.dependency.check.cve.update.limit=6
+      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -Dowasp.dependency.check.cve.update.limit=1
       script:
         - ./mvnw test -B
     - <<: *test-compatability
       # Only the api and implementation need testing with Java 1.7
       dist: precise
       jdk: oraclejdk7
-      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -pl !yoti-sdk-spring-boot-example -Dowasp.dependency.check.cve.update.limit=6
+      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -pl !yoti-sdk-spring-boot-example -Dowasp.dependency.check.cve.update.limit=1
       script:
         - ./mvnw test -B -pl yoti-sdk-api,yoti-sdk-impl
     - <<: *test-compatability
       dist: precise
       jdk: openjdk7
-      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -pl !yoti-sdk-spring-boot-example -Dowasp.dependency.check.cve.update.limit=6
+      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -pl !yoti-sdk-spring-boot-example -Dowasp.dependency.check.cve.update.limit=1
       script:
         - ./mvnw test -B -pl yoti-sdk-api,yoti-sdk-impl
     - <<: *test-compatability

--- a/yoti-sdk-parent/pom.xml
+++ b/yoti-sdk-parent/pom.xml
@@ -108,7 +108,7 @@
     <!-- spring versions -->
     <springboot.version>1.5.10.RELEASE</springboot.version>
     <spring.core.version>4.3.22.RELEASE</spring.core.version>
-    <spring.security.version>4.2.6.RELEASE</spring.security.version>
+    <spring.security.version>4.2.13.RELEASE</spring.security.version>
     <javax.servlet.version>2.5</javax.servlet.version>
 
     <!-- test libraries -->

--- a/yoti-sdk-parent/suppressed-cves.xml
+++ b/yoti-sdk-parent/suppressed-cves.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
-
+    <suppress>
+        <cve>CVE-2018-1258</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
- Vunerability CVE-2018-1258 for spring-security has not been fixed in the latest 5.X release.
- Added a dependency-check suppression until this vulnerability has been fixed.