### PR TITLE
SDK-1107: Update Javadocs to HTML5 spec

### DIFF
--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/Base64.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/Base64.java
@@ -38,21 +38,21 @@ package com.yoti.api.client.spi.remote;
  * <a href="http://www.ietf.org/rfc/rfc2045.txt">RFC 2045</a>.
  *
  * <ul>
- * <li><a name="basic"><b>Basic</b></a>
+ * <li><a id="basic"><b>Basic</b></a>
  * <p> Uses "The Base64 Alphabet" as specified in Table 1 of
  *     RFC 4648 and RFC 2045 for encoding and decoding operation.
  *     The encoder does not add any line feed (line separator)
  *     character. The decoder rejects data that contains characters
  *     outside the base64 alphabet.</p></li>
  *
- * <li><a name="url"><b>URL and Filename safe</b></a>
+ * <li><a id="url"><b>URL and Filename safe</b></a>
  * <p> Uses the "URL and Filename safe Base64 Alphabet" as specified
  *     in Table 2 of RFC 4648 for encoding and decoding. The
  *     encoder does not add any line feed (line separator) character.
  *     The decoder rejects data that contains characters outside the
  *     base64 alphabet.</p></li>
  *
- * <li><a name="mime"><b>MIME</b></a>
+ * <li><a id="mime"><b>MIME</b></a>
  * <p> Uses the "The Base64 Alphabet" as specified in Table 1 of
  *     RFC 2045 for encoding and decoding operation. The encoded output
  *     must be represented in lines of no more than 76 characters each

--- a/yoti-sdk-parent/pom.xml
+++ b/yoti-sdk-parent/pom.xml
@@ -133,6 +133,7 @@
     <mojo.extra.rules.version>1.0-beta-7</mojo.extra.rules.version>
     <nexus.plugin.version>1.6.8</nexus.plugin.version>
     <javadoc.plugin.version>3.1.0</javadoc.plugin.version>
+    <javadoc.plugin.source>8</javadoc.plugin.source>
     <gpg.plugin.version>1.6</gpg.plugin.version>
     
   </properties>
@@ -409,7 +410,7 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>${javadoc.plugin.version}</version>
           <configuration>
-            <source>8</source>
+            <source>${javadoc.plugin.source}</source>
           </configuration>
           <executions>
             <execution>

--- a/yoti-sdk-parent/pom.xml
+++ b/yoti-sdk-parent/pom.xml
@@ -408,6 +408,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>${javadoc.plugin.version}</version>
+          <configuration>
+            <source>8</source>
+          </configuration>
           <executions>
             <execution>
               <id>attach-javadocs</id>


### PR DESCRIPTION
- Building with Java 11 was failing due to using HTML elements that have been deprecated in the HTML5 spec.
- Change these to use HTML5 spec
- Update source target version to 8 for Javadocs