### PR TITLE
SDK-1274: Update Signed Request & Builder

### DIFF
--- a/yoti-sdk-impl/findbugs-rules.xml
+++ b/yoti-sdk-impl/findbugs-rules.xml
@@ -32,6 +32,21 @@
     </Match>
 
     <Match>
+        <Class name="com.yoti.api.client.spi.remote.JpegAttributeValue"/>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+    </Match>
+
+    <Match>
+        <Class name="com.yoti.api.client.spi.remote.PngAttributeValue"/>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+    </Match>
+
+    <Match>
+        <Class name="com.yoti.api.client.spi.remote.call.SignedRequestResponse"/>
+        <Bug pattern="EI_EXPOSE_REP"/>
+    </Match>
+
+    <Match>
         <Bug pattern="CRLF_INJECTION_LOGS"/>
     </Match>
 

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/JpegAttributeValue.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/JpegAttributeValue.java
@@ -4,7 +4,7 @@ package com.yoti.api.client.spi.remote;
  * Attribute value holding a JPEG image.
  *
  */
-final class JpegAttributeValue extends ImageAttributeValue {
+public final class JpegAttributeValue extends ImageAttributeValue {
 
     private static final String MIME_TYPE = "image/jpeg";
 

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/PngAttributeValue.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/PngAttributeValue.java
@@ -4,7 +4,7 @@ package com.yoti.api.client.spi.remote;
  * Attribute value holding a PNG image.
  *
  */
-final class PngAttributeValue extends ImageAttributeValue {
+public final class PngAttributeValue extends ImageAttributeValue {
 
     private static final String MIME_TYPE = "image/png";
 

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ReceiptFetcher.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ReceiptFetcher.java
@@ -2,18 +2,17 @@ package com.yoti.api.client.spi.remote;
 
 import static com.yoti.api.client.spi.remote.call.YotiConstants.DEFAULT_CHARSET;
 
-import java.security.KeyPair;
-import java.security.PrivateKey;
-
 import com.yoti.api.client.ActivityFailureException;
 import com.yoti.api.client.ProfileException;
 import com.yoti.api.client.spi.remote.call.ProfileService;
 import com.yoti.api.client.spi.remote.call.Receipt;
 import com.yoti.api.client.spi.remote.call.RemoteProfileService;
 import com.yoti.api.client.spi.remote.util.DecryptionHelper;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.security.KeyPair;
+import java.security.PrivateKey;
 
 class ReceiptFetcher {
 

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/ImageResourceFetcher.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/ImageResourceFetcher.java
@@ -1,0 +1,55 @@
+package com.yoti.api.client.spi.remote.call;
+
+import static com.yoti.api.client.spi.remote.call.YotiConstants.CONTENT_TYPE;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.CONTENT_TYPE_JPEG;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.CONTENT_TYPE_PNG;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import com.yoti.api.client.Image;
+import com.yoti.api.client.spi.remote.JpegAttributeValue;
+import com.yoti.api.client.spi.remote.PngAttributeValue;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class ImageResourceFetcher {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ImageResourceFetcher.class);
+
+    private final RawResourceFetcher rawResourceFetcher;
+
+    public static ImageResourceFetcher newInstance(RawResourceFetcher rawResourceFetcher) {
+        return new ImageResourceFetcher(rawResourceFetcher);
+    }
+
+    private ImageResourceFetcher(RawResourceFetcher rawResourceFetcher) {
+        this.rawResourceFetcher = rawResourceFetcher;
+    }
+
+    Image doRequest(SignedRequest signedRequest) throws IOException, ResourceException {
+        SignedRequestResponse signedRequestResponse = rawResourceFetcher.doRequest(signedRequest);
+        String contentType = getContentType(signedRequestResponse.getResponseHeaders());
+        byte[] responseBody = signedRequestResponse.getResponseBody();
+        switch (contentType) {
+            case CONTENT_TYPE_PNG:
+                return new PngAttributeValue(responseBody);
+            case CONTENT_TYPE_JPEG:
+                return new JpegAttributeValue(responseBody);
+            default:
+                LOG.error("Failed to convert image of type: (" + contentType + ")");
+                throw new ResourceException(signedRequestResponse.getResponseCode(), "Failed to convert image of type: (" + contentType + ")", null);
+        }
+    }
+
+    private String getContentType(Map<String, List<String>> responseHeaders) {
+        List<String> values = responseHeaders.get(CONTENT_TYPE);
+        if (values != null && values.size() > 0) {
+            return values.get(0);
+        }
+        return null;
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/JsonResourceFetcher.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/JsonResourceFetcher.java
@@ -2,98 +2,53 @@ package com.yoti.api.client.spi.remote.call;
 
 import static com.yoti.api.client.spi.remote.call.HttpMethod.HTTP_GET;
 import static com.yoti.api.client.spi.remote.call.HttpMethod.HTTP_POST;
-import static com.yoti.api.client.spi.remote.call.YotiConstants.DEFAULT_CHARSET;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
 import java.util.Map;
-import java.util.Scanner;
-
-import com.yoti.api.client.spi.remote.util.QuietCloseable;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public final class JsonResourceFetcher implements ResourceFetcher {
 
-    private static final Logger LOG = LoggerFactory.getLogger(JsonResourceFetcher.class);
-
     private final ObjectMapper objectMapper;
+    private final RawResourceFetcher rawResourceFetcher;
 
     public static JsonResourceFetcher newInstance() {
-        return new JsonResourceFetcher(new ObjectMapper());
+        return JsonResourceFetcher.newInstance(new RawResourceFetcher());
     }
 
-    JsonResourceFetcher(ObjectMapper objectMapper) {
+    public static JsonResourceFetcher newInstance(RawResourceFetcher rawResourceFetcher) {
+        return new JsonResourceFetcher(new ObjectMapper(), rawResourceFetcher);
+    }
+
+    private JsonResourceFetcher(ObjectMapper objectMapper,
+            RawResourceFetcher rawResourceFetcher) {
         this.objectMapper = objectMapper;
+        this.rawResourceFetcher = rawResourceFetcher;
     }
 
     @Override
+    @Deprecated
     public <T> T fetchResource(UrlConnector urlConnector, Map<String, String> headers, Class<T> resourceClass) throws ResourceException, IOException {
         return doRequest(urlConnector, HTTP_GET, null, headers, resourceClass);
     }
 
     @Override
+    @Deprecated
     public <T> T postResource(UrlConnector urlConnector, byte[] body, Map<String, String> headers, Class<T> resourceClass)
             throws ResourceException, IOException {
         return doRequest(urlConnector, HTTP_POST, body, headers, resourceClass);
     }
 
+    @Deprecated
     public <T> T doRequest(UrlConnector urlConnector, String httpMethod, byte[] body, Map<String, String> headers, Class<T> resourceClass) throws ResourceException, IOException {
-        HttpURLConnection httpUrlConnection = openConnection(urlConnector, httpMethod, headers);
-        sendBody(body, httpUrlConnection);
-        return parseResponse(httpUrlConnection, resourceClass);
+        SignedRequestResponse signedRequestResponse = rawResourceFetcher.doRequest(urlConnector, httpMethod, body, headers);
+        return objectMapper.readValue(signedRequestResponse.getResponseBody(), resourceClass);
     }
 
-    private HttpURLConnection openConnection(UrlConnector urlConnector, String httpMethod, Map<String, String> headers) throws IOException {
-        LOG.debug("Connecting to: '{}'", urlConnector.getUrlString());
-        HttpURLConnection httpUrlConnection = urlConnector.getHttpUrlConnection();
-        httpUrlConnection.setRequestMethod(httpMethod);
-        setHeaders(headers, httpUrlConnection);
-        return httpUrlConnection;
-    }
-
-    private void setHeaders(Map<String, String> headers, HttpURLConnection con) {
-        if (headers != null) {
-            for (Map.Entry<String, String> entry : headers.entrySet()) {
-                con.setRequestProperty(entry.getKey(), entry.getValue());
-            }
-        }
-    }
-
-    private void sendBody(byte[] body, HttpURLConnection httpUrlConnection) throws IOException {
-        if (body != null) {
-            httpUrlConnection.setDoOutput(true);
-            httpUrlConnection.getOutputStream().write(body);
-            httpUrlConnection.getOutputStream().close();
-        }
-    }
-
-    private <T> T parseResponse(HttpURLConnection httpUrlConnection, Class<T> resourceClass) throws ResourceException, IOException {
-        int responseCode = httpUrlConnection.getResponseCode();
-        if (responseCode >= HttpURLConnection.HTTP_BAD_REQUEST) {
-            String responseBody = readError(httpUrlConnection);
-            throw new ResourceException(responseCode, httpUrlConnection.getResponseMessage(), responseBody);
-        }
-        return readBody(httpUrlConnection, resourceClass);
-    }
-
-    private String readError(HttpURLConnection httpURLConnection) throws IOException {
-        try (QuietCloseable<Scanner> scanner = new QuietCloseable(createScanner(httpURLConnection.getErrorStream()))) {
-            return scanner.get().hasNext() ? scanner.get().next() : "";
-        }
-    }
-
-    private static Scanner createScanner(InputStream inputStream) {
-        return new Scanner(inputStream, DEFAULT_CHARSET).useDelimiter("\\A");
-    }
-
-    private <T> T readBody(HttpURLConnection httpURLConnection, Class<T> clazz) throws IOException {
-        try (QuietCloseable<InputStream> inputStream = new QuietCloseable<>(httpURLConnection.getInputStream())) {
-            return objectMapper.readValue(inputStream.get(), clazz);
-        }
+    <T> T doRequest(SignedRequest signedRequest, Class<T> resourceClass) throws ResourceException, IOException {
+        SignedRequestResponse signedRequestResponse = rawResourceFetcher.doRequest(signedRequest);
+        return objectMapper.readValue(signedRequestResponse.getResponseBody(), resourceClass);
     }
 
 }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/RawResourceFetcher.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/RawResourceFetcher.java
@@ -1,0 +1,129 @@
+package com.yoti.api.client.spi.remote.call;
+
+import static com.yoti.api.client.spi.remote.call.YotiConstants.DEFAULT_CHARSET;
+
+import com.yoti.api.client.spi.remote.util.QuietCloseable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.util.Map;
+import java.util.Scanner;
+
+class RawResourceFetcher {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RawResourceFetcher.class);
+
+    private static Scanner createScanner(InputStream inputStream) {
+        return new Scanner(inputStream, DEFAULT_CHARSET).useDelimiter("\\A");
+    }
+
+    public SignedRequestResponse doRequest(SignedRequest signedRequest) throws IOException, ResourceException {
+        UrlConnector urlConnector = UrlConnector.get(signedRequest.getUri().toString());
+        return doRequest(urlConnector, signedRequest.getMethod(), signedRequest.getData(), signedRequest.getHeaders());
+    }
+
+    public SignedRequestResponse doRequest(UrlConnector urlConnector, String method, byte[] data, Map<String, String> headers)
+            throws IOException, ResourceException {
+        HttpURLConnection httpUrlConnection = openConnection(urlConnector, method, headers);
+        sendBody(data, httpUrlConnection);
+        return parseResponse(httpUrlConnection);
+    }
+
+    /**
+     * Open a connection to the specified host, using the httpMethod and headers.
+     *
+     * @param urlConnector the {@link UrlConnector}
+     * @param httpMethod   the HTTP Method
+     * @param headers      {@link Map} of headers
+     * @return {@link HttpURLConnection} the url connection
+     * @throws IOException
+     */
+    private HttpURLConnection openConnection(UrlConnector urlConnector, String httpMethod, Map<String, String> headers) throws IOException {
+        LOG.debug("Connecting to: '{}'", urlConnector.getUrlString());
+        HttpURLConnection httpUrlConnection = urlConnector.getHttpUrlConnection();
+        httpUrlConnection.setRequestMethod(httpMethod);
+        setHeaders(headers, httpUrlConnection);
+        return httpUrlConnection;
+    }
+
+    /**
+     * Sets the request properties on a {@link HttpURLConnection}
+     * using supplied {@link Map}
+     *
+     * @param headers the request headers
+     * @param con     the connection
+     */
+    private void setHeaders(Map<String, String> headers, HttpURLConnection con) {
+        if (headers != null) {
+            for (Map.Entry<String, String> entry : headers.entrySet()) {
+                con.setRequestProperty(entry.getKey(), entry.getValue());
+            }
+        }
+    }
+
+    /**
+     * Sends request body to the supplied {@link HttpURLConnection}
+     *
+     * @param body              the request body
+     * @param httpUrlConnection the http connection
+     * @throws IOException
+     */
+    private void sendBody(byte[] body, HttpURLConnection httpUrlConnection) throws IOException {
+        if (body != null) {
+            httpUrlConnection.setDoOutput(true);
+            httpUrlConnection.getOutputStream().write(body);
+            httpUrlConnection.getOutputStream().close();
+        }
+    }
+
+    /**
+     * Parse the response from the {@link HttpURLConnection}
+     *
+     * @param httpUrlConnection the url connection
+     * @return the response
+     * @throws ResourceException
+     * @throws IOException
+     */
+    private SignedRequestResponse parseResponse(HttpURLConnection httpUrlConnection) throws ResourceException, IOException {
+        int responseCode = httpUrlConnection.getResponseCode();
+        if (responseCode >= HttpURLConnection.HTTP_BAD_REQUEST) {
+            String responseBody = readError(httpUrlConnection);
+            throw new ResourceException(responseCode, httpUrlConnection.getResponseMessage(), responseBody);
+        }
+        return new SignedRequestResponse(responseCode, readBody(httpUrlConnection), httpUrlConnection.getHeaderFields());
+    }
+
+    /**
+     * Read the error from the {@link HttpURLConnection} if an error
+     * HTTP status code has been returned.
+     *
+     * @param httpURLConnection the url connection
+     * @return the error string
+     */
+    private String readError(HttpURLConnection httpURLConnection) {
+        try (QuietCloseable<Scanner> scanner = new QuietCloseable<>(createScanner(httpURLConnection.getErrorStream()))) {
+            return scanner.get().hasNext() ? scanner.get().next() : "";
+        }
+    }
+
+    private byte[] readBody(HttpURLConnection httpURLConnection) throws IOException {
+        try (QuietCloseable<InputStream> inputStream = new QuietCloseable<>(httpURLConnection.getInputStream())) {
+            return readChunked(inputStream.get());
+        }
+    }
+
+    private byte[] readChunked(InputStream inputStream) throws IOException {
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        byte[] byteChunk = new byte[4096];
+        int n;
+        while ((n = inputStream.read(byteChunk)) > 0) {
+            byteArrayOutputStream.write(byteChunk, 0, n);
+        }
+        return byteArrayOutputStream.toByteArray();
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/SignedRequestBuilder.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/SignedRequestBuilder.java
@@ -20,12 +20,14 @@ import com.yoti.api.client.spi.remote.util.Validation;
 public class SignedRequestBuilder {
 
     public static SignedRequestBuilder newInstance() {
+        RawResourceFetcher rawResourceFetcher = new RawResourceFetcher();
         return new SignedRequestBuilder(
                 new PathFactory(),
                 SignedMessageFactory.newInstance(),
                 new HeadersFactory(),
-                JsonResourceFetcher.newInstance()
-        );
+                JsonResourceFetcher.newInstance(rawResourceFetcher),
+                rawResourceFetcher,
+                ImageResourceFetcher.newInstance(rawResourceFetcher));
     }
 
     private KeyPair keyPair;
@@ -40,15 +42,21 @@ public class SignedRequestBuilder {
     private final SignedMessageFactory signedMessageFactory;
     private final HeadersFactory headersFactory;
     private final JsonResourceFetcher jsonResourceFetcher;
+    private final RawResourceFetcher rawResourceFetcher;
+    private final ImageResourceFetcher imageResourceFetcher;
 
     SignedRequestBuilder(PathFactory pathFactory,
             SignedMessageFactory signedMessageFactory,
             HeadersFactory headersFactory,
-            JsonResourceFetcher jsonResourceFetcher) {
+            JsonResourceFetcher jsonResourceFetcher,
+            RawResourceFetcher rawResourceFetcher,
+            ImageResourceFetcher imageResourceFetcher) {
         this.pathFactory = pathFactory;
         this.signedMessageFactory = signedMessageFactory;
         this.headersFactory = headersFactory;
         this.jsonResourceFetcher = jsonResourceFetcher;
+        this.rawResourceFetcher = rawResourceFetcher;
+        this.imageResourceFetcher = imageResourceFetcher;
     }
 
     /**
@@ -154,8 +162,9 @@ public class SignedRequestBuilder {
                 httpMethod,
                 payload,
                 headers,
-                jsonResourceFetcher
-        );
+                jsonResourceFetcher,
+                rawResourceFetcher,
+                imageResourceFetcher);
     }
 
     private void validateRequest() {

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/SignedRequestResponse.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/SignedRequestResponse.java
@@ -1,0 +1,29 @@
+package com.yoti.api.client.spi.remote.call;
+
+import java.util.List;
+import java.util.Map;
+
+public class SignedRequestResponse {
+
+    private final int responseCode;
+    private final byte[] responseBody;
+    private final Map<String, List<String>> responseHeaders;
+
+    public SignedRequestResponse(int responseCode, byte[] responseBody, Map<String, List<String>> responseHeaders) {
+        this.responseCode = responseCode;
+        this.responseBody = responseBody.clone();
+        this.responseHeaders = responseHeaders;
+    }
+
+    public int getResponseCode() {
+        return responseCode;
+    }
+
+    public byte[] getResponseBody() {
+        return responseBody;
+    }
+
+    public Map<String, List<String>> getResponseHeaders() {
+        return responseHeaders;
+    }
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/YotiConstants.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/YotiConstants.java
@@ -17,6 +17,8 @@ public final class YotiConstants {
 
     public static final String CONTENT_TYPE = "Content-Type";
     public static final String CONTENT_TYPE_JSON = "application/json";
+    public static final String CONTENT_TYPE_PNG = "image/png";
+    public static final String CONTENT_TYPE_JPEG = "image/jpeg";
 
     public static final String JAVA = "Java";
     public static final String SDK_VERSION = JAVA + "-2.6.0-SNAPSHOT";

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/call/ImageResourceFetcherTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/call/ImageResourceFetcherTest.java
@@ -1,0 +1,76 @@
+package com.yoti.api.client.spi.remote.call;
+
+import static java.util.Arrays.asList;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.yoti.api.client.Image;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ImageResourceFetcherTest {
+
+    private static final int SOME_OK_STATUS_CODE = 200;
+    private static final byte[] SOME_RESPONSE_BODY = new byte[] { 5, 6, 7, 8 };
+
+    @InjectMocks ImageResourceFetcher testObj;
+
+    @Mock RawResourceFetcher rawResourceFetcherMock;
+    @Mock SignedRequest signedRequestMock;
+
+    private Map<String, List<String>> createResponseHeaderMap(String name, List<String> values) {
+        HashMap<String, List<String>> result = new HashMap<>();
+        result.put(name, values);
+        return result;
+    }
+
+    @Test
+    public void doRequest_shouldReturnPngImage() throws Exception {
+        Map<String, List<String>> headersMap = createResponseHeaderMap("Content-Type", asList(YotiConstants.CONTENT_TYPE_PNG));
+        SignedRequestResponse signedRequestResponse = new SignedRequestResponse(SOME_OK_STATUS_CODE, SOME_RESPONSE_BODY, headersMap);
+        when(rawResourceFetcherMock.doRequest(signedRequestMock)).thenReturn(signedRequestResponse);
+
+        Image result = testObj.doRequest(signedRequestMock);
+
+        assertThat(result.getMimeType(), is(YotiConstants.CONTENT_TYPE_PNG));
+        assertTrue(Arrays.equals(result.getContent(), SOME_RESPONSE_BODY));
+    }
+
+    @Test
+    public void doRequest_shouldReturnJpegImage() throws Exception {
+        Map<String, List<String>> headersMap = createResponseHeaderMap("Content-Type", asList(YotiConstants.CONTENT_TYPE_JPEG));
+        SignedRequestResponse signedRequestResponse = new SignedRequestResponse(SOME_OK_STATUS_CODE, SOME_RESPONSE_BODY, headersMap);
+        when(rawResourceFetcherMock.doRequest(signedRequestMock)).thenReturn(signedRequestResponse);
+
+        Image result = testObj.doRequest(signedRequestMock);
+
+        String mimeType = result.getMimeType();
+        byte[] content = result.getContent();
+
+        assertThat(mimeType, is(YotiConstants.CONTENT_TYPE_JPEG));
+        assertTrue(Arrays.equals(content, SOME_RESPONSE_BODY));
+    }
+
+    @Test(expected = ResourceException.class)
+    public void doRequest_shouldThrowResourceExceptionForUnsupportedImageType() throws Exception {
+        Map<String, List<String>> headersMap = createResponseHeaderMap("Content-Type", asList("image/webp"));
+        SignedRequestResponse signedRequestResponse = new SignedRequestResponse(SOME_OK_STATUS_CODE, SOME_RESPONSE_BODY, headersMap);
+        when(rawResourceFetcherMock.doRequest(signedRequestMock)).thenReturn(signedRequestResponse);
+
+        testObj.doRequest(signedRequestMock);
+    }
+
+}

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/call/JsonResourceFetcherTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/call/JsonResourceFetcherTest.java
@@ -1,23 +1,7 @@
 package com.yoti.api.client.spi.remote.call;
 
-import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
-import static java.net.HttpURLConnection.HTTP_OK;
-
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
-import static org.mockito.Answers.RETURNS_DEEP_STUBS;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.util.HashMap;
-import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
@@ -28,10 +12,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
 @RunWith(MockitoJUnitRunner.class)
 public class JsonResourceFetcherTest {
 
-    private static final String ERROR_BODY = "errorBody";
     private static final String TEST_HEADER_KEY = "testHeader";
     private static final String TEST_HEADER_VALUE = "testValue";
     private static final Map<String, String> TEST_HEADERS = new HashMap();
@@ -39,12 +26,11 @@ public class JsonResourceFetcherTest {
     @InjectMocks JsonResourceFetcher testObj;
 
     @Mock ObjectMapper objectMapperMock;
+    @Mock RawResourceFetcher rawResourceFetcherMock;
 
-    @Mock(answer = RETURNS_DEEP_STUBS) HttpURLConnection httpURLConnectionMock;
     @Mock UrlConnector urlConnectorMock;
-    @Mock InputStream inputStreamMock;
-    InputStream errorStreamSpy;
-    byte[] requestBody = new byte[]{};
+    @Mock SignedRequestResponse signedRequestResponseMock;
+
     Object parsedResponse = new Object();
 
     @BeforeClass
@@ -54,147 +40,39 @@ public class JsonResourceFetcherTest {
 
     @Before
     public void setUp() throws Exception {
-        errorStreamSpy = spy(new ByteArrayInputStream(ERROR_BODY.getBytes()));
-
-        when(urlConnectorMock.getHttpUrlConnection()).thenReturn(httpURLConnectionMock);
-        when(httpURLConnectionMock.getInputStream()).thenReturn(inputStreamMock);
-        when(httpURLConnectionMock.getErrorStream()).thenReturn(errorStreamSpy);
+        when(rawResourceFetcherMock.doRequest(urlConnectorMock, HttpMethod.HTTP_GET, null, TEST_HEADERS)).thenReturn(signedRequestResponseMock);
     }
 
     @Test
     public void fetchResource_shouldReturnResource() throws Exception {
-        when(httpURLConnectionMock.getResponseCode()).thenReturn(HTTP_OK);
-        when(objectMapperMock.readValue(inputStreamMock, Object.class)).thenReturn(parsedResponse);
-
-        Object result = testObj.fetchResource(urlConnectorMock, TEST_HEADERS, Object.class);
-
-        verify(httpURLConnectionMock).setRequestMethod("GET");
-        verify(httpURLConnectionMock).setRequestProperty(TEST_HEADER_KEY, TEST_HEADER_VALUE);
-        assertSame(parsedResponse, result);
-        verify(inputStreamMock).close();
-    }
-
-    @Test
-    public void fetchResource_shouldFailForNonOkStatusCode() throws Exception {
-        when(httpURLConnectionMock.getResponseCode()).thenReturn(HTTP_BAD_REQUEST);
-
-        try {
-            testObj.fetchResource(urlConnectorMock, TEST_HEADERS, Object.class);
-            fail("ResourceException expected");
-        } catch (ResourceException re) {
-            assertEquals(HTTP_BAD_REQUEST, re.getResponseCode());
-            assertEquals(ERROR_BODY, re.getResponseBody());
-            verify(errorStreamSpy).close();
-        }
-    }
-
-    @Test
-    public void fetchResource_shouldCloseConnectionAfterParsingError() throws Exception {
-        when(httpURLConnectionMock.getResponseCode()).thenReturn(HTTP_OK);
-        when(objectMapperMock.readValue(inputStreamMock, Object.class)).thenThrow(new IOException());
-
-        try {
-            testObj.fetchResource(urlConnectorMock, TEST_HEADERS, Object.class);
-            testObj.fetchResource(urlConnectorMock, null, Object.class);
-            fail("IOException expected");
-        } catch (IOException ioe) {
-            verify(inputStreamMock).close();
-        }
-    }
-
-    @Test
-    public void fetchResource_shouldSuppressExceptionFromClosingInputStream() throws Exception {
-        when(httpURLConnectionMock.getResponseCode()).thenReturn(HTTP_OK);
-        when(objectMapperMock.readValue(inputStreamMock, Object.class)).thenReturn(parsedResponse);
-        doThrow(new IOException()).when(inputStreamMock).close();
+        when(objectMapperMock.readValue(signedRequestResponseMock.getResponseBody(), Object.class)).thenReturn(parsedResponse);
 
         Object result = testObj.fetchResource(urlConnectorMock, TEST_HEADERS, Object.class);
 
         assertSame(parsedResponse, result);
-        verify(inputStreamMock).close();
+    }
+
+    @Test(expected = IOException.class)
+    public void fetchResource_shouldThrowIOExceptionForInvalidResponse() throws Exception {
+        when(objectMapperMock.readValue(signedRequestResponseMock.getResponseBody(), Object.class)).thenThrow(new IOException());
+
+        testObj.fetchResource(urlConnectorMock, TEST_HEADERS, Object.class);
     }
 
     @Test
-    public void fetchResource_shouldSuppressExceptionFromClosingErrorStream() throws Exception {
-        when(httpURLConnectionMock.getResponseCode()).thenReturn(HTTP_BAD_REQUEST);
-        doThrow(new IOException()).when(errorStreamSpy).close();
+    public void doRequest_shouldReturnResource() throws Exception {
+        when(objectMapperMock.readValue(signedRequestResponseMock.getResponseBody(), Object.class)).thenReturn(parsedResponse);
 
-        try {
-            testObj.fetchResource(urlConnectorMock, TEST_HEADERS, Object.class);
-            fail("ResourceException expected");
-        } catch (ResourceException re) {
-            assertEquals(HTTP_BAD_REQUEST, re.getResponseCode());
-            assertEquals(ERROR_BODY, re.getResponseBody());
-            verify(errorStreamSpy).close();
-        }
-    }
-
-    @Test
-    public void postResource_shouldSendBodyAndReturnResponse() throws Exception {
-        when(httpURLConnectionMock.getResponseCode()).thenReturn(HTTP_OK);
-        when(objectMapperMock.readValue(inputStreamMock, Object.class)).thenReturn(parsedResponse);
-
-        Object result = testObj.postResource(urlConnectorMock, requestBody, TEST_HEADERS, Object.class);
-
-        verify(httpURLConnectionMock).setRequestMethod("POST");
-        verify(httpURLConnectionMock).setRequestProperty(TEST_HEADER_KEY, TEST_HEADER_VALUE);
-        verify(httpURLConnectionMock.getOutputStream()).write(requestBody);
-        assertSame(parsedResponse, result);
-        verify(inputStreamMock).close();
-    }
-
-    @Test
-    public void postResource_shouldFailForNonOkStatusCode() throws Exception {
-        when(httpURLConnectionMock.getResponseCode()).thenReturn(HTTP_BAD_REQUEST);
-
-        try {
-            testObj.postResource(urlConnectorMock, null, null, Object.class);
-            fail("ResourceException expected");
-        } catch (ResourceException re) {
-            assertEquals(HTTP_BAD_REQUEST, re.getResponseCode());
-            assertEquals(ERROR_BODY, re.getResponseBody());
-            verify(errorStreamSpy).close();
-        }
-    }
-
-    @Test
-    public void postResource_shouldCloseConnectionAfterParsingError() throws Exception {
-        when(httpURLConnectionMock.getResponseCode()).thenReturn(HTTP_OK);
-        when(objectMapperMock.readValue(inputStreamMock, Object.class)).thenThrow(new IOException());
-
-        try {
-            testObj.postResource(urlConnectorMock, null, null, Object.class);
-            fail("IOException expected");
-        } catch (IOException ioe) {
-            verify(inputStreamMock).close();
-        }
-    }
-
-    @Test
-    public void postResource_shouldSuppressExceptionFromClosingInputStream() throws Exception {
-        when(httpURLConnectionMock.getResponseCode()).thenReturn(HTTP_OK);
-        when(objectMapperMock.readValue(inputStreamMock, Object.class)).thenReturn(parsedResponse);
-        doThrow(new IOException()).when(inputStreamMock).close();
-
-        Object result = testObj.postResource(urlConnectorMock, requestBody, TEST_HEADERS, Object.class);
+        Object result = testObj.doRequest(urlConnectorMock, HttpMethod.HTTP_GET, null, TEST_HEADERS, Object.class);
 
         assertSame(parsedResponse, result);
-        verify(inputStreamMock).close();
     }
 
-    @Test
-    public void postResource_shouldSuppressExceptionFromClosingErrorStream() throws Exception {
-        when(httpURLConnectionMock.getResponseCode()).thenReturn(HTTP_BAD_REQUEST);
-        doThrow(new IOException()).when(errorStreamSpy).close();
+    @Test(expected = IOException.class)
+    public void doRequest_shouldThrowIOExceptionForInvalidResponse() throws Exception {
+        when(objectMapperMock.readValue(signedRequestResponseMock.getResponseBody(), Object.class)).thenThrow(new IOException());
 
-        try {
-            testObj.postResource(urlConnectorMock, null, null, Object.class);
-            fail("ResourceException expected");
-        } catch (ResourceException re) {
-            assertEquals(HTTP_BAD_REQUEST, re.getResponseCode());
-            assertEquals(ERROR_BODY, re.getResponseBody());
-            verify(errorStreamSpy).close();
-        }
+        testObj.doRequest(urlConnectorMock, HttpMethod.HTTP_GET, null, TEST_HEADERS, Object.class);
     }
 
 }

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/call/RawResourceFetcherTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/call/RawResourceFetcherTest.java
@@ -1,0 +1,177 @@
+package com.yoti.api.client.spi.remote.call;
+
+import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.junit.Assert.*;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.*;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.util.HashMap;
+import java.util.Map;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RawResourceFetcherTest {
+
+    private static final String ERROR_BODY = "errorBody";
+    private static final String TEST_HEADER_KEY = "testHeader";
+    private static final String TEST_HEADER_VALUE = "testValue";
+    private static final Map<String, String> TEST_HEADERS = new HashMap();
+
+    @Spy @InjectMocks RawResourceFetcher testObj;
+
+    @Mock(answer = RETURNS_DEEP_STUBS) HttpURLConnection httpURLConnectionMock;
+    @Mock UrlConnector urlConnectorMock;
+
+    InputStream inputStreamSpy;
+    InputStream errorStreamSpy;
+
+    byte[] requestBody = new byte[]{5, 6, 7, 8};
+    byte[] responseBody = new byte[]{1, 2, 3, 4};
+
+    @BeforeClass
+    public static void classSetup() {
+        TEST_HEADERS.put(TEST_HEADER_KEY, TEST_HEADER_VALUE);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        inputStreamSpy = spy(new ByteArrayInputStream(responseBody));
+        errorStreamSpy = spy(new ByteArrayInputStream(ERROR_BODY.getBytes()));
+        when(urlConnectorMock.getHttpUrlConnection()).thenReturn(httpURLConnectionMock);
+        when(httpURLConnectionMock.getErrorStream()).thenReturn(errorStreamSpy);
+    }
+
+    @Test
+    public void doRequest_shouldReturnByteArray() throws Exception {
+        when(httpURLConnectionMock.getInputStream()).thenReturn(inputStreamSpy);
+        when(httpURLConnectionMock.getResponseCode()).thenReturn(HTTP_OK);
+
+        SignedRequestResponse result = testObj.doRequest(urlConnectorMock, HttpMethod.HTTP_GET, null, TEST_HEADERS);
+
+        verify(httpURLConnectionMock).setRequestMethod("GET");
+        verify(httpURLConnectionMock).setRequestProperty(TEST_HEADER_KEY, TEST_HEADER_VALUE);
+        assertArrayEquals(responseBody, result.getResponseBody());
+        verify(inputStreamSpy).close();
+    }
+
+    @Test
+    public void chunkRead_shouldHandleInputStreamSmallerThanDefaultChunkSize() throws Exception {
+        byte[] response = createByteArrayOfSize(40);
+        InputStream smallerSizeByteArray = spy(new ByteArrayInputStream(response));
+
+        when(httpURLConnectionMock.getInputStream()).thenReturn(smallerSizeByteArray);
+        when(httpURLConnectionMock.getResponseCode()).thenReturn(HTTP_OK);
+
+        SignedRequestResponse result = testObj.doRequest(urlConnectorMock, HttpMethod.HTTP_GET, null, TEST_HEADERS);
+
+        verify(httpURLConnectionMock).setRequestMethod("GET");
+        verify(httpURLConnectionMock).setRequestProperty(TEST_HEADER_KEY, TEST_HEADER_VALUE);
+        assertArrayEquals(response, result.getResponseBody());
+        verify(smallerSizeByteArray).close();
+    }
+
+    @Test
+    public void chunkRead_shouldHandleInputStreamLargerThanDefaultChunkSize() throws Exception {
+        byte[] response = createByteArrayOfSize(40);
+        InputStream largerSizeByteArray = spy(new ByteArrayInputStream(response));
+
+        when(httpURLConnectionMock.getInputStream()).thenReturn(largerSizeByteArray);
+        when(httpURLConnectionMock.getResponseCode()).thenReturn(HTTP_OK);
+
+        SignedRequestResponse result = testObj.doRequest(urlConnectorMock, HttpMethod.HTTP_GET, null, TEST_HEADERS);
+
+        verify(httpURLConnectionMock).setRequestMethod("GET");
+        verify(httpURLConnectionMock).setRequestProperty(TEST_HEADER_KEY, TEST_HEADER_VALUE);
+        assertArrayEquals(response, result.getResponseBody());
+    }
+
+    @Test
+    public void doRequest_shouldFailForNonOkStatusCode() throws Exception {
+        when(httpURLConnectionMock.getResponseCode()).thenReturn(HTTP_BAD_REQUEST);
+
+        try {
+            testObj.doRequest(urlConnectorMock, HttpMethod.HTTP_GET, null, TEST_HEADERS);
+            fail("ResourceException expected");
+        } catch (ResourceException re) {
+            assertEquals(HTTP_BAD_REQUEST, re.getResponseCode());
+            assertEquals(ERROR_BODY, re.getResponseBody());
+            verify(errorStreamSpy).close();
+        }
+    }
+
+    @Test
+    public void doRequest_shouldCloseConnectionAfterParsingError() throws Exception {
+        when(httpURLConnectionMock.getResponseCode()).thenReturn(HTTP_OK);
+        when(httpURLConnectionMock.getInputStream()).thenReturn(inputStreamSpy);
+
+        doThrow(new IOException()).when(inputStreamSpy).read(any(byte[].class));
+
+        try {
+            testObj.doRequest(urlConnectorMock, HttpMethod.HTTP_GET, null, TEST_HEADERS);
+            fail("IOException expected");
+        } catch (IOException ioe) {
+            verify(inputStreamSpy).close();
+        }
+    }
+
+    @Test
+    public void doRequest_shouldSuppressExceptionFromClosingInputStream() throws Exception {
+        when(httpURLConnectionMock.getResponseCode()).thenReturn(HTTP_OK);
+        when(httpURLConnectionMock.getInputStream()).thenReturn(inputStreamSpy);
+        doThrow(new IOException()).when(inputStreamSpy).close();
+
+        testObj.doRequest(urlConnectorMock, HttpMethod.HTTP_GET, null, TEST_HEADERS);
+
+        verify(inputStreamSpy).close();
+    }
+
+    @Test
+    public void doRequest_shouldSuppressExceptionFromClosingErrorStream() throws Exception {
+        when(httpURLConnectionMock.getResponseCode()).thenReturn(HTTP_BAD_REQUEST);
+        doThrow(new IOException()).when(errorStreamSpy).close();
+
+        try {
+            testObj.doRequest(urlConnectorMock, HttpMethod.HTTP_GET, null, TEST_HEADERS);
+            fail("ResourceException expected");
+        } catch (ResourceException re) {
+            assertEquals(HTTP_BAD_REQUEST, re.getResponseCode());
+            assertEquals(ERROR_BODY, re.getResponseBody());
+            verify(errorStreamSpy).close();
+        }
+    }
+
+    @Test
+    public void doRequest_shouldSendBodyAndReturnResponse() throws Exception {
+        when(httpURLConnectionMock.getResponseCode()).thenReturn(HTTP_OK);
+        when(httpURLConnectionMock.getInputStream()).thenReturn(inputStreamSpy);
+
+        SignedRequestResponse result = testObj.doRequest(urlConnectorMock, HttpMethod.HTTP_POST, requestBody, TEST_HEADERS);
+
+        verify(httpURLConnectionMock).setRequestMethod("POST");
+        verify(httpURLConnectionMock).setRequestProperty(TEST_HEADER_KEY, TEST_HEADER_VALUE);
+        verify(httpURLConnectionMock.getOutputStream()).write(requestBody);
+        assertArrayEquals(responseBody, result.getResponseBody());
+    }
+
+    private byte[] createByteArrayOfSize(int size) {
+        byte[] output = new byte[size];
+        for (int i = 0; i < size; i++) {
+            output[i] = (byte) i;
+        }
+        return output;
+    }
+
+}

--- a/yoti-sdk-parent/pom.xml
+++ b/yoti-sdk-parent/pom.xml
@@ -9,34 +9,7 @@
   <name>Yoti SDK Parent Pom</name>
   <description>Parent pom for the Java SDK projects</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>
-  
-  <developers>
-    <developer>
-      <name>Andras Bulla</name>
-    </developer>
-    <developer>
-      <name>Radoslaw Busz</name>
-    </developer>
-    <developer>
-      <name>David Goaté</name>
-    </developer>
-    <developer>
-      <name>Attila Kiss</name>
-    </developer>
-    <developer>
-      <name>Quirino Zagarese</name>
-    </developer>
-    <developer>
-      <name>Michael Buck</name>
-    </developer>
-    <developer>
-      <name>Francesco Sorice</name>
-    </developer>
-    <developer>
-      <name>Vincenzo Candela</name>
-    </developer>
-  </developers>
-  
+
   <licenses>
     <license>
       <name>Yoti License</name>


### PR DESCRIPTION
## Added

* Support for different Content-Types that are used in the Yoti ecosystem (mainly images and binary data used in Doc Scan)