### PR TITLE
SDK-1278: Refactor exception handling for more concise error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,13 @@ If you are using Maven, you need to add the following dependency:
 <dependency>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-impl</artifactId>
-    <version>2.5.0</version>
+    <version>2.5.1</version>
 </dependency>
 ```
 
 If you are using Gradle, here is the dependency to add:
 
-`compile group: 'com.yoti', name: 'yoti-sdk-impl', version: '2.5.0'`
+`compile group: 'com.yoti', name: 'yoti-sdk-impl', version: '2.5.1'`
 
 You will find all classes packaged under `com.yoti.api`
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk</artifactId>
   <packaging>pom</packaging>
-  <version>2.5.0</version>
+  <version>2.5.1</version>
   <name>Yoti SDK</name>
   <description>Java SDK for simple integration with the Yoti platform</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>

--- a/yoti-sdk-api/pom.xml
+++ b/yoti-sdk-api/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.5.0</version>
+    <version>2.5.1</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
 

--- a/yoti-sdk-impl/pom.xml
+++ b/yoti-sdk-impl/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.5.0</version>
+    <version>2.5.1</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
   

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/YotiConstants.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/YotiConstants.java
@@ -19,7 +19,7 @@ public final class YotiConstants {
     public static final String CONTENT_TYPE_JSON = "application/json";
 
     public static final String JAVA = "Java";
-    public static final String SDK_VERSION = JAVA + "-2.5.0";
+    public static final String SDK_VERSION = JAVA + "-2.5.1";
     public static final String SIGNATURE_ALGORITHM = "SHA256withRSA";
     public static final String ASYMMETRIC_CIPHER = "RSA/NONE/PKCS1Padding";
     public static final String SYMMETRIC_CIPHER = "AES/CBC/PKCS7Padding";

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/call/aml/RemoteAmlServiceTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/call/aml/RemoteAmlServiceTest.java
@@ -2,18 +2,13 @@ package com.yoti.api.client.spi.remote.call.aml;
 
 import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 
-import static com.yoti.api.client.spi.remote.call.HttpMethod.HTTP_POST;
-import static com.yoti.api.client.spi.remote.call.YotiConstants.DEFAULT_YOTI_API_URL;
-
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
-import static org.mockito.Answers.RETURNS_SELF;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.util.HashMap;
 import java.util.Map;
@@ -22,7 +17,6 @@ import com.yoti.api.client.AmlException;
 import com.yoti.api.client.aml.AmlProfile;
 import com.yoti.api.client.spi.remote.call.ResourceException;
 import com.yoti.api.client.spi.remote.call.SignedRequest;
-import com.yoti.api.client.spi.remote.call.SignedRequestBuilder;
 import com.yoti.api.client.spi.remote.call.factory.UnsignedPathFactory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -33,6 +27,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -44,11 +39,10 @@ public class RemoteAmlServiceTest {
     private static final byte[] BODY_BYTES = SERIALIZED_BODY.getBytes();
     private static final Map<String, String> SOME_HEADERS = new HashMap<>();
 
-    @InjectMocks RemoteAmlService testObj;
+    @Spy @InjectMocks RemoteAmlService testObj;
 
     @Mock UnsignedPathFactory unsignedPathFactoryMock;
     @Mock ObjectMapper objectMapperMock;
-    @Mock(answer = RETURNS_SELF) SignedRequestBuilder signedRequestBuilderMock;
 
     @Mock AmlProfile amlProfileMock;
     @Mock(answer = RETURNS_DEEP_STUBS) KeyPair keyPairMock;
@@ -68,16 +62,11 @@ public class RemoteAmlServiceTest {
     @Test
     public void shouldPerformAmlCheck() throws Exception {
         when(objectMapperMock.writeValueAsString(amlProfileMock)).thenReturn(SERIALIZED_BODY);
-        when(signedRequestBuilderMock.build()).thenReturn(signedRequestMock);
+        doReturn(signedRequestMock).when(testObj).createSignedRequest(keyPairMock, GENERATED_PATH, BODY_BYTES);
         when(signedRequestMock.execute(SimpleAmlResult.class)).thenReturn(simpleAmlResultMock);
 
         SimpleAmlResult result = testObj.performCheck(keyPairMock, SOME_APP_ID, amlProfileMock);
 
-        verify(signedRequestBuilderMock).withKeyPair(keyPairMock);
-        verify(signedRequestBuilderMock).withBaseUrl(DEFAULT_YOTI_API_URL);
-        verify(signedRequestBuilderMock).withEndpoint(GENERATED_PATH);
-        verify(signedRequestBuilderMock).withPayload(BODY_BYTES);
-        verify(signedRequestBuilderMock).withHttpMethod(HTTP_POST);
         assertSame(result, simpleAmlResultMock);
     }
 
@@ -85,7 +74,7 @@ public class RemoteAmlServiceTest {
     public void shouldWrapIOException() throws Exception {
         IOException ioException = new IOException();
         when(objectMapperMock.writeValueAsString(amlProfileMock)).thenReturn(SERIALIZED_BODY);
-        when(signedRequestBuilderMock.build()).thenReturn(signedRequestMock);
+        doReturn(signedRequestMock).when(testObj).createSignedRequest(keyPairMock, GENERATED_PATH, BODY_BYTES);
         when(signedRequestMock.execute(SimpleAmlResult.class)).thenThrow(ioException);
 
         try {
@@ -100,7 +89,7 @@ public class RemoteAmlServiceTest {
     public void shouldWrapResourceException() throws Exception {
         ResourceException resourceException = new ResourceException(HTTP_UNAUTHORIZED, "Unauthorized", "failed verification");
         when(objectMapperMock.writeValueAsString(amlProfileMock)).thenReturn(SERIALIZED_BODY);
-        when(signedRequestBuilderMock.build()).thenReturn(signedRequestMock);
+        doReturn(signedRequestMock).when(testObj).createSignedRequest(keyPairMock, GENERATED_PATH, BODY_BYTES);
         when(signedRequestMock.execute(SimpleAmlResult.class)).thenThrow(resourceException);
 
         try {
@@ -108,20 +97,6 @@ public class RemoteAmlServiceTest {
             fail("Expected AmlException");
         } catch (AmlException e) {
             assertSame(resourceException, e.getCause());
-        }
-    }
-
-    @Test
-    public void shouldWrapGeneralSecurityException() throws Exception {
-        GeneralSecurityException generalSecurityException = new GeneralSecurityException();
-        when(objectMapperMock.writeValueAsString(amlProfileMock)).thenReturn(SERIALIZED_BODY);
-        when(signedRequestBuilderMock.build()).thenThrow(generalSecurityException);
-
-        try {
-            testObj.performCheck(keyPairMock, SOME_APP_ID, amlProfileMock);
-            fail("Expected AmlException");
-        } catch (AmlException e) {
-            assertSame(generalSecurityException, e.getCause());
         }
     }
 

--- a/yoti-sdk-parent/pom.xml
+++ b/yoti-sdk-parent/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-parent</artifactId>
   <packaging>pom</packaging>
-  <version>2.5.0</version>
+  <version>2.5.1</version>
   <name>Yoti SDK Parent Pom</name>
   <description>Parent pom for the Java SDK projects</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>

--- a/yoti-sdk-sandbox/pom.xml
+++ b/yoti-sdk-sandbox/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.5.0</version>
+    <version>2.5.1</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
   

--- a/yoti-sdk-spring-boot-auto-config/README.md
+++ b/yoti-sdk-spring-boot-auto-config/README.md
@@ -18,7 +18,7 @@ If you are using Maven, you need to add the following dependencies:
 <dependency>
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-boot-auto-config</artifactId>
-  <version>2.5.0</version>
+  <version>2.5.1</version>
 </dependency>
 ```
 
@@ -26,7 +26,7 @@ If you are using Maven, you need to add the following dependencies:
 If you are using Gradle, here is the dependency to add:
 
 ```
-compile group: 'com.yoti', name: 'yoti-sdk-spring-boot-auto-config', version: '2.5.0'
+compile group: 'com.yoti', name: 'yoti-sdk-spring-boot-auto-config', version: '2.5.1'
 ```
 
 

--- a/yoti-sdk-spring-boot-auto-config/pom.xml
+++ b/yoti-sdk-spring-boot-auto-config/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.5.0</version>
+    <version>2.5.1</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
 

--- a/yoti-sdk-spring-boot-example/README.md
+++ b/yoti-sdk-spring-boot-example/README.md
@@ -16,7 +16,7 @@ Before you start, you'll need to create an Application in [Yoti Hub](https://hub
     <dependency>
       <groupId>com.yoti</groupId>
       <artifactId>yoti-sdk-impl</artifactId>
-      <version>2.5.0</version>
+      <version>2.5.1</version>
     </dependency>
 ```
 
@@ -29,8 +29,8 @@ Before you start, you'll need to create an Application in [Yoti Hub](https://hub
 1. Run `mvn clean package` to build the project.
 
 ## Running
-* You can run your server-app by executing `java -jar target/yoti-sdk-spring-boot-example-2.5.0.jar`
-  * If you are using Java 9, you can run the server-app as follows `java -jar target/yoti-sdk-spring-boot-example-2.5.0.jar --add-exports java.base/jdk.internal.ref=ALL-UNNAMED`
+* You can run your server-app by executing `java -jar target/yoti-sdk-spring-boot-example-2.5.1.jar`
+  * If you are using Java 9, you can run the server-app as follows `java -jar target/yoti-sdk-spring-boot-example-2.5.1.jar --add-exports java.base/jdk.internal.ref=ALL-UNNAMED`
 * Navigate to `https://localhost:8443`
 * You can then initiate a login using Yoti.  The Spring demo is listening for the response on `https://localhost:8443/login`.
 

--- a/yoti-sdk-spring-boot-example/pom.xml
+++ b/yoti-sdk-spring-boot-example/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-boot-example</artifactId>
 
-  <version>2.5.0</version>
+  <version>2.5.1</version>
 
   <name>Yoti Spring Boot Example</name>
   <parent>

--- a/yoti-sdk-spring-security/README.md
+++ b/yoti-sdk-spring-security/README.md
@@ -25,14 +25,14 @@ If you are using Maven, you need to add the following dependencies:
 <dependency>
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-security</artifactId>
-  <version>2.5.0</version>
+  <version>2.5.1</version>
 </dependency>
 ```
 
 If you are using Gradle, here is the dependency to add:
 
 ```
-compile group: 'com.yoti', name: 'yoti-sdk-spring-security', version: '2.5.0'
+compile group: 'com.yoti', name: 'yoti-sdk-spring-security', version: '2.5.1'
 ```
 
 ### Provide a `YotiClient` instance

--- a/yoti-sdk-spring-security/pom.xml
+++ b/yoti-sdk-spring-security/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.5.0</version>
+    <version>2.5.1</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
 


### PR DESCRIPTION
## Changed

* Updated exception handling of the Signed Request builder to make error reporting more concise