### PR TITLE
SDK-1162: Signed Request Builder

### DIFF
--- a/yoti-sdk-impl/findbugs-rules.xml
+++ b/yoti-sdk-impl/findbugs-rules.xml
@@ -10,6 +10,16 @@
         <Class name="com.yoti.api.client.spi.remote.call.Receipt"/>
         <Bug pattern="EI_EXPOSE_REP"/>
     </Match>
+    
+    <Match>
+        <Class name="com.yoti.api.client.spi.remote.call.SignedRequest" />
+        <Bug pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS" />
+    </Match>
+    
+    <Match>
+        <Class name="com.yoti.api.client.spi.remote.call.SignedRequestBuilder" />
+        <Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR,EI_EXPOSE_REP2" />
+    </Match>
 
     <Match>
         <Package name="com.yoti.api.client.spi.remote.proto"/>

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/HttpMethod.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/HttpMethod.java
@@ -1,6 +1,18 @@
 package com.yoti.api.client.spi.remote.call;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+
+import java.util.List;
+
 public class HttpMethod {
+
     public static final String HTTP_GET = "GET";
     public static final String HTTP_POST = "POST";
+    public static final String HTTP_PUT = "PUT";
+    public static final String HTTP_PATCH = "PATCH";
+    public static final String HTTP_DELETE = "DELETE";
+
+    public static final List<String> SUPPORTED_HTTP_METHODS = unmodifiableList(asList(HTTP_POST, HTTP_PUT, HTTP_PATCH, HTTP_GET, HTTP_DELETE));
+
 }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/JsonResourceFetcher.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/JsonResourceFetcher.java
@@ -32,15 +32,17 @@ public final class JsonResourceFetcher implements ResourceFetcher {
 
     @Override
     public <T> T fetchResource(UrlConnector urlConnector, Map<String, String> headers, Class<T> resourceClass) throws ResourceException, IOException {
-        HttpURLConnection httpUrlConnection = openConnection(urlConnector, HTTP_GET, headers);
-        return parseResponse(httpUrlConnection, resourceClass);
+        return doRequest(urlConnector, HTTP_GET, null, headers, resourceClass);
     }
 
     @Override
     public <T> T postResource(UrlConnector urlConnector, byte[] body, Map<String, String> headers, Class<T> resourceClass)
             throws ResourceException, IOException {
+        return doRequest(urlConnector, HTTP_POST, body, headers, resourceClass);
+    }
 
-        HttpURLConnection httpUrlConnection = openConnection(urlConnector, HTTP_POST, headers);
+    public <T> T doRequest(UrlConnector urlConnector, String httpMethod, byte[] body, Map<String, String> headers, Class<T> resourceClass) throws ResourceException, IOException {
+        HttpURLConnection httpUrlConnection = openConnection(urlConnector, httpMethod, headers);
         sendBody(body, httpUrlConnection);
         return parseResponse(httpUrlConnection, resourceClass);
     }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/SignedRequest.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/SignedRequest.java
@@ -1,0 +1,48 @@
+package com.yoti.api.client.spi.remote.call;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+
+public class SignedRequest {
+
+    private final URI uri;
+    private final String method;
+    private final byte[] data;
+    private final Map<String, String> headers;
+    private final JsonResourceFetcher jsonResourceFetcher;
+
+    SignedRequest(final URI uri,
+            final String method,
+            final byte[] data,
+            final Map<String, String> headers,
+            JsonResourceFetcher jsonResourceFetcher) {
+
+        this.uri = uri;
+        this.method = method;
+        this.data = data;
+        this.headers = headers;
+        this.jsonResourceFetcher = jsonResourceFetcher;
+    }
+
+    public URI getUri() {
+        return uri;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public byte[] getData() {
+        return data != null ? data.clone() : null;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    public <T> T execute(Class<T> clazz) throws ResourceException, IOException {
+        UrlConnector urlConnector = UrlConnector.get(uri.toString());
+        return jsonResourceFetcher.doRequest(urlConnector, getMethod(), getData(), getHeaders(), clazz);
+    }
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/SignedRequestBuilder.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/SignedRequestBuilder.java
@@ -1,0 +1,188 @@
+package com.yoti.api.client.spi.remote.call;
+
+import static com.yoti.api.client.spi.remote.call.HttpMethod.SUPPORTED_HTTP_METHODS;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.yoti.api.client.spi.remote.call.factory.HeadersFactory;
+import com.yoti.api.client.spi.remote.call.factory.PathFactory;
+import com.yoti.api.client.spi.remote.call.factory.SignedMessageFactory;
+import com.yoti.api.client.spi.remote.util.Validation;
+
+public class SignedRequestBuilder {
+
+    public static SignedRequestBuilder newInstance() {
+        return new SignedRequestBuilder(
+                new PathFactory(),
+                SignedMessageFactory.newInstance(),
+                new HeadersFactory(),
+                JsonResourceFetcher.newInstance()
+        );
+    }
+
+    private KeyPair keyPair;
+    private String baseUrl;
+    private String endpoint;
+    private byte[] payload;
+    private final Map<String, String> queryParameters = new HashMap<>();
+    private final Map<String, String> headers = new HashMap<>();
+    private String httpMethod;
+
+    private final PathFactory pathFactory;
+    private final SignedMessageFactory signedMessageFactory;
+    private final HeadersFactory headersFactory;
+    private final JsonResourceFetcher jsonResourceFetcher;
+
+    SignedRequestBuilder(PathFactory pathFactory,
+            SignedMessageFactory signedMessageFactory,
+            HeadersFactory headersFactory,
+            JsonResourceFetcher jsonResourceFetcher) {
+        this.pathFactory = pathFactory;
+        this.signedMessageFactory = signedMessageFactory;
+        this.headersFactory = headersFactory;
+        this.jsonResourceFetcher = jsonResourceFetcher;
+    }
+
+    /**
+     * Proceed building the signed request with a specific key pair
+     *
+     * @param keyPair the key pair
+     * @return the updated builder
+     */
+    public SignedRequestBuilder withKeyPair(KeyPair keyPair) {
+        this.keyPair = keyPair;
+        return this;
+    }
+
+    /**
+     * Proceed building the signed request with specific base url
+     *
+     * @param baseUrl the base url
+     * @return the updated builder
+     */
+    public SignedRequestBuilder withBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl.replaceAll("([/]+)$", "");
+        return this;
+    }
+
+    /**
+     * Proceed building the signed request with a specific endpoint
+     *
+     * @param endpoint the endpoint
+     * @return the updated builder
+     */
+    public SignedRequestBuilder withEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+        return this;
+    }
+
+    /**
+     * Proceed building the signed request with a specific payload
+     *
+     * @param payload the payload
+     * @return the update builder
+     */
+    public SignedRequestBuilder withPayload(byte[] payload) {
+        this.payload = payload;
+        return this;
+    }
+
+    /**
+     * Proceed building the signed request with a specific query parameter
+     *
+     * @param name  the name of the query parameter
+     * @param value the value of the query parameter
+     * @return the updated builder
+     */
+    public SignedRequestBuilder withQueryParameter(String name, String value) {
+        this.queryParameters.put(name, value);
+        return this;
+    }
+
+    /**
+     * Proceed building the signed request with a specific header
+     *
+     * @param name  the name of the header
+     * @param value the value of the header
+     * @return the updated builder
+     */
+    public SignedRequestBuilder withHeader(String name, String value) {
+        this.headers.put(name, value);
+        return this;
+    }
+
+    /**
+     * Proceed building the signed request with a specific HTTP method
+     *
+     * @param httpMethod the HTTP method
+     * @return the updated builder
+     */
+    public SignedRequestBuilder withHttpMethod(String httpMethod) throws IllegalArgumentException {
+        Validation.withinList(httpMethod, SUPPORTED_HTTP_METHODS);
+        this.httpMethod = httpMethod;
+        return this;
+    }
+
+    /**
+     * Build the signed request with specified options
+     *
+     * @return the signed request
+     */
+    public SignedRequest build() throws GeneralSecurityException, UnsupportedEncodingException, URISyntaxException {
+        validateRequest();
+
+        if (endpoint.contains("?")) {
+            endpoint = endpoint.concat("&");
+        } else {
+            endpoint = endpoint.concat("?");
+        }
+
+        String builtEndpoint = endpoint + createQueryParameterString(queryParameters);
+        String digest = createDigest(builtEndpoint);
+        headers.putAll(headersFactory.create(digest));
+
+        return new SignedRequest(
+                new URI(baseUrl + builtEndpoint),
+                httpMethod,
+                payload,
+                headers,
+                jsonResourceFetcher
+        );
+    }
+
+    private void validateRequest() {
+        Validation.notNull(keyPair, "keyPair");
+        Validation.notNullOrEmpty(baseUrl, "baseUrl");
+        Validation.notNullOrEmpty(endpoint, "endpoint");
+        Validation.notNullOrEmpty(httpMethod, "httpMethod");
+    }
+
+    private String createQueryParameterString(Map<String, String> queryParameters) throws UnsupportedEncodingException {
+        StringBuilder stringBuilder = new StringBuilder();
+        for (Map.Entry<String, String> entry : queryParameters.entrySet()) {
+            stringBuilder.append(entry.getKey());
+            stringBuilder.append("=");
+            stringBuilder.append(URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8.toString()));
+            stringBuilder.append("&");
+        }
+        stringBuilder.append(pathFactory.createSignatureParams());
+        return stringBuilder.toString();
+    }
+
+    private String createDigest(String endpoint) throws GeneralSecurityException {
+        if (payload != null) {
+            return signedMessageFactory.create(keyPair.getPrivate(), httpMethod, endpoint, payload);
+        } else {
+            return signedMessageFactory.create(keyPair.getPrivate(), httpMethod, endpoint);
+        }
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/factory/HeadersFactory.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/factory/HeadersFactory.java
@@ -23,6 +23,7 @@ public class HeadersFactory {
         return headers;
     }
 
+    @Deprecated
     public Map<String, String> create(String digest, String authKey) {
         Map<String, String> headers = create(digest);
         headers.put(AUTH_KEY_HEADER, authKey);

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/factory/PathFactory.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/factory/PathFactory.java
@@ -1,25 +1,32 @@
 package com.yoti.api.client.spi.remote.call.factory;
 
-import static java.lang.String.format;
 import static java.lang.System.nanoTime;
 import static java.util.UUID.randomUUID;
 
 public class PathFactory {
 
-    private static final String PROFILE_PATH_TEMPLATE = "/profile/%s?nonce=%s&timestamp=%s&appId=%s";
-    private static final String AML_PATH_TEMPLATE = "/aml-check?appId=%s&nonce=%s&timestamp=%s";
-    private static final String QR_CODE_PATH_TEMPLATE = "/qrcodes/apps/%s?nonce=%s&timestamp=%s";
+    private static final String SIGNATURE_PARAMS = "nonce=%s&timestamp=%s";
+
+    private UnsignedPathFactory unsignedPathFactory;
+
+    public PathFactory() {
+        this.unsignedPathFactory = new UnsignedPathFactory();
+    }
+
+    public String createSignatureParams() {
+        return String.format(SIGNATURE_PARAMS, randomUUID(), createTimestamp());
+    }
 
     public String createProfilePath(String appId, String connectToken) {
-        return format(PROFILE_PATH_TEMPLATE, connectToken, randomUUID(), createTimestamp(), appId);
+        return unsignedPathFactory.createProfilePath(appId, connectToken) + createSignatureParams();
     }
 
     public String createAmlPath(String appId) {
-        return format(AML_PATH_TEMPLATE, appId, randomUUID(), createTimestamp());
+        return unsignedPathFactory.createAmlPath(appId) + createSignatureParams();
     }
 
     public String createDynamicSharingPath(String appId) {
-        return format(QR_CODE_PATH_TEMPLATE, appId, randomUUID(), createTimestamp());
+        return unsignedPathFactory.createDynamicSharingPath(appId) + createSignatureParams();
     }
 
     protected long createTimestamp() {

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/factory/UnsignedPathFactory.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/factory/UnsignedPathFactory.java
@@ -1,0 +1,23 @@
+package com.yoti.api.client.spi.remote.call.factory;
+
+import static java.lang.String.format;
+
+public class UnsignedPathFactory {
+
+    static final String PROFILE_PATH_TEMPLATE = "/profile/%s?appId=%s";
+    static final String AML_PATH_TEMPLATE = "/aml-check?appId=%s";
+    static final String QR_CODE_PATH_TEMPLATE = "/qrcodes/apps/%s";
+
+    public String createProfilePath(String appId, String connectToken) {
+        return format(PROFILE_PATH_TEMPLATE, connectToken, appId);
+    }
+
+    public String createAmlPath(String appId) {
+        return format(AML_PATH_TEMPLATE, appId);
+    }
+
+    public String createDynamicSharingPath(String appId) {
+        return format(QR_CODE_PATH_TEMPLATE, appId);
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/util/Validation.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/util/Validation.java
@@ -2,6 +2,8 @@ package com.yoti.api.client.spi.remote.util;
 
 import static java.lang.String.format;
 
+import java.util.List;
+
 public class Validation {
 
     public static <T> T notNull(T value, String name) {
@@ -54,6 +56,12 @@ public class Validation {
     public static void matchesPattern(String value, String regex, String name) {
         if (value == null || ! value.matches(regex)) {
             throw new IllegalArgumentException(format("'%s' value '%s' does not match format '%s'", name, value, regex));
+        }
+    }
+
+    public static <T> void withinList(T value, List<T> allowedValues) {
+        if (!allowedValues.contains(value)) {
+            throw new IllegalArgumentException(format("value '%s' is not in the list '%s'", value, allowedValues));
         }
     }
 

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/AnchorConverterTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/AnchorConverterTest.java
@@ -22,6 +22,7 @@ import com.yoti.api.client.Time;
 import com.yoti.api.client.spi.remote.proto.AttrProto;
 import com.yoti.api.client.spi.remote.util.AnchorType;
 
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.hamcrest.collection.IsCollectionWithSize;
@@ -31,7 +32,7 @@ import org.junit.Test;
 public class AnchorConverterTest {
 
     static {
-        Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+        Security.addProvider(new BouncyCastleProvider());
     }
 
     private static final String PASSPORT_ISSUER = "CN=passport-registration-server";

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/call/RemoteProfileServiceTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/call/RemoteProfileServiceTest.java
@@ -1,38 +1,29 @@
 package com.yoti.api.client.spi.remote.call;
 
 import static com.yoti.api.client.spi.remote.call.HttpMethod.HTTP_GET;
-import static com.yoti.api.client.spi.remote.call.YotiConstants.YOTI_API_PATH_PREFIX;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.DEFAULT_YOTI_API_URL;
 import static com.yoti.api.client.spi.remote.util.CryptoUtil.KEY_PAIR_PEM;
-import static com.yoti.api.client.spi.remote.util.CryptoUtil.base64;
 import static com.yoti.api.client.spi.remote.util.CryptoUtil.generateKeyPairFrom;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.util.HashMap;
 import java.util.Map;
 
 import com.yoti.api.client.ProfileException;
-import com.yoti.api.client.spi.remote.call.factory.HeadersFactory;
-import com.yoti.api.client.spi.remote.call.factory.PathFactory;
-import com.yoti.api.client.spi.remote.call.factory.SignedMessageFactory;
+import com.yoti.api.client.spi.remote.call.factory.UnsignedPathFactory;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
+import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -50,18 +41,15 @@ public class RemoteProfileServiceTest {
     private static final String APP_ID = "test-app";
     private static final String TOKEN = "test-token";
     private static final String GENERATED_PROFILE_PATH = "generatedProfilePath";
-    private static final String SOME_SIGNATURE = "someSignature";
     private static final Map<String, String> SOME_HEADERS = new HashMap<>();
     private static KeyPair KEY_PAIR;
 
     @InjectMocks RemoteProfileService testObj;
 
-    @Mock ResourceFetcher resourceFetcherMock;
-    @Mock PathFactory pathFactoryMock;
-    @Mock HeadersFactory headersFactoryMock;
-    @Mock SignedMessageFactory signedMessageFactoryMock;
+    @Mock UnsignedPathFactory unsignedPathFactory;
+    @Mock(answer = Answers.RETURNS_SELF) SignedRequestBuilder signedRequestBuilderMock;
 
-    @Captor ArgumentCaptor<UrlConnector> urlConnectorCaptor;
+    @Mock SignedRequest signedRequestMock;
 
     @BeforeClass
     public static void setUpClass() throws Exception {
@@ -71,31 +59,27 @@ public class RemoteProfileServiceTest {
 
     @Before
     public void setUp() {
-        when(pathFactoryMock.createProfilePath(APP_ID, TOKEN)).thenReturn(GENERATED_PROFILE_PATH);
-        when(headersFactoryMock.create(SOME_SIGNATURE, base64(KEY_PAIR.getPublic().getEncoded()))).thenReturn(SOME_HEADERS);
+        when(unsignedPathFactory.createProfilePath(APP_ID, TOKEN)).thenReturn(GENERATED_PROFILE_PATH);
     }
 
     @Test
     public void shouldReturnReceiptForCorrectRequest() throws Exception {
-        when(signedMessageFactoryMock.create(KEY_PAIR.getPrivate(), HTTP_GET, GENERATED_PROFILE_PATH)).thenReturn(SOME_SIGNATURE);
-        when(resourceFetcherMock.fetchResource(any(UrlConnector.class), eq(SOME_HEADERS), eq(ProfileResponse.class))).thenReturn(PROFILE_RESPONSE);
+        when(signedRequestBuilderMock.build()).thenReturn(signedRequestMock);
+        when(signedRequestMock.execute(ProfileResponse.class)).thenReturn(PROFILE_RESPONSE);
 
         Receipt result = testObj.getReceipt(KEY_PAIR, APP_ID, TOKEN);
 
-        verify(resourceFetcherMock).fetchResource(urlConnectorCaptor.capture(), eq(SOME_HEADERS), eq(ProfileResponse.class));
-        assertUrl(urlConnectorCaptor.getValue());
+        verify(signedRequestBuilderMock).withKeyPair(KEY_PAIR);
+        verify(signedRequestBuilderMock).withBaseUrl(DEFAULT_YOTI_API_URL);
+        verify(signedRequestBuilderMock).withEndpoint(GENERATED_PROFILE_PATH);
+        verify(signedRequestBuilderMock).withHttpMethod(HTTP_GET);
         assertSame(RECEIPT, result);
-    }
-
-    private void assertUrl(UrlConnector urlConnector) throws MalformedURLException {
-        URL url = new URL(urlConnector.getUrlString());
-        assertEquals(YOTI_API_PATH_PREFIX + GENERATED_PROFILE_PATH, url.getPath());
     }
 
     @Test
     public void shouldWrapSecurityExceptionInProfileException() throws Exception {
         GeneralSecurityException securityException = new GeneralSecurityException();
-        when(signedMessageFactoryMock.create(KEY_PAIR.getPrivate(), HTTP_GET, GENERATED_PROFILE_PATH)).thenThrow(securityException);
+        when(signedRequestBuilderMock.build()).thenThrow(securityException);
 
         try {
             testObj.getReceipt(KEY_PAIR, APP_ID, TOKEN);
@@ -108,8 +92,8 @@ public class RemoteProfileServiceTest {
     @Test
     public void shouldThrowExceptionForIOError() throws Exception {
         IOException ioException = new IOException("Test exception");
-        when(signedMessageFactoryMock.create(KEY_PAIR.getPrivate(), HTTP_GET, GENERATED_PROFILE_PATH)).thenReturn(SOME_SIGNATURE);
-        when(resourceFetcherMock.fetchResource(any(UrlConnector.class), eq(SOME_HEADERS), eq(ProfileResponse.class))).thenThrow(ioException);
+        when(signedRequestBuilderMock.build()).thenReturn(signedRequestMock);
+        when(signedRequestMock.execute(ProfileResponse.class)).thenThrow(ioException);
 
         try {
             testObj.getReceipt(KEY_PAIR, APP_ID, TOKEN);
@@ -122,8 +106,8 @@ public class RemoteProfileServiceTest {
     @Test
     public void shouldThrowExceptionWithResourceExceptionCause() throws Throwable {
         ResourceException resourceException = new ResourceException(404, "Not Found", "Test exception");
-        when(signedMessageFactoryMock.create(KEY_PAIR.getPrivate(), HTTP_GET, GENERATED_PROFILE_PATH)).thenReturn(SOME_SIGNATURE);
-        when(resourceFetcherMock.fetchResource(any(UrlConnector.class), eq(SOME_HEADERS), eq(ProfileResponse.class))).thenThrow(resourceException);
+        when(signedRequestBuilderMock.build()).thenReturn(signedRequestMock);
+        when(signedRequestMock.execute(ProfileResponse.class)).thenThrow(resourceException);
 
         try {
             testObj.getReceipt(KEY_PAIR, APP_ID, TOKEN);

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/call/SignedRequestBuilderTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/call/SignedRequestBuilderTest.java
@@ -1,0 +1,233 @@
+package com.yoti.api.client.spi.remote.call;
+
+import static com.yoti.api.client.spi.remote.call.HttpMethod.HTTP_GET;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.DEFAULT_YOTI_API_URL;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.DIGEST_HEADER;
+import static com.yoti.api.client.spi.remote.util.CryptoUtil.KEY_PAIR_PEM;
+import static com.yoti.api.client.spi.remote.util.CryptoUtil.generateKeyPairFrom;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.Security;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.yoti.api.client.spi.remote.call.factory.HeadersFactory;
+import com.yoti.api.client.spi.remote.call.factory.PathFactory;
+import com.yoti.api.client.spi.remote.call.factory.SignedMessageFactory;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SignedRequestBuilderTest {
+
+    private static final String SOME_ENDPOINT = "/someEndpoint";
+    private static final String SOME_SIGNATURE = "someSignature";
+    private static final Map<String, String> SIGNED_REQUEST_HEADERS;
+    private static final String SOME_BASE_URL = "someBaseUrl";
+    private static final byte[] SOME_BYTES = "someBytes".getBytes();
+    private static final String SIGNATURE_PARAMS_STRING = "nonce=someNonce&timestamp=someTimestamp";
+    private static KeyPair KEY_PAIR;
+
+    static {
+        Security.addProvider(new BouncyCastleProvider());
+
+        SIGNED_REQUEST_HEADERS = new HashMap<>();
+        SIGNED_REQUEST_HEADERS.put(YotiConstants.DIGEST_HEADER, SOME_SIGNATURE);
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        KEY_PAIR = generateKeyPairFrom(KEY_PAIR_PEM);
+    }
+
+    @InjectMocks SignedRequestBuilder signedRequestBuilder;
+
+    @Mock PathFactory pathFactoryMock;
+    @Mock SignedMessageFactory signedMessageFactoryMock;
+    @Mock HeadersFactory headersFactoryMock;
+    @Captor ArgumentCaptor<String> pathCaptor;
+
+    @Test
+    public void withHttpMethod_shouldThrowExceptionWhenSuppliedWithUnsupportedHttpMethod() throws Exception {
+        try {
+            signedRequestBuilder.withHttpMethod("someNonsenseHere");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("someNonsenseHere"));
+            return;
+        }
+        fail("Expected an IllegalArgumentException");
+
+    }
+
+    @Test
+    public void build_shouldThrowExceptionWhenMissingKeyPair() throws Exception {
+        try {
+            signedRequestBuilder.build();
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("keyPair"));
+            return;
+        }
+        fail("Expected an IllegalArgumentException");
+    }
+
+    @Test
+    public void build_shouldThrowExceptionWhenMissingBaseUrl() throws Exception {
+        try {
+            signedRequestBuilder.withKeyPair(KEY_PAIR)
+                    .build();
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("baseUrl"));
+            return;
+        }
+        fail("Expected an IllegalArgumentException");
+    }
+
+    @Test
+    public void build_shouldThrowExceptionWhenMissingEndpoint() throws Exception {
+        try {
+            signedRequestBuilder.withKeyPair(KEY_PAIR)
+                    .withBaseUrl(SOME_BASE_URL)
+                    .build();
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("endpoint"));
+            return;
+        }
+        fail("Expected an IllegalArgumentException");
+    }
+
+    @Test
+    public void build_shouldThrowExceptionWhenMissingHttpMethod() throws Exception {
+        try {
+            signedRequestBuilder.withKeyPair(KEY_PAIR)
+                    .withBaseUrl(SOME_BASE_URL)
+                    .withEndpoint(SOME_ENDPOINT)
+                    .build();
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("httpMethod"));
+            return;
+        }
+        fail("Expected an IllegalArgumentException");
+    }
+
+    @Test
+    public void build_shouldCreateSignedRequestWithCustomQueryParameter() throws Exception {
+        when(pathFactoryMock.createSignatureParams()).thenReturn(SIGNATURE_PARAMS_STRING);
+
+        SignedRequest result = signedRequestBuilder.withKeyPair(KEY_PAIR)
+                .withBaseUrl(SOME_BASE_URL)
+                .withEndpoint(SOME_ENDPOINT)
+                .withHttpMethod(HTTP_GET)
+                .withQueryParameter("someQueryParam", "someParamValue")
+                .build();
+
+        assertThat(result.getUri().getQuery(), containsString(SIGNATURE_PARAMS_STRING));
+    }
+
+    @Test
+    public void build_shouldCreateSignedRequestWithProvidedHttpHeader() throws Exception {
+        SignedRequest result = signedRequestBuilder.withKeyPair(KEY_PAIR)
+                .withBaseUrl(DEFAULT_YOTI_API_URL)
+                .withEndpoint(SOME_ENDPOINT)
+                .withHttpMethod(HTTP_GET)
+                .withHeader("myCustomHeader", "customHeaderValue")
+                .build();
+
+        assertThat(result.getHeaders(), hasEntry("myCustomHeader", "customHeaderValue"));
+    }
+
+    @Test
+    public void build_shouldIgnoreAnyProvidedSignedRequestHeaders() throws Exception {
+        when(pathFactoryMock.createSignatureParams()).thenReturn(SIGNATURE_PARAMS_STRING);
+        when(signedMessageFactoryMock.create(any(PrivateKey.class), anyString(), anyString())).thenReturn(SOME_SIGNATURE);
+        when(headersFactoryMock.create(SOME_SIGNATURE)).thenReturn(SIGNED_REQUEST_HEADERS);
+
+        SignedRequest result = signedRequestBuilder.withKeyPair(KEY_PAIR)
+                .withBaseUrl(DEFAULT_YOTI_API_URL)
+                .withEndpoint(SOME_ENDPOINT)
+                .withHttpMethod(HTTP_GET)
+                .withHeader(DIGEST_HEADER, "customHeaderValue")
+                .build();
+
+        assertThat(result.getHeaders(), hasEntry(DIGEST_HEADER, SOME_SIGNATURE));
+    }
+
+    @Test
+    public void shouldRemoveTrailingSlashesFromBaseUrl() throws Exception {
+        SignedRequest simpleSignedRequest = signedRequestBuilder.withKeyPair(KEY_PAIR)
+                .withBaseUrl(SOME_BASE_URL + "////////////")
+                .withEndpoint(SOME_ENDPOINT)
+                .withHttpMethod(HTTP_GET)
+                .build();
+
+        assertThat(simpleSignedRequest.getUri().toString(), containsString(SOME_BASE_URL + SOME_ENDPOINT));
+    }
+
+    @Test
+    public void shouldCreateSignedRequestSuccessfullyWithRequiredFieldsOnly() throws Exception {
+        when(pathFactoryMock.createSignatureParams()).thenReturn(SIGNATURE_PARAMS_STRING);
+        when(signedMessageFactoryMock.create(any(PrivateKey.class), anyString(), anyString())).thenReturn(SOME_SIGNATURE);
+        when(headersFactoryMock.create(SOME_SIGNATURE)).thenReturn(SIGNED_REQUEST_HEADERS);
+
+        SignedRequest result = signedRequestBuilder.withKeyPair(KEY_PAIR)
+                .withBaseUrl(SOME_BASE_URL)
+                .withEndpoint(SOME_ENDPOINT)
+                .withHttpMethod(HTTP_GET)
+                .build();
+
+        verify(signedMessageFactoryMock).create(eq(KEY_PAIR.getPrivate()), eq(HTTP_GET), pathCaptor.capture());
+        assertThat(pathCaptor.getValue(), is(SOME_ENDPOINT + "?" + SIGNATURE_PARAMS_STRING));
+        assertThat(result.getUri().toString(), is(SOME_BASE_URL + pathCaptor.getValue()));
+        assertThat(result.getMethod(), is(HTTP_GET));
+        assertThat(result.getHeaders().get(DIGEST_HEADER), containsString(SOME_SIGNATURE));
+        assertThat(result.getHeaders(), hasEntry(DIGEST_HEADER, SOME_SIGNATURE));
+        assertTrue(result.getData() == null);
+    }
+
+    @Test
+    public void shouldCreatedSignedRequestSuccessfullyWithAllProperties() throws Exception {
+        when(pathFactoryMock.createSignatureParams()).thenReturn(SIGNATURE_PARAMS_STRING);
+        when(signedMessageFactoryMock.create(any(PrivateKey.class), anyString(), anyString(), any(byte[].class))).thenReturn(SOME_SIGNATURE);
+        when(headersFactoryMock.create(SOME_SIGNATURE)).thenReturn(SIGNED_REQUEST_HEADERS);
+
+        SignedRequest result = signedRequestBuilder.withKeyPair(KEY_PAIR)
+                .withBaseUrl(SOME_BASE_URL)
+                .withEndpoint(SOME_ENDPOINT)
+                .withHttpMethod(HTTP_GET)
+                .withQueryParameter("someQueryParam", "someParamValue")
+                .withHeader("myCustomHeader", "customHeaderValue")
+                .withPayload(SOME_BYTES)
+                .build();
+
+        verify(signedMessageFactoryMock).create(eq(KEY_PAIR.getPrivate()), eq(HTTP_GET), pathCaptor.capture(), eq(SOME_BYTES));
+        assertThat(pathCaptor.getValue(), is(SOME_ENDPOINT + "?someQueryParam=someParamValue&" + SIGNATURE_PARAMS_STRING));
+        assertThat(result.getUri().toString(), is(SOME_BASE_URL + pathCaptor.getValue()));
+        assertThat(result.getMethod(), is(HTTP_GET));
+        assertThat(result.getHeaders().get(DIGEST_HEADER), containsString(SOME_SIGNATURE));
+        assertThat(result.getHeaders(), hasEntry(DIGEST_HEADER, SOME_SIGNATURE));
+        assertThat(result.getHeaders(), hasEntry("myCustomHeader", "customHeaderValue"));
+        assertArrayEquals(SOME_BYTES, result.getData());
+    }
+
+}


### PR DESCRIPTION
## Added

* `SignedRequestBuilder` and `SignedRequest` to assist users with creating and executing a signed request
* `UnsignedPathFactory` for returning internal SDK paths without signature query parameters

## Changed

* Internal SDK now uses SignedRequestBuilder for making calls to Yoti API's