### PR TITLE
SDK-1257: Change example project to show document images

### DIFF
--- a/yoti-sdk-spring-boot-example/src/main/resources/templates/profile.html
+++ b/yoti-sdk-spring-boot-example/src/main/resources/templates/profile.html
@@ -77,6 +77,9 @@
                                         </tr>
                                     </table>
                                 </div>
+                                <div th:case="document_images">
+                                    <img th:src="${attribute.attribute.value[0].base64Content}" alt="document_image" />
+                                </div>
                                 <div th:case="*" class="yoti-attribute-value-text" th:text="${attribute.displayValue}"></div>
                             </div>
                         </div>


### PR DESCRIPTION
## Added

* Document images should now be shown in the example project profile page instead of String representation of Attribute object