### PR TITLE
SDK-1109: Add ability to add WantedAttribute by name

### DIFF
--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/shareurl/policy/DynamicPolicyBuilder.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/shareurl/policy/DynamicPolicyBuilder.java
@@ -17,6 +17,8 @@ public abstract class DynamicPolicyBuilder {
 
     public abstract DynamicPolicyBuilder withWantedAttribute(WantedAttribute wantedAttribute);
 
+    public abstract DynamicPolicyBuilder withWantedAttribute(boolean optional, String name);
+
     public abstract DynamicPolicyBuilder withFamilyName(boolean optional);
 
     public abstract DynamicPolicyBuilder withFamilyName();

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilder.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilder.java
@@ -29,7 +29,8 @@ public class SimpleDynamicPolicyBuilder extends DynamicPolicyBuilder {
         return this;
     }
 
-    private DynamicPolicyBuilder withWantedAttribute(boolean optional, String name) {
+    @Override
+    public DynamicPolicyBuilder withWantedAttribute(boolean optional, String name) {
         WantedAttribute wantedAttribute = new SimpleWantedAttributeBuilder()
                 .withName(name)
                 .withOptional(optional)

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilderTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilderTest.java
@@ -260,6 +260,26 @@ public class SimpleDynamicPolicyBuilderTest {
         assertThat(result.getWantedAuthTypes(), Matchers.hasSize(0));
     }
 
+    @Test
+    public void buildsWithWantedAttributeByNameWithOptionalTrue() {
+        DynamicPolicy result = new SimpleDynamicPolicyBuilder()
+                .withWantedAttribute(true, GIVEN_NAMES)
+                .build();
+
+        assertThat(result.getWantedAttributes(), Matchers.hasSize(1));
+        assertThat(result.getWantedAttributes(), hasItem(WantedAttributeMatcher.forAttribute(GIVEN_NAMES, true)));
+    }
+
+    @Test
+    public void buildsWithWantedAttributeByNameWithOptionalFalse() {
+        DynamicPolicy result = new SimpleDynamicPolicyBuilder()
+                .withWantedAttribute(false, GIVEN_NAMES)
+                .build();
+
+        assertThat(result.getWantedAttributes(), Matchers.hasSize(1));
+        assertThat(result.getWantedAttributes(), hasItem(WantedAttributeMatcher.forAttribute(GIVEN_NAMES, false)));
+    }
+
     private static class WantedAttributeMatcher extends TypeSafeDiagnosingMatcher<WantedAttribute> {
 
         private static final String TEMPLATE = "{ name: '%s', derivation: '%s',  optional: '%s' }";


### PR DESCRIPTION
- To bring the Java SDK inline with others, expose the functionality to add a WantedAttribute by name through the DynamicPolicyBuilder