### PR TITLE
Release-2.6.0: Add Yoti as a developer in parent POM

### DIFF
--- a/yoti-sdk-parent/pom.xml
+++ b/yoti-sdk-parent/pom.xml
@@ -10,6 +10,12 @@
   <description>Parent pom for the Java SDK projects</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>
 
+  <developers>
+    <developer>
+      <name>Yoti</name>
+    </developer>
+  </developers>
+
   <licenses>
     <license>
       <name>Yoti License</name>


### PR DESCRIPTION
## Added

* `Yoti` as a developer in the parent POM (this is required to push to sonatype)