### PR TITLE
SDK-1148: Multiple of the same attribute with different constraints

### DIFF
--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/Profile.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/Profile.java
@@ -11,11 +11,12 @@ public interface Profile {
     /**
      * Return typed {@link Attribute} object for a key.
      *
-     * @param <T> the type parameter indicating the type of the returned value
-     * @param name attribute name
+     * @param <T>   the type parameter indicating the type of the returned value
+     * @param name  attribute name
      * @param clazz attribute type
      * @return typed attribute, null if it is not present in the profile
      */
+    @Deprecated
     <T> Attribute<T> getAttribute(String name, Class<T> clazz);
 
     /**
@@ -24,7 +25,39 @@ public interface Profile {
      * @param name
      * @return the attribute object, null if it is not present in the profile
      */
+    @Deprecated
     Attribute getAttribute(String name);
+
+    /**
+     * Return single typed {@link Attribute} object
+     * by exact name
+     *
+     * @param name  the name of the {@link Attribute}
+     * @param clazz the type of the {@link Attribute} value
+     * @param <T>   the type parameter indicating the type of the returned value
+     * @return typed attribute, null if it is not present in the profile
+     */
+    <T> Attribute<T> getAttributeByName(String name, Class<T> clazz);
+
+    /**
+     * Return single {@link Attribute} object
+     * by exact name
+     *
+     * @param name the name of the {@link Attribute}
+     * @return the attribute object, null if it is not present in the profule
+     */
+    Attribute getAttributeByName(String name);
+
+    /**
+     * Return a list of {@link Attribute}s that match
+     * the exact name
+     *
+     * @param name   the name of the {@link Attribute}s
+     * @param clazz  the type of the {@link Attribute} value
+     * @param <T>the type parameter indicating the type of the returned value
+     * @return typed list of attribute, empty list if there are no matching attributes on the profile
+     */
+    <T> List<Attribute<T>> getAttributesByName(String name, Class<T> clazz);
 
     /**
      * Return a list of all the {@link Attribute}s with a name starting with <code>name</code>

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/Profile.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/Profile.java
@@ -44,7 +44,7 @@ public interface Profile {
      * by exact name
      *
      * @param name the name of the {@link Attribute}
-     * @return the attribute object, null if it is not present in the profule
+     * @return the attribute object, null if it is not present in the profile
      */
     Attribute getAttributeByName(String name);
 

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/shareurl/policy/WantedAttribute.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/shareurl/policy/WantedAttribute.java
@@ -35,7 +35,7 @@ public interface WantedAttribute {
      * Allows self asserted attributes
      * @return accept self asserted
      */
-    boolean getAcceptSelfAsserted();
+    Boolean getAcceptSelfAsserted();
 
     /**
      * List of {@link Constraint} for a {@link WantedAttribute}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilder.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilder.java
@@ -34,7 +34,7 @@ public class SimpleDynamicPolicyBuilder extends DynamicPolicyBuilder {
 
     @Override
     public DynamicPolicyBuilder withWantedAttribute(boolean optional, String name, List<Constraint> constraints) {
-        WantedAttribute wantedAttribute = WantedAttributeBuilder.newInstance()
+        WantedAttribute wantedAttribute = new SimpleWantedAttributeBuilder()
                 .withName(name)
                 .withOptional(optional)
                 .withConstraints(constraints)
@@ -108,7 +108,7 @@ public class SimpleDynamicPolicyBuilder extends DynamicPolicyBuilder {
     }
 
     private DynamicPolicyBuilder withAgeDerivedAttribute(boolean optional, String derivation) {
-        WantedAttribute wantedAttribute = WantedAttributeBuilder.newInstance()
+        WantedAttribute wantedAttribute = new SimpleWantedAttributeBuilder()
                 .withName(AttributeConstants.HumanProfileAttributes.DATE_OF_BIRTH)
                 .withDerivation(derivation)
                 .withOptional(optional)

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilder.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilder.java
@@ -25,7 +25,7 @@ public class SimpleDynamicPolicyBuilder extends DynamicPolicyBuilder {
         String key = wantedAttribute.getDerivation() != null ? wantedAttribute.getDerivation() : wantedAttribute.getName();
 
         if (wantedAttribute.getConstraints().size() > 0) {
-            key = key + wantedAttribute.getConstraints().hashCode();
+            key += "-" + wantedAttribute.getConstraints().hashCode();
         }
 
         this.wantedAttributes.put(key, wantedAttribute);

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilder.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilder.java
@@ -23,6 +23,11 @@ public class SimpleDynamicPolicyBuilder extends DynamicPolicyBuilder {
     @Override
     public DynamicPolicyBuilder withWantedAttribute(WantedAttribute wantedAttribute) {
         String key = wantedAttribute.getDerivation() != null ? wantedAttribute.getDerivation() : wantedAttribute.getName();
+
+        if (wantedAttribute.getConstraints().size() > 0) {
+            key = key + wantedAttribute.getConstraints().hashCode();
+        }
+
         this.wantedAttributes.put(key, wantedAttribute);
         return this;
     }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilder.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/shareurl/policy/SimpleDynamicPolicyBuilder.java
@@ -34,7 +34,7 @@ public class SimpleDynamicPolicyBuilder extends DynamicPolicyBuilder {
 
     @Override
     public DynamicPolicyBuilder withWantedAttribute(boolean optional, String name, List<Constraint> constraints) {
-        WantedAttribute wantedAttribute = new SimpleWantedAttributeBuilder()
+        WantedAttribute wantedAttribute = WantedAttributeBuilder.newInstance()
                 .withName(name)
                 .withOptional(optional)
                 .withConstraints(constraints)
@@ -108,7 +108,7 @@ public class SimpleDynamicPolicyBuilder extends DynamicPolicyBuilder {
     }
 
     private DynamicPolicyBuilder withAgeDerivedAttribute(boolean optional, String derivation) {
-        WantedAttribute wantedAttribute = new SimpleWantedAttributeBuilder()
+        WantedAttribute wantedAttribute = WantedAttributeBuilder.newInstance()
                 .withName(AttributeConstants.HumanProfileAttributes.DATE_OF_BIRTH)
                 .withDerivation(derivation)
                 .withOptional(optional)

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/shareurl/policy/SimpleWantedAttribute.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/shareurl/policy/SimpleWantedAttribute.java
@@ -1,5 +1,7 @@
 package com.yoti.api.client.shareurl.policy;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.yoti.api.client.shareurl.constraint.Constraint;
 
@@ -20,13 +22,15 @@ class SimpleWantedAttribute implements WantedAttribute {
     @JsonProperty("optional")
     private final boolean optional;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("accept_self_asserted")
-    private final boolean acceptSelfAsserted;
+    private final Boolean acceptSelfAsserted;
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonProperty("constraints")
     private final List<Constraint> constraints;
 
-    SimpleWantedAttribute(String name, String derivation, boolean optional, boolean acceptSelfAsserted, List<Constraint> constraints) {
+    SimpleWantedAttribute(String name, String derivation, boolean optional, Boolean acceptSelfAsserted, List<Constraint> constraints) {
         this.name = name;
         this.derivation = derivation;
         this.optional = optional;
@@ -67,7 +71,7 @@ class SimpleWantedAttribute implements WantedAttribute {
      * @see WantedAttribute#getAcceptSelfAsserted()
      */
     @Override
-    public boolean getAcceptSelfAsserted() {
+    public Boolean getAcceptSelfAsserted() {
         return acceptSelfAsserted;
     }
 

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/shareurl/policy/SimpleWantedAttribute.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/shareurl/policy/SimpleWantedAttribute.java
@@ -1,6 +1,5 @@
 package com.yoti.api.client.shareurl.policy;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.yoti.api.client.shareurl.constraint.Constraint;

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/shareurl/policy/SimpleWantedAttributeBuilder.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/shareurl/policy/SimpleWantedAttributeBuilder.java
@@ -11,7 +11,7 @@ public class SimpleWantedAttributeBuilder extends WantedAttributeBuilder {
     private String name;
     private String derivation;
     private boolean optional;
-    private boolean acceptSelfAsserted;
+    private Boolean acceptSelfAsserted;
     private List<Constraint> constraints;
 
     public SimpleWantedAttributeBuilder() {

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ApplicationProfileAdapter.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ApplicationProfileAdapter.java
@@ -25,13 +25,53 @@ public final class ApplicationProfileAdapter implements ApplicationProfile {
     }
 
     @Override
+    @Deprecated
     public Attribute getAttribute(String name) {
         return wrapped.getAttribute(name);
     }
 
     @Override
+    @Deprecated
     public <T> Attribute<T> getAttribute(String name, Class<T> clazz) {
         return wrapped.getAttribute(name, clazz);
+    }
+
+    /**
+     * Return single typed {@link Attribute} object
+     * by exact name
+     *
+     * @param name  the name of the {@link Attribute}
+     * @param clazz the type of the {@link Attribute} value
+     * @return typed attribute, null if it is not present in the profile
+     */
+    @Override
+    public <T> Attribute<T> getAttributeByName(String name, Class<T> clazz) {
+        return wrapped.getAttributeByName(name, clazz);
+    }
+
+    /**
+     * Return single {@link Attribute} object
+     * by exact name
+     *
+     * @param name the name of the {@link Attribute}
+     * @return the attribute object, null if it is not present in the profule
+     */
+    @Override
+    public Attribute getAttributeByName(String name) {
+        return wrapped.getAttributeByName(name);
+    }
+
+    /**
+     * Return a list of {@link Attribute}s that match
+     * the exact name
+     *
+     * @param name  the name of the {@link Attribute}s
+     * @param clazz the type of the {@link Attribute} value
+     * @return typed list of attribute, empty list if there are no matching attributes on the profile
+     */
+    @Override
+    public <T> List<Attribute<T>> getAttributesByName(String name, Class<T> clazz) {
+        return wrapped.getAttributesByName(name, clazz);
     }
 
     @Override
@@ -51,22 +91,22 @@ public final class ApplicationProfileAdapter implements ApplicationProfile {
 
     @Override
     public Attribute<String> getApplicationName() {
-        return wrapped.getAttribute(AttributeConstants.ApplicationProfileAttributes.ATTRIBUTE_APPLICATION_NAME, String.class);
+        return wrapped.getAttributeByName(AttributeConstants.ApplicationProfileAttributes.ATTRIBUTE_APPLICATION_NAME, String.class);
     }
 
     @Override
     public Attribute<String> getApplicationUrl() {
-        return wrapped.getAttribute(AttributeConstants.ApplicationProfileAttributes.ATTRIBUTE_APPLICATION_URL, String.class);
+        return wrapped.getAttributeByName(AttributeConstants.ApplicationProfileAttributes.ATTRIBUTE_APPLICATION_URL, String.class);
     }
 
     @Override
     public Attribute<String> getApplicationReceiptBgColor() {
-        return wrapped.getAttribute(AttributeConstants.ApplicationProfileAttributes.ATTRIBUTE_APPLICATION_RECEIPT_BGCOLOR, String.class);
+        return wrapped.getAttributeByName(AttributeConstants.ApplicationProfileAttributes.ATTRIBUTE_APPLICATION_RECEIPT_BGCOLOR, String.class);
     }
 
     @Override
     public Attribute<Image> getApplicationLogo() {
-        return wrapped.getAttribute(AttributeConstants.ApplicationProfileAttributes.ATTRIBUTE_APPLICATION_LOGO, Image.class);
+        return wrapped.getAttributeByName(AttributeConstants.ApplicationProfileAttributes.ATTRIBUTE_APPLICATION_LOGO, Image.class);
     }
 
     @Override

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/HumanProfileAdapter.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/HumanProfileAdapter.java
@@ -1,22 +1,12 @@
 package com.yoti.api.client.spi.remote;
 
-import static java.lang.Boolean.parseBoolean;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import com.yoti.api.attributes.AttributeConstants.HumanProfileAttributes;
-import com.yoti.api.client.AgeVerification;
-import com.yoti.api.client.Attribute;
 import com.yoti.api.client.Date;
-import com.yoti.api.client.DocumentDetails;
-import com.yoti.api.client.HumanProfile;
-import com.yoti.api.client.Image;
-import com.yoti.api.client.Profile;
+import com.yoti.api.client.*;
+
+import java.util.*;
+
+import static java.lang.Boolean.parseBoolean;
 
 /**
  * Adapter linking Profile and ApplicationProfile together by wrapping the latter and exposing well-known attributes.
@@ -35,13 +25,53 @@ final class HumanProfileAdapter implements HumanProfile {
     }
 
     @Override
+    @Deprecated
     public Attribute getAttribute(String name) {
         return wrapped.getAttribute(name);
     }
 
     @Override
+    @Deprecated
     public <T> Attribute<T> getAttribute(String name, Class<T> clazz) {
         return wrapped.getAttribute(name, clazz);
+    }
+
+    /**
+     * Return single typed {@link Attribute} object
+     * by exact name
+     *
+     * @param name  the name of the {@link Attribute}
+     * @param clazz the type of the {@link Attribute} value
+     * @return typed attribute, null if it is not present in the profile
+     */
+    @Override
+    public <T> Attribute<T> getAttributeByName(String name, Class<T> clazz) {
+        return wrapped.getAttributeByName(name, clazz);
+    }
+
+    /**
+     * Return single {@link Attribute} object
+     * by exact name
+     *
+     * @param name the name of the {@link Attribute}
+     * @return the attribute object, null if it is not present in the profule
+     */
+    @Override
+    public Attribute getAttributeByName(String name) {
+        return wrapped.getAttributeByName(name);
+    }
+
+    /**
+     * Return a list of {@link Attribute}s that match
+     * the exact name
+     *
+     * @param name  the name of the {@link Attribute}s
+     * @param clazz the type of the {@link Attribute} value
+     * @return typed list of attribute, empty list if there are no matching attributes on the profile
+     */
+    @Override
+    public <T> List<Attribute<T>> getAttributesByName(String name, Class<T> clazz) {
+        return wrapped.getAttributesByName(name, clazz);
     }
 
     @Override
@@ -61,22 +91,22 @@ final class HumanProfileAdapter implements HumanProfile {
 
     @Override
     public Attribute<String> getFamilyName() {
-        return wrapped.getAttribute(HumanProfileAttributes.FAMILY_NAME, String.class);
+        return wrapped.getAttributeByName(HumanProfileAttributes.FAMILY_NAME, String.class);
     }
 
     @Override
     public Attribute<String> getGivenNames() {
-        return wrapped.getAttribute(HumanProfileAttributes.GIVEN_NAMES, String.class);
+        return wrapped.getAttributeByName(HumanProfileAttributes.GIVEN_NAMES, String.class);
     }
 
     @Override
     public Attribute<String> getFullName() {
-        return wrapped.getAttribute(HumanProfileAttributes.FULL_NAME, String.class);
+        return wrapped.getAttributeByName(HumanProfileAttributes.FULL_NAME, String.class);
     }
 
     @Override
     public Attribute<Date> getDateOfBirth() {
-        return wrapped.getAttribute(HumanProfileAttributes.DATE_OF_BIRTH, Date.class);
+        return wrapped.getAttributeByName(HumanProfileAttributes.DATE_OF_BIRTH, Date.class);
     }
 
     @Override
@@ -120,48 +150,48 @@ final class HumanProfileAdapter implements HumanProfile {
 
     @Override
     public Attribute<String> getGender() {
-        return wrapped.getAttribute(HumanProfileAttributes.GENDER, String.class);
+        return wrapped.getAttributeByName(HumanProfileAttributes.GENDER, String.class);
     }
 
     @Override
     public Attribute<String> getPostalAddress() {
-        return wrapped.getAttribute(HumanProfileAttributes.POSTAL_ADDRESS, String.class);
+        return wrapped.getAttributeByName(HumanProfileAttributes.POSTAL_ADDRESS, String.class);
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public Attribute<Map<?, ?>> getStructuredPostalAddress() {
-        return wrapped.getAttribute(HumanProfileAttributes.STRUCTURED_POSTAL_ADDRESS, (Class) Map.class);
+        return wrapped.getAttributeByName(HumanProfileAttributes.STRUCTURED_POSTAL_ADDRESS, (Class) Map.class);
     }
 
     @Override
     public Attribute<String> getNationality() {
-        return wrapped.getAttribute(HumanProfileAttributes.NATIONALITY, String.class);
+        return wrapped.getAttributeByName(HumanProfileAttributes.NATIONALITY, String.class);
     }
 
     @Override
     public Attribute<String> getPhoneNumber() {
-        return wrapped.getAttribute(HumanProfileAttributes.PHONE_NUMBER, String.class);
+        return wrapped.getAttributeByName(HumanProfileAttributes.PHONE_NUMBER, String.class);
     }
 
     @Override
     public Attribute<Image> getSelfie() {
-        return wrapped.getAttribute(HumanProfileAttributes.SELFIE, Image.class);
+        return wrapped.getAttributeByName(HumanProfileAttributes.SELFIE, Image.class);
     }
 
     @Override
     public Attribute<String> getEmailAddress() {
-        return wrapped.getAttribute(HumanProfileAttributes.EMAIL_ADDRESS, String.class);
+        return wrapped.getAttributeByName(HumanProfileAttributes.EMAIL_ADDRESS, String.class);
     }
 
     @Override
     public Attribute<DocumentDetails> getDocumentDetails() {
-        return wrapped.getAttribute(HumanProfileAttributes.DOCUMENT_DETAILS, DocumentDetails.class);
+        return wrapped.getAttributeByName(HumanProfileAttributes.DOCUMENT_DETAILS, DocumentDetails.class);
     }
 
     @Override
     public Attribute<List<Image>> getDocumentImages() {
-        Attribute<?> a = wrapped.getAttribute(HumanProfileAttributes.DOCUMENT_IMAGES, List.class);
+        Attribute<?> a = wrapped.getAttributeByName(HumanProfileAttributes.DOCUMENT_IMAGES, List.class);
         return (Attribute<List<Image>>) a;
     }
 

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SimpleProfile.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SimpleProfile.java
@@ -1,13 +1,10 @@
 package com.yoti.api.client.spi.remote;
 
 import static java.util.Collections.unmodifiableList;
-import static java.util.Collections.unmodifiableMap;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import com.yoti.api.client.Attribute;
 import com.yoti.api.client.Profile;
@@ -38,14 +35,14 @@ final class SimpleProfile implements Profile {
     @Deprecated
     @Override
     public <T> Attribute<T> getAttribute(String name, Class<T> clazz) {
-        Attribute<?> attribute = doFindAttributeThatStartsWith(name);
+        Attribute<?> attribute = getAttribute(name);
         return castSafely(clazz, attribute);
     }
 
     @Deprecated
     @Override
     public Attribute getAttribute(String name) {
-        return doFindAttributeThatStartsWith(name);
+        return findAttributeStartingWith(name);
     }
 
     /**
@@ -58,7 +55,7 @@ final class SimpleProfile implements Profile {
      */
     @Override
     public <T> Attribute<T> getAttributeByName(String name, Class<T> clazz) {
-        Attribute<?> attribute = doFindAttributeThatHasName(name);
+        Attribute<?> attribute = getAttributeByName(name);
         return castSafely(clazz, attribute);
     }
 
@@ -71,7 +68,13 @@ final class SimpleProfile implements Profile {
      */
     @Override
     public Attribute getAttributeByName(String name) {
-        return doFindAttributeThatHasName(name);
+        ensureName(name);
+        for (Attribute<?> entry : protectedAttributes) {
+            if (entry.getName().equals(name)) {
+                return entry;
+            }
+        }
+        return null;
     }
 
     /**
@@ -111,7 +114,7 @@ final class SimpleProfile implements Profile {
     @Override
     public <T> Attribute<T> findAttributeStartingWith(String name, Class<T> clazz) {
         ensureName(name);
-        Attribute<?> attribute = doFindAttributeThatStartsWith(name);
+        Attribute<?> attribute = findAttributeStartingWith(name);
         return castSafely(clazz, attribute);
     }
 
@@ -120,20 +123,10 @@ final class SimpleProfile implements Profile {
         return protectedAttributes;
     }
 
-    private Attribute<?> doFindAttributeThatStartsWith(String name) {
+    private Attribute<?> findAttributeStartingWith(String name) {
         ensureName(name);
         for (Attribute<?> entry : protectedAttributes) {
             if (entry.getName().startsWith(name)) {
-                return entry;
-            }
-        }
-        return null;
-    }
-
-    private Attribute<?> doFindAttributeThatHasName(String name) {
-        ensureName(name);
-        for (Attribute<?> entry : protectedAttributes) {
-            if (entry.getName().equals(name)) {
                 return entry;
             }
         }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SimpleProfile.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SimpleProfile.java
@@ -64,7 +64,7 @@ final class SimpleProfile implements Profile {
      * by exact name
      *
      * @param name the name of the {@link Attribute}
-     * @return the attribute object, null if it is not present in the profule
+     * @return the attribute object, null if it is not present in the profile
      */
     @Override
     public Attribute getAttributeByName(String name) {

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SimpleProfile.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SimpleProfile.java
@@ -35,17 +35,64 @@ final class SimpleProfile implements Profile {
      * @param clazz attribute type
      * @return typed attribute value, null if attribute type is not assignable from the specified class
      */
+    @Deprecated
     @Override
     public <T> Attribute<T> getAttribute(String name, Class<T> clazz) {
-        ensureName(name);
-        Attribute<?> attribute = doFindAttribute(name);
+        Attribute<?> attribute = doFindAttributeThatStartsWith(name);
         return castSafely(clazz, attribute);
     }
 
+    @Deprecated
     @Override
     public Attribute getAttribute(String name) {
+        return doFindAttributeThatStartsWith(name);
+    }
+
+    /**
+     * Return single typed {@link Attribute} object
+     * by exact name
+     *
+     * @param name  the name of the {@link Attribute}
+     * @param clazz the type of the {@link Attribute} value
+     * @return typed attribute, null if it is not present in the profile
+     */
+    @Override
+    public <T> Attribute<T> getAttributeByName(String name, Class<T> clazz) {
+        Attribute<?> attribute = doFindAttributeThatHasName(name);
+        return castSafely(clazz, attribute);
+    }
+
+    /**
+     * Return single {@link Attribute} object
+     * by exact name
+     *
+     * @param name the name of the {@link Attribute}
+     * @return the attribute object, null if it is not present in the profule
+     */
+    @Override
+    public Attribute getAttributeByName(String name) {
+        return doFindAttributeThatHasName(name);
+    }
+
+    /**
+     * Return a list of {@link Attribute}s that match
+     * the exact name
+     *
+     * @param name  the name of the {@link Attribute}s
+     * @param clazz the type of the {@link Attribute} value
+     * @return typed list of attribute, empty list if there are no matching attributes on the profile
+     */
+    @Override
+    public <T> List<Attribute<T>> getAttributesByName(String name, Class<T> clazz) {
         ensureName(name);
-        return doFindAttribute(name);
+        List<Attribute<T>> matches = new ArrayList<>();
+        for (Attribute<?> entry : protectedAttributes) {
+            if (entry.getName().equals(name)) {
+                Attribute<T> value = castSafely(clazz, entry);
+                matches.add(value);
+            }
+        }
+        return matches;
     }
 
     @Override
@@ -64,7 +111,7 @@ final class SimpleProfile implements Profile {
     @Override
     public <T> Attribute<T> findAttributeStartingWith(String name, Class<T> clazz) {
         ensureName(name);
-        Attribute<?> attribute = doFindAttribute(name);
+        Attribute<?> attribute = doFindAttributeThatStartsWith(name);
         return castSafely(clazz, attribute);
     }
 
@@ -73,10 +120,20 @@ final class SimpleProfile implements Profile {
         return protectedAttributes;
     }
 
-    private Attribute<?> doFindAttribute(String name) {
+    private Attribute<?> doFindAttributeThatStartsWith(String name) {
         ensureName(name);
         for (Attribute<?> entry : protectedAttributes) {
             if (entry.getName().startsWith(name)) {
+                return entry;
+            }
+        }
+        return null;
+    }
+
+    private Attribute<?> doFindAttributeThatHasName(String name) {
+        ensureName(name);
+        for (Attribute<?> entry : protectedAttributes) {
+            if (entry.getName().equals(name)) {
                 return entry;
             }
         }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SimpleProfile.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/SimpleProfile.java
@@ -1,5 +1,6 @@
 package com.yoti.api.client.spi.remote;
 
+import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 
 import java.util.ArrayList;
@@ -13,7 +14,7 @@ import com.yoti.api.client.Profile;
 
 final class SimpleProfile implements Profile {
 
-    private final Map<String, Attribute<?>> protectedAttributes;
+    private final List<Attribute<?>> protectedAttributes;
 
     /**
      * Create a new profile based on a list of attributes
@@ -24,7 +25,7 @@ final class SimpleProfile implements Profile {
         if (attributeList == null) {
             throw new IllegalArgumentException("Attributes must not be null.");
         }
-        this.protectedAttributes = unmodifiableMap(createAttributeMap(attributeList));
+        this.protectedAttributes = unmodifiableList(attributeList);
     }
 
     /**
@@ -37,23 +38,23 @@ final class SimpleProfile implements Profile {
     @Override
     public <T> Attribute<T> getAttribute(String name, Class<T> clazz) {
         ensureName(name);
-        Attribute<?> attribute = protectedAttributes.get(name);
+        Attribute<?> attribute = doFindAttribute(name);
         return castSafely(clazz, attribute);
     }
 
     @Override
     public Attribute getAttribute(String name) {
         ensureName(name);
-        return protectedAttributes.get(name);
+        return doFindAttribute(name);
     }
 
     @Override
     public <T> List<Attribute<T>> findAttributesStartingWith(String name, Class<T> clazz) {
         ensureName(name);
         List<Attribute<T>> matches = new ArrayList<>();
-        for (Map.Entry<String, Attribute<?>> entry : protectedAttributes.entrySet()) {
-            if (entry.getKey().startsWith(name)) {
-                Attribute<T> value = castSafely(clazz, entry.getValue());
+        for (Attribute<?> entry : protectedAttributes) {
+            if (entry.getName().startsWith(name)) {
+                Attribute<T> value = castSafely(clazz, entry);
                 matches.add(value);
             }
         }
@@ -69,22 +70,14 @@ final class SimpleProfile implements Profile {
 
     @Override
     public Collection<Attribute<?>> getAttributes() {
-        return protectedAttributes.values();
-    }
-
-    private Map<String, Attribute<?>> createAttributeMap(List<Attribute<?>> attributes) {
-        Map<String, Attribute<?>> result = new HashMap<>();
-        for (Attribute<?> a : attributes) {
-            result.put(a.getName(), a);
-        }
-        return result;
+        return protectedAttributes;
     }
 
     private Attribute<?> doFindAttribute(String name) {
         ensureName(name);
-        for (Map.Entry<String, Attribute<?>> entry : protectedAttributes.entrySet()) {
-            if (entry.getKey().startsWith(name)) {
-                return entry.getValue();
+        for (Attribute<?> entry : protectedAttributes) {
+            if (entry.getName().startsWith(name)) {
+                return entry;
             }
         }
         return null;

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/shareurl/policy/SimpleWantedAttributeBuilderTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/shareurl/policy/SimpleWantedAttributeBuilderTest.java
@@ -27,7 +27,7 @@ public class SimpleWantedAttributeBuilderTest {
 
     @Test
     public void buildsAnAttribute() {
-        WantedAttribute result = new SimpleWantedAttributeBuilder()
+        WantedAttribute result = WantedAttributeBuilder.newInstance()
                 .withName(SOME_NAME)
                 .withDerivation(SOME_DERIVATION)
                 .withOptional(true)
@@ -42,7 +42,7 @@ public class SimpleWantedAttributeBuilderTest {
     public void buildsAnAttributeWithSourceConstraint() {
         when(constraintListMock.size()).thenReturn(1);
 
-        WantedAttribute result = new SimpleWantedAttributeBuilder()
+        WantedAttribute result = WantedAttributeBuilder.newInstance()
                 .withName(SOME_NAME)
                 .withDerivation(SOME_DERIVATION)
                 .withOptional(true)

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/shareurl/policy/SimpleWantedAttributeBuilderTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/shareurl/policy/SimpleWantedAttributeBuilderTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yoti.api.client.shareurl.constraint.Constraint;
 import com.yoti.api.client.shareurl.constraint.SourceConstraint;
 import org.junit.BeforeClass;

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/shareurl/policy/SimpleWantedAttributeBuilderTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/shareurl/policy/SimpleWantedAttributeBuilderTest.java
@@ -1,21 +1,17 @@
 package com.yoti.api.client.shareurl.policy;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.when;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yoti.api.client.shareurl.constraint.Constraint;
-import com.yoti.api.client.shareurl.constraint.SourceConstraint;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.ArrayList;
 import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SimpleWantedAttributeBuilderTest {

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/SimpleProfileTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/SimpleProfileTest.java
@@ -242,7 +242,7 @@ public class SimpleProfileTest {
     }
 
     @Test
-    public void getAttributeByName_shouldReturnAllMatchingAttributesWhenMultipleWithSameName() {
+    public void getAttributesByName_shouldReturnAllMatchingAttributesWhenMultipleWithSameName() {
         List<Attribute<?>> attributeList = new ArrayList<>();
         attributeList.add(createAttribute("some_attribute", "firstValue"));
         attributeList.add(createAttribute("some_attribute", "secondValue"));


### PR DESCRIPTION
- [x] Merge #138 into `DEVELOPMENT`

## Added

* `Profile`
  * Added methods for getting an attribute by exact name, as the old `getAttribute` method used the same filtering functionality as `findAttributeByName` which checked if the attribute name started with the name supplied.
  * Changed the way Attributes are stored within Profile to use a list rather than a map.  This is to support receiving multiple attributes with the same name (i.e. document_images with different constraints)
* `DynamicPolicyBuilder`
  * The key of each wanted attribute is now modified if the attribute has a list of constraints attached to it.  This is to support the requesting of the same attribute multiple times with different constraints in Dynamic Scenarios

## Deprecated

* `Profile`
  * The old `getAttribute` methods have been deprecated in favour of using `getAttributeByName` using an equality match.