### PR TITLE
SDK-1244: Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,43 +13,43 @@ git:
 
 jobs:
   include:
-    - state: Test
+    - &test
+      stage: Test
       jdk: oraclejdk8
-      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -Ddependency-check.skip=true
+      install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -Ddependency-check.skip=true
       script:
-        - ./mvnw test -B -Ddependency-check.skip=true
-    - &test-compatability
-      stage: Compatability
-      jdk: oraclejdk8
-      os: linux
-      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -Ddependency-check.skip=true
-      script:
-        - ./mvnw test -B -Ddependency-check.skip=true
-    - <<: *test-compatability
+        - mvn test -B -Ddependency-check.skip=true
+    - <<: *test
       # Only the api and implementation need testing with Java 1.7
-      dist: precise
       jdk: oraclejdk7
-      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -pl yoti-sdk-api,yoti-sdk-impl -Ddependency-check.skip=true
-      script:
-        - ./mvnw test -B -pl yoti-sdk-api,yoti-sdk-impl -Ddependency-check.skip=true
-    - <<: *test-compatability
       dist: precise
-      jdk: openjdk7
-      install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -pl yoti-sdk-api,yoti-sdk-impl -Ddependency-check.skip=true
+      install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -pl yoti-sdk-api,yoti-sdk-impl -Ddependency-check.skip=true
       script:
-        - ./mvnw test -B -pl yoti-sdk-api,yoti-sdk-impl -Ddependency-check.skip=true
-    - <<: *test-compatability
+        - mvn test -B -pl yoti-sdk-api,yoti-sdk-impl -Ddependency-check.skip=true
+    - <<: *test
+      jdk: openjdk7
+      dist: precise
+      install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -pl yoti-sdk-api,yoti-sdk-impl -Ddependency-check.skip=true
+      script:
+        - mvn test -B -pl yoti-sdk-api,yoti-sdk-impl -Ddependency-check.skip=true
+    - <<: *test
       jdk: openjdk8
-    - <<: *test-compatability
+    - <<: *test
       jdk: oraclejdk9
-    - <<: *test-compatability
+    - <<: *test
       jdk: openjdk9
-    - <<: *test-compatability
-      dist: bionic
+    - <<: *test
       jdk: openjdk10
-    - <<: *test-compatability
-      dist: bionic
+    - <<: *test
       jdk: openjdk11
-    - <<: *test-compatability
-      dist: bionic
+    - <<: *test
       jdk: oraclejdk11
+    - stage: Coverage
+      name: Coveralls
+      if: type = pull_request OR branch = master
+      jdk: oraclejdk8
+      install:
+        - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip=true -Ddependency-check.skip=true
+      script:
+        - mvn jacoco:prepare-agent test jacoco:report coveralls:report -pl yoti-sdk-impl
+

--- a/yoti-sdk-impl/pom.xml
+++ b/yoti-sdk-impl/pom.xml
@@ -92,6 +92,15 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>com/yoti/api/client/spi/remote/proto/**/*</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/yoti-sdk-parent/pom.xml
+++ b/yoti-sdk-parent/pom.xml
@@ -135,7 +135,8 @@
     <javadoc.plugin.version>3.1.0</javadoc.plugin.version>
     <javadoc.plugin.source>8</javadoc.plugin.source>
     <gpg.plugin.version>1.6</gpg.plugin.version>
-    
+    <coveralls.plugin.version>4.3.0</coveralls.plugin.version>
+    <jacoco.plugin.version>0.8.4</jacoco.plugin.version>
   </properties>
   
   <dependencyManagement>
@@ -251,8 +252,6 @@
         <artifactId>commons-lang3</artifactId>
         <version>${commons.lang3.version}</version>
       </dependency>
-
-
     </dependencies>
   </dependencyManagement>
   
@@ -441,6 +440,33 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-project-info-reports-plugin</artifactId>
           <version>${maven.reports.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.eluder.coveralls</groupId>
+          <artifactId>coveralls-maven-plugin</artifactId>
+          <version>${coveralls.plugin.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>${jacoco.plugin.version}</version>
+          <executions>
+            <execution>
+              <id>default-prepare-agent</id>
+              <goals>
+                <goal>prepare-agent</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>report</id>
+              <phase>prepare-package</phase>
+              <goals>
+                <goal>report</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
       
       </plugins>


### PR DESCRIPTION
## Added

* Coveralls support when using travis (found [here](https://coveralls.io/github/getyoti/yoti-java-sdk))

## Changes

* Updated travis to use `mvn` rather than `mvnw` (as it wasn't using the built in maven cache)