### PR TITLE
SDK-1307: Extra Data Exception

### DIFF
--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ActivityDetailsFactory.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/ActivityDetailsFactory.java
@@ -57,11 +57,11 @@ class ActivityDetailsFactory {
         return new SimpleActivityDetails(rememberMeId, parentRememberMeId, userProfile, applicationProfile, extraData, timestamp, receipt.getReceiptId());
     }
 
-    private ExtraData parseExtraData(byte[] extraDataBytes, Key secretKey) {
+    private ExtraData parseExtraData(byte[] extraDataBytes, Key secretKey) throws ProfileException {
         ExtraData extraData;
         try {
             extraData = extraDataReader.read(extraDataBytes, secretKey);
-        } catch (ProfileException | ExtraDataException e) {
+        } catch (ExtraDataException e) {
             LOG.error("Failed to parse extra data from receipt");
             extraData = new SimpleExtraData();
         }


### PR DESCRIPTION
## Changed

* `ActivityDetailsFactory.create(...)` now re-throws `ProfileException` when reading extra data, and failing to decrypt the object.
* Any other exception from reading Extra Data (i.e. invalid data entry) will be wrapped silently.