### PR TITLE
SDK-1462: Add Doc Scan support for multiple documents and filters

### DIFF
--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/DocScanClient.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/DocScanClient.java
@@ -4,6 +4,7 @@ import com.yoti.api.client.Media;
 import com.yoti.api.client.docs.session.create.CreateSessionResult;
 import com.yoti.api.client.docs.session.create.SessionSpec;
 import com.yoti.api.client.docs.session.retrieve.GetSessionResult;
+import com.yoti.api.client.docs.support.SupportedDocumentsResponse;
 
 /**
  * Client used for communication with the Yoti Doc Scan service
@@ -59,5 +60,13 @@ public interface DocScanClient {
      * @throws DocScanException if an error has occurred
      */
     void deleteMediaContent(String sessionId, String mediaId)  throws DocScanException;
+
+    /**
+     * Gets a list of supported documents.
+     *
+     * @return the supported documents
+     * @throws DocScanException if an error has occurred
+     */
+    SupportedDocumentsResponse getSupportedDocuments() throws DocScanException;
 
 }

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/DocScanConstants.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/DocScanConstants.java
@@ -25,4 +25,11 @@ public class DocScanConstants {
     public static final String FALLBACK = "FALLBACK";
     public static final String NEVER = "NEVER";
 
+    public static final String ID_DOCUMENT = "ID_DOCUMENT";
+    public static final String ORTHOGONAL_RESTRICTIONS = "ORTHOGONAL_RESTRICTIONS";
+    public static final String DOCUMENT_RESTRICTIONS = "DOCUMENT_RESTRICTIONS";
+
+    public static final String INCLUSION_WHITELIST = "WHITELIST";
+    public static final String INCLUSION_BLACKLIST = "BLACKLIST";
+
 }

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/SessionSpec.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/SessionSpec.java
@@ -1,6 +1,7 @@
 package com.yoti.api.client.docs.session.create;
 
 import com.yoti.api.client.docs.session.create.check.RequestedCheck;
+import com.yoti.api.client.docs.session.create.filters.RequiredDocument;
 import com.yoti.api.client.docs.session.create.task.RequestedTask;
 
 import java.util.List;
@@ -58,5 +59,12 @@ public interface SessionSpec {
      * @return the {@link SdkConfig}
      */
     SdkConfig getSdkConfig();
+
+    /**
+     * List of {@link RequiredDocument} defining the documents required from the client
+     *
+     * @return the required documents
+     */
+    List<RequiredDocument> getRequiredDocuments();
 
 }

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/SessionSpecBuilder.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/SessionSpecBuilder.java
@@ -1,6 +1,7 @@
 package com.yoti.api.client.docs.session.create;
 
 import com.yoti.api.client.docs.session.create.check.RequestedCheck;
+import com.yoti.api.client.docs.session.create.filters.RequiredDocument;
 import com.yoti.api.client.docs.session.create.task.RequestedTask;
 
 /**
@@ -63,6 +64,14 @@ public interface SessionSpecBuilder {
      * @return the builder
      */
     SessionSpecBuilder withSdkConfig(SdkConfig sdkConfig);
+
+    /**
+     * Adds a {@link RequiredDocument} to the list
+     *
+     * @param requiredDocument the {@code RequiredDocument}
+     * @return the builder
+     */
+    SessionSpecBuilder withRequiredDocument(RequiredDocument requiredDocument);
 
     /**
      * Builds the {@link SessionSpec} based on the values supplied to the builder

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/CountryRestriction.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/CountryRestriction.java
@@ -1,0 +1,11 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+import java.util.List;
+
+public interface CountryRestriction {
+
+    String getInclusion();
+
+    List<String> getCountryCodes();
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/DocumentFilter.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/DocumentFilter.java
@@ -1,0 +1,16 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+/**
+ * Filter for a required document, allowing specification
+ * of restrictive parameters
+ */
+public interface DocumentFilter {
+
+    /**
+     * The type of the filter
+     *
+     * @return the type
+     */
+    String getType();
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/DocumentFilterBuilderFactory.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/DocumentFilterBuilderFactory.java
@@ -1,0 +1,25 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+import java.util.ServiceLoader;
+
+public abstract class DocumentFilterBuilderFactory {
+
+    /**
+     * Returns a new instance of a {@link DocumentFilterBuilderFactory} using
+     * Java's service loader to find the first available implementation
+     *
+     * @return the factory
+     */
+    public static DocumentFilterBuilderFactory newInstance() {
+        ServiceLoader<DocumentFilterBuilderFactory> serviceLoader = ServiceLoader.load(DocumentFilterBuilderFactory.class);
+        if (!serviceLoader.iterator().hasNext()) {
+            throw new IllegalStateException("Cannot find any implementation of " + DocumentFilterBuilderFactory.class.getSimpleName());
+        }
+        return serviceLoader.iterator().next();
+    }
+
+    public abstract OrthogonalRestrictionsFilterBuilder forOrthogonalRestrictionsFilter();
+
+    public abstract DocumentRestrictionsFilterBuilder forDocumentRestrictionsFilter();
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/DocumentRestriction.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/DocumentRestriction.java
@@ -1,0 +1,11 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+import java.util.List;
+
+public interface DocumentRestriction {
+
+    List<String> getCountryCodes();
+
+    List<String> getDocumentTypes();
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/DocumentRestrictionBuilder.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/DocumentRestrictionBuilder.java
@@ -1,0 +1,13 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+import java.util.List;
+
+public interface DocumentRestrictionBuilder {
+
+    DocumentRestrictionBuilder withCountries(List<String> countryCodes);
+
+    DocumentRestrictionBuilder withDocumentTypes(List<String> documentTypes);
+
+    DocumentRestriction build();
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/DocumentRestrictionBuilderFactory.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/DocumentRestrictionBuilderFactory.java
@@ -1,0 +1,23 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+import java.util.ServiceLoader;
+
+public abstract class DocumentRestrictionBuilderFactory {
+
+    /**
+     * Returns a new instance of a {@link DocumentRestrictionBuilderFactory} using
+     * Java's service loader to find the first available implementation
+     *
+     * @return the factory
+     */
+    public static DocumentRestrictionBuilderFactory newInstance() {
+        ServiceLoader<DocumentRestrictionBuilderFactory> serviceLoader = ServiceLoader.load(DocumentRestrictionBuilderFactory.class);
+        if (!serviceLoader.iterator().hasNext()) {
+            throw new IllegalStateException("Cannot find any implementation of " + DocumentRestrictionBuilderFactory.class.getSimpleName());
+        }
+        return serviceLoader.iterator().next();
+    }
+
+    public abstract DocumentRestrictionBuilder forDocumentRestriction();
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/DocumentRestrictionsFilter.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/DocumentRestrictionsFilter.java
@@ -1,0 +1,11 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+import java.util.List;
+
+public interface DocumentRestrictionsFilter extends DocumentFilter {
+
+    String getInclusion();
+
+    List<DocumentRestriction> getDocuments();
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/DocumentRestrictionsFilterBuilder.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/DocumentRestrictionsFilterBuilder.java
@@ -1,0 +1,17 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+import java.util.List;
+
+public interface DocumentRestrictionsFilterBuilder {
+
+    DocumentRestrictionsFilterBuilder forWhitelist();
+
+    DocumentRestrictionsFilterBuilder forBlacklist();
+
+    DocumentRestrictionsFilterBuilder withDocumentRestriction(List<String> countryCodes, List<String> documentTypes);
+
+    DocumentRestrictionsFilterBuilder withDocumentRestriction(DocumentRestriction documentRestriction);
+
+    DocumentRestrictionsFilter build();
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/OrthogonalRestrictionsFilter.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/OrthogonalRestrictionsFilter.java
@@ -1,0 +1,9 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+public interface OrthogonalRestrictionsFilter extends DocumentFilter {
+
+    CountryRestriction getCountryRestriction();
+
+    TypeRestriction getTypeRestriction();
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/OrthogonalRestrictionsFilterBuilder.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/OrthogonalRestrictionsFilterBuilder.java
@@ -1,0 +1,17 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+import java.util.List;
+
+public interface OrthogonalRestrictionsFilterBuilder {
+
+    OrthogonalRestrictionsFilterBuilder withWhitelistedCountries(List<String> countryCodes);
+
+    OrthogonalRestrictionsFilterBuilder withBlacklistedCountries(List<String> countryCodes);
+
+    OrthogonalRestrictionsFilterBuilder withWhitelistedDocumentTypes(List<String> documentTypes);
+
+    OrthogonalRestrictionsFilterBuilder withBlacklistedDocumentTypes(List<String> documentTypes);
+
+    OrthogonalRestrictionsFilter build();
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/RequiredDocument.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/RequiredDocument.java
@@ -1,0 +1,15 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+/**
+ * Defines a document to be provided by the user
+ */
+public interface RequiredDocument {
+
+    /**
+     * The type of the required document
+     *
+     * @return the type
+     */
+    String getType();
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/RequiredDocumentBuilderFactory.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/RequiredDocumentBuilderFactory.java
@@ -1,0 +1,23 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+import java.util.ServiceLoader;
+
+public abstract class RequiredDocumentBuilderFactory {
+
+    /**
+     * Returns a new instance of a {@link DocumentFilterBuilderFactory} using
+     * Java's service loader to find the first relevant implementation
+     *
+     * @return the factory
+     */
+    public static RequiredDocumentBuilderFactory newInstance() {
+        ServiceLoader<RequiredDocumentBuilderFactory> serviceLoader = ServiceLoader.load(RequiredDocumentBuilderFactory.class);
+        if (!serviceLoader.iterator().hasNext()) {
+            throw new IllegalStateException("Cannot find any implementation of " + RequiredDocumentBuilderFactory.class.getSimpleName());
+        }
+        return serviceLoader.iterator().next();
+    }
+
+    public abstract RequiredIdDocumentBuilder forIdDocument();
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/RequiredIdDocument.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/RequiredIdDocument.java
@@ -1,0 +1,15 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+/**
+ * Defines an identity document to be provided by the user
+ */
+public interface RequiredIdDocument extends RequiredDocument {
+
+    /**
+     * Filter for the required document
+     *
+     * @return the filter
+     */
+    DocumentFilter getFilter();
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/RequiredIdDocumentBuilder.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/RequiredIdDocumentBuilder.java
@@ -1,0 +1,9 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+public interface RequiredIdDocumentBuilder {
+
+    RequiredIdDocumentBuilder withFilter(DocumentFilter filter);
+
+    RequiredIdDocument build();
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/TypeRestriction.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/filters/TypeRestriction.java
@@ -1,0 +1,11 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+import java.util.List;
+
+public interface TypeRestriction {
+
+    String getInclusion();
+
+    List<String> getDocumentTypes();
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/support/SupportedCountry.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/support/SupportedCountry.java
@@ -1,0 +1,11 @@
+package com.yoti.api.client.docs.support;
+
+import java.util.List;
+
+public interface SupportedCountry {
+
+    String getCode();
+
+    List<? extends SupportedDocument> getSupportedDocuments();
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/support/SupportedDocument.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/support/SupportedDocument.java
@@ -1,0 +1,7 @@
+package com.yoti.api.client.docs.support;
+
+public interface SupportedDocument {
+
+    String getType();
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/support/SupportedDocumentsResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/support/SupportedDocumentsResponse.java
@@ -1,0 +1,9 @@
+package com.yoti.api.client.docs.support;
+
+import java.util.List;
+
+public interface SupportedDocumentsResponse {
+
+    List<? extends SupportedCountry> getSupportedCountries();
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/DocScanService.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/DocScanService.java
@@ -13,6 +13,8 @@ import com.yoti.api.client.docs.session.create.CreateSessionResult;
 import com.yoti.api.client.docs.session.create.SessionSpec;
 import com.yoti.api.client.docs.session.create.SimpleCreateSessionResult;
 import com.yoti.api.client.docs.session.retrieve.SimpleGetSessionResult;
+import com.yoti.api.client.docs.support.SimpleSupportedDocumentsResponse;
+import com.yoti.api.client.docs.support.SupportedDocumentsResponse;
 import com.yoti.api.client.spi.remote.MediaValue;
 import com.yoti.api.client.spi.remote.call.ResourceException;
 import com.yoti.api.client.spi.remote.call.SignedRequest;
@@ -242,6 +244,27 @@ final class DocScanService {
         }
     }
 
+    public SupportedDocumentsResponse getSupportedDocuments(KeyPair keyPair) throws DocScanException {
+        notNull(keyPair, "Application key Pair");
+
+        String path = unsignedPathFactory.createGetSupportedDocumentsPath();
+
+        try {
+            SignedRequest signedRequest = getSignedRequestBuilder()
+                    .withKeyPair(keyPair)
+                    .withBaseUrl(apiUrl)
+                    .withEndpoint(path)
+                    .withHttpMethod(HTTP_GET)
+                    .build();
+
+            return signedRequest.execute(SimpleSupportedDocumentsResponse.class);
+        } catch (GeneralSecurityException | ResourceException ex) {
+            throw new DocScanException("Error executing the GET: " + ex.getMessage(), ex);
+        } catch (IOException | URISyntaxException ex) {
+            throw new DocScanException("Error building the request: " + ex.getMessage(), ex);
+        }
+    }
+
     private String findContentType(SignedRequestResponse response) {
         List<String> contentTypeValues = null;
         for (Map.Entry<String, List<String>> entry : response.getResponseHeaders().entrySet()) {
@@ -256,5 +279,4 @@ final class DocScanService {
     SignedRequestBuilder getSignedRequestBuilder() {
         return SignedRequestBuilder.newInstance();
     }
-
 }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/SimpleDocScanClient.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/SimpleDocScanClient.java
@@ -10,6 +10,7 @@ import com.yoti.api.client.Media;
 import com.yoti.api.client.docs.session.create.CreateSessionResult;
 import com.yoti.api.client.docs.session.create.SessionSpec;
 import com.yoti.api.client.docs.session.retrieve.GetSessionResult;
+import com.yoti.api.client.docs.support.SupportedDocumentsResponse;
 import com.yoti.api.client.spi.remote.KeyStreamVisitor;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -65,6 +66,18 @@ public class SimpleDocScanClient implements DocScanClient {
     public void deleteMediaContent(String sessionId, String mediaId) throws DocScanException {
         LOG.debug("Deleting media content '{}' in session '{}'", mediaId, sessionId);
         docScanService.deleteMediaContent(sdkId, keyPair, sessionId, mediaId);
+    }
+
+    /**
+     * Gets a list of supported documents.
+     *
+     * @return the supported documents
+     * @throws DocScanException if an error has occurred
+     */
+    @Override
+    public SupportedDocumentsResponse getSupportedDocuments() throws DocScanException {
+        LOG.debug("Getting all supported documents");
+        return docScanService.getSupportedDocuments(keyPair);
     }
 
     private KeyPair loadKeyPair(KeyPairSource kpSource) throws InitialisationException {

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/SimpleSessionSpec.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/SimpleSessionSpec.java
@@ -3,6 +3,7 @@ package com.yoti.api.client.docs.session.create;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.yoti.api.client.docs.session.create.check.RequestedCheck;
+import com.yoti.api.client.docs.session.create.filters.RequiredDocument;
 import com.yoti.api.client.docs.session.create.task.RequestedTask;
 
 import java.util.List;
@@ -31,11 +32,17 @@ public class SimpleSessionSpec implements SessionSpec {
     @JsonProperty("sdk_config")
     private final SdkConfig sdkConfig;
 
+    @JsonProperty("required_documents")
+    private final List<RequiredDocument> requiredDocuments;
+
     public SimpleSessionSpec(Integer clientSessionTokenTtl,
                              Integer resourcesTtl,
                              String userTrackingId,
                              NotificationConfig notifications,
-                             List<RequestedCheck> requestedChecks, List<RequestedTask> requestedTasks, SdkConfig sdkConfig) {
+                             List<RequestedCheck> requestedChecks,
+                             List<RequestedTask> requestedTasks,
+                             SdkConfig sdkConfig,
+                             List<RequiredDocument> requiredDocuments) {
         this.clientSessionTokenTtl = clientSessionTokenTtl;
         this.resourcesTtl = resourcesTtl;
         this.userTrackingId = userTrackingId;
@@ -43,6 +50,7 @@ public class SimpleSessionSpec implements SessionSpec {
         this.requestedChecks = requestedChecks;
         this.requestedTasks = requestedTasks;
         this.sdkConfig = sdkConfig;
+        this.requiredDocuments = requiredDocuments;
     }
 
     @Override
@@ -78,6 +86,11 @@ public class SimpleSessionSpec implements SessionSpec {
     @Override
     public SdkConfig getSdkConfig() {
         return sdkConfig;
+    }
+
+    @Override
+    public List<RequiredDocument> getRequiredDocuments() {
+        return requiredDocuments;
     }
 
 }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/SimpleSessionSpecBuilder.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/SimpleSessionSpecBuilder.java
@@ -2,6 +2,7 @@ package com.yoti.api.client.docs.session.create;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.yoti.api.client.docs.session.create.check.RequestedCheck;
+import com.yoti.api.client.docs.session.create.filters.RequiredDocument;
 import com.yoti.api.client.docs.session.create.task.RequestedTask;
 
 import java.util.ArrayList;
@@ -12,6 +13,7 @@ public class SimpleSessionSpecBuilder implements SessionSpecBuilder {
 
     private final List<RequestedCheck> requestedChecks = new ArrayList<>();
     private final List<RequestedTask> requestedTasks = new ArrayList<>();
+    private final List<RequiredDocument> requiredDocuments = new ArrayList<>();
     private Integer clientSessionTokenTtl;
     private Integer resourcesTtl;
     private String userTrackingId;
@@ -61,8 +63,14 @@ public class SimpleSessionSpecBuilder implements SessionSpecBuilder {
     }
 
     @Override
+    public SessionSpecBuilder withRequiredDocument(RequiredDocument requiredDocument) {
+        this.requiredDocuments.add(requiredDocument);
+        return this;
+    }
+
+    @Override
     public SessionSpec build() {
-        return new SimpleSessionSpec(clientSessionTokenTtl, resourcesTtl, userTrackingId, notifications, requestedChecks, requestedTasks, sdkConfig);
+        return new SimpleSessionSpec(clientSessionTokenTtl, resourcesTtl, userTrackingId, notifications, requestedChecks, requestedTasks, sdkConfig, requiredDocuments);
     }
 
 }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleCountryRestriction.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleCountryRestriction.java
@@ -1,0 +1,34 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+import static com.yoti.api.client.spi.remote.util.Validation.notNull;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+class SimpleCountryRestriction implements CountryRestriction {
+
+    @JsonProperty("inclusion")
+    private String inclusion;
+
+    @JsonProperty("country_codes")
+    private List<String> countryCodes;
+
+    SimpleCountryRestriction(String inclusion, List<String> countryCodes) {
+        notNull(inclusion, "inclusion");
+        notNull(countryCodes, "countryCodes");
+        this.inclusion = inclusion;
+        this.countryCodes = countryCodes;
+    }
+
+    @Override
+    public String getInclusion() {
+        return inclusion;
+    }
+
+    @Override
+    public List<String> getCountryCodes() {
+        return countryCodes;
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleDocumentFilterBuilderFactory.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleDocumentFilterBuilderFactory.java
@@ -1,0 +1,15 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+public class SimpleDocumentFilterBuilderFactory extends DocumentFilterBuilderFactory {
+
+    @Override
+    public OrthogonalRestrictionsFilterBuilder forOrthogonalRestrictionsFilter() {
+        return new SimpleOrthogonalRestrictionsFilterBuilder();
+    }
+
+    @Override
+    public DocumentRestrictionsFilterBuilder forDocumentRestrictionsFilter() {
+        return new SimpleDocumentRestrictionsFilterBuilder();
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleDocumentRestriction.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleDocumentRestriction.java
@@ -1,0 +1,32 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class SimpleDocumentRestriction implements DocumentRestriction {
+
+    @JsonProperty("country_codes")
+    private List<String> countryCodes;
+
+    @JsonProperty("document_types")
+    private List<String> documentTypes;
+
+    SimpleDocumentRestriction(List<String> countryCodes, List<String> documentTypes) {
+        this.countryCodes = countryCodes;
+        this.documentTypes = documentTypes;
+    }
+
+    @Override
+    public List<String> getCountryCodes() {
+        return countryCodes;
+    }
+
+    @Override
+    public List<String> getDocumentTypes() {
+        return documentTypes;
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleDocumentRestrictionBuilder.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleDocumentRestrictionBuilder.java
@@ -1,0 +1,27 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+import java.util.List;
+
+public class SimpleDocumentRestrictionBuilder implements DocumentRestrictionBuilder {
+
+    private List<String> countryCodes;
+    private List<String> documentTypes;
+
+    @Override
+    public DocumentRestrictionBuilder withCountries(List<String> countryCodes) {
+        this.countryCodes = countryCodes;
+        return this;
+    }
+
+    @Override
+    public DocumentRestrictionBuilder withDocumentTypes(List<String> documentTypes) {
+        this.documentTypes = documentTypes;
+        return this;
+    }
+
+    @Override
+    public DocumentRestriction build() {
+        return new SimpleDocumentRestriction(countryCodes, documentTypes);
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleDocumentRestrictionBuilderFactory.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleDocumentRestrictionBuilderFactory.java
@@ -1,0 +1,10 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+public class SimpleDocumentRestrictionBuilderFactory extends DocumentRestrictionBuilderFactory {
+
+    @Override
+    public DocumentRestrictionBuilder forDocumentRestriction() {
+        return new SimpleDocumentRestrictionBuilder();
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleDocumentRestrictionsFilter.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleDocumentRestrictionsFilter.java
@@ -1,0 +1,36 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.yoti.api.client.docs.DocScanConstants;
+
+import java.util.List;
+
+class SimpleDocumentRestrictionsFilter implements DocumentRestrictionsFilter {
+
+    @JsonProperty("inclusion")
+    private String inclusion;
+
+    @JsonProperty("documents")
+    private List<DocumentRestriction> documents;
+
+    SimpleDocumentRestrictionsFilter(String inclusion, List<DocumentRestriction> documents) {
+        this.inclusion = inclusion;
+        this.documents = documents;
+    }
+
+    @Override
+    public String getInclusion() {
+        return inclusion;
+    }
+
+    @Override
+    public List<DocumentRestriction> getDocuments() {
+        return documents;
+    }
+
+    @Override
+    public String getType() {
+        return DocScanConstants.DOCUMENT_RESTRICTIONS;
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleDocumentRestrictionsFilterBuilder.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleDocumentRestrictionsFilterBuilder.java
@@ -1,0 +1,45 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+import static com.yoti.api.client.spi.remote.util.Validation.notNullOrEmpty;
+
+import com.yoti.api.client.docs.DocScanConstants;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class SimpleDocumentRestrictionsFilterBuilder implements DocumentRestrictionsFilterBuilder {
+
+    private String inclusion;
+    private List<DocumentRestriction> documents = new ArrayList<>();
+
+    @Override
+    public DocumentRestrictionsFilterBuilder forWhitelist() {
+        this.inclusion = DocScanConstants.INCLUSION_WHITELIST;
+        return this;
+    }
+
+    @Override
+    public DocumentRestrictionsFilterBuilder forBlacklist() {
+        this.inclusion = DocScanConstants.INCLUSION_BLACKLIST;
+        return this;
+    }
+
+    @Override
+    public DocumentRestrictionsFilterBuilder withDocumentRestriction(List<String> countryCodes, List<String> documentTypes) {
+        this.documents.add(new SimpleDocumentRestriction(countryCodes, documentTypes));
+        return this;
+    }
+
+    @Override
+    public DocumentRestrictionsFilterBuilder withDocumentRestriction(DocumentRestriction documentRestriction) {
+        this.documents.add(documentRestriction);
+        return this;
+    }
+
+    @Override
+    public DocumentRestrictionsFilter build() {
+        notNullOrEmpty(inclusion, "inclusion");
+        return new SimpleDocumentRestrictionsFilter(inclusion, documents);
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleOrthogonalRestrictionsFilter.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleOrthogonalRestrictionsFilter.java
@@ -1,0 +1,35 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+import com.yoti.api.client.docs.DocScanConstants;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+class SimpleOrthogonalRestrictionsFilter implements OrthogonalRestrictionsFilter {
+
+    @JsonProperty("country_restriction")
+    private CountryRestriction countryRestriction;
+
+    @JsonProperty("type_restriction")
+    private TypeRestriction typeRestriction;
+
+    SimpleOrthogonalRestrictionsFilter(CountryRestriction countryRestriction, TypeRestriction typeRestriction) {
+        this.countryRestriction = countryRestriction;
+        this.typeRestriction = typeRestriction;
+    }
+
+    @Override
+    public CountryRestriction getCountryRestriction() {
+        return countryRestriction;
+    }
+
+    @Override
+    public TypeRestriction getTypeRestriction() {
+        return typeRestriction;
+    }
+
+    @Override
+    public String getType() {
+        return DocScanConstants.ORTHOGONAL_RESTRICTIONS;
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleOrthogonalRestrictionsFilterBuilder.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleOrthogonalRestrictionsFilterBuilder.java
@@ -1,0 +1,41 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+import java.util.List;
+
+import com.yoti.api.client.docs.DocScanConstants;
+
+class SimpleOrthogonalRestrictionsFilterBuilder implements OrthogonalRestrictionsFilterBuilder {
+
+    private CountryRestriction countryRestriction;
+    private TypeRestriction typeRestriction;
+
+    @Override
+    public OrthogonalRestrictionsFilterBuilder withWhitelistedCountries(List<String> countryCodes) {
+        countryRestriction = new SimpleCountryRestriction(DocScanConstants.INCLUSION_WHITELIST, countryCodes);
+        return this;
+    }
+
+    @Override
+    public OrthogonalRestrictionsFilterBuilder withBlacklistedCountries(List<String> countryCodes) {
+        countryRestriction = new SimpleCountryRestriction(DocScanConstants.INCLUSION_BLACKLIST, countryCodes);
+        return this;
+    }
+
+    @Override
+    public OrthogonalRestrictionsFilterBuilder withWhitelistedDocumentTypes(List<String> documentTypes) {
+        typeRestriction = new SimpleTypeRestriction(DocScanConstants.INCLUSION_WHITELIST, documentTypes);
+        return this;
+    }
+
+    @Override
+    public OrthogonalRestrictionsFilterBuilder withBlacklistedDocumentTypes(List<String> documentTypes) {
+        typeRestriction = new SimpleTypeRestriction(DocScanConstants.INCLUSION_BLACKLIST, documentTypes);
+        return this;
+    }
+
+    @Override
+    public OrthogonalRestrictionsFilter build() {
+        return new SimpleOrthogonalRestrictionsFilter(countryRestriction, typeRestriction);
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleRequiredDocument.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleRequiredDocument.java
@@ -1,0 +1,10 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+abstract class SimpleRequiredDocument implements RequiredDocument {
+
+    @JsonProperty("type")
+    public abstract String getType();
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleRequiredDocumentBuilderFactory.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleRequiredDocumentBuilderFactory.java
@@ -1,0 +1,10 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+public class SimpleRequiredDocumentBuilderFactory extends RequiredDocumentBuilderFactory {
+
+    @Override
+    public RequiredIdDocumentBuilder forIdDocument() {
+        return new SimpleRequiredIdDocumentBuilder();
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleRequiredIdDocument.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleRequiredIdDocument.java
@@ -1,0 +1,26 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+import com.yoti.api.client.docs.DocScanConstants;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SimpleRequiredIdDocument extends SimpleRequiredDocument implements RequiredIdDocument {
+
+    private DocumentFilter filter;
+
+    public SimpleRequiredIdDocument(DocumentFilter filter) {
+        this.filter = filter;
+    }
+
+    @Override
+    public String getType() {
+        return DocScanConstants.ID_DOCUMENT;
+    }
+
+    @Override
+    @JsonProperty("filter")
+    public DocumentFilter getFilter() {
+        return filter;
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleRequiredIdDocumentBuilder.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleRequiredIdDocumentBuilder.java
@@ -1,0 +1,18 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+class SimpleRequiredIdDocumentBuilder implements RequiredIdDocumentBuilder {
+
+    private DocumentFilter filter;
+
+    @Override
+    public RequiredIdDocumentBuilder withFilter(DocumentFilter filter) {
+        this.filter = filter;
+        return this;
+    }
+
+    @Override
+    public RequiredIdDocument build() {
+        return new SimpleRequiredIdDocument(filter);
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleTypeRestriction.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/create/filters/SimpleTypeRestriction.java
@@ -1,0 +1,34 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+import static com.yoti.api.client.spi.remote.util.Validation.notNull;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+class SimpleTypeRestriction implements TypeRestriction {
+
+    @JsonProperty("inclusion")
+    private String inclusion;
+
+    @JsonProperty("document_types")
+    private List<String> documentTypes;
+
+    SimpleTypeRestriction(String inclusion, List<String> documentTypes) {
+        notNull(inclusion, "inclusion");
+        notNull(documentTypes, "documentTypes");
+        this.inclusion = inclusion;
+        this.documentTypes = documentTypes;
+    }
+
+    @Override
+    public String getInclusion() {
+        return inclusion;
+    }
+
+    @Override
+    public List<String> getDocumentTypes() {
+        return documentTypes;
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/support/SimpleSupportedCountry.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/support/SimpleSupportedCountry.java
@@ -1,0 +1,25 @@
+package com.yoti.api.client.docs.support;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+class SimpleSupportedCountry implements SupportedCountry {
+
+    @JsonProperty("code")
+    private String code;
+
+    @JsonProperty("supported_documents")
+    private List<SimpleSupportedDocument> supportedDocuments;
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public List<? extends SupportedDocument> getSupportedDocuments() {
+        return supportedDocuments;
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/support/SimpleSupportedDocument.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/support/SimpleSupportedDocument.java
@@ -1,0 +1,15 @@
+package com.yoti.api.client.docs.support;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+class SimpleSupportedDocument implements SupportedDocument {
+
+    @JsonProperty("type")
+    private String type;
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/support/SimpleSupportedDocumentsResponse.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/support/SimpleSupportedDocumentsResponse.java
@@ -1,0 +1,17 @@
+package com.yoti.api.client.docs.support;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class SimpleSupportedDocumentsResponse implements SupportedDocumentsResponse {
+
+    @JsonProperty("supported_countries")
+    List<SimpleSupportedCountry> supportedCountries;
+
+    @Override
+    public List<? extends SupportedCountry> getSupportedCountries() {
+        return supportedCountries;
+    }
+
+}

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/factory/PathFactory.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/factory/PathFactory.java
@@ -41,6 +41,10 @@ public class PathFactory {
         return unsignedPathFactory.createMediaContentPath(appId, sessionId, mediaId) + "&" + createSignatureParams();
     }
 
+    public String createGetSupportedDocumentsPath() {
+        return unsignedPathFactory.createGetSupportedDocumentsPath() + "?" + createSignatureParams();
+    }
+
     protected long createTimestamp() {
         return nanoTime() / 1000;
     }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/factory/UnsignedPathFactory.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/factory/UnsignedPathFactory.java
@@ -10,6 +10,7 @@ public class UnsignedPathFactory {
     static final String DOCS_CREATE_SESSION_PATH_TEMPLATE = "/sessions?sdkId=%s";
     static final String DOCS_SESSION_PATH_TEMPLATE = "/sessions/%s?sdkId=%s";
     static final String DOCS_MEDIA_CONTENT_PATH_TEMPLATE = "/sessions/%s/media/%s/content?sdkId=%s";
+    static final String DOCS_SUPPORTED_DOCUMENTS_PATH = "/supported-documents";
 
     public String createProfilePath(String appId, String connectToken) {
         return format(PROFILE_PATH_TEMPLATE, connectToken, appId);
@@ -33,6 +34,10 @@ public class UnsignedPathFactory {
 
     public String createMediaContentPath(String appId, String sessionId, String mediaId) {
         return format(DOCS_MEDIA_CONTENT_PATH_TEMPLATE, sessionId, mediaId, appId);
+    }
+
+    public String createGetSupportedDocumentsPath() {
+        return DOCS_SUPPORTED_DOCUMENTS_PATH;
     }
 
 }

--- a/yoti-sdk-impl/src/main/resources/META-INF/services/com.yoti.api.client.docs.session.create.filters.DocumentFilterBuilderFactory
+++ b/yoti-sdk-impl/src/main/resources/META-INF/services/com.yoti.api.client.docs.session.create.filters.DocumentFilterBuilderFactory
@@ -1,0 +1,1 @@
+com.yoti.api.client.docs.session.create.filters.SimpleDocumentFilterBuilderFactory

--- a/yoti-sdk-impl/src/main/resources/META-INF/services/com.yoti.api.client.docs.session.create.filters.DocumentRestrictionBuilderFactory
+++ b/yoti-sdk-impl/src/main/resources/META-INF/services/com.yoti.api.client.docs.session.create.filters.DocumentRestrictionBuilderFactory
@@ -1,0 +1,1 @@
+com.yoti.api.client.docs.session.create.filters.SimpleDocumentRestrictionBuilderFactory

--- a/yoti-sdk-impl/src/main/resources/META-INF/services/com.yoti.api.client.docs.session.create.filters.RequiredDocumentBuilderFactory
+++ b/yoti-sdk-impl/src/main/resources/META-INF/services/com.yoti.api.client.docs.session.create.filters.RequiredDocumentBuilderFactory
@@ -1,0 +1,1 @@
+com.yoti.api.client.docs.session.create.filters.SimpleRequiredDocumentBuilderFactory

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/docs/DocScanClientTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/docs/DocScanClientTest.java
@@ -134,4 +134,20 @@ public class DocScanClientTest {
         fail("Expected an exception");
     }
 
+    @Test
+    public void getSupportedDocuments_shouldFailWithExceptionFromYotiDocsService() throws Exception {
+        DocScanException original = new DocScanException("Test exception");
+
+        doThrow(original).when(docScanServiceMock).getSupportedDocuments(any(KeyPair.class));
+
+        try {
+            SimpleDocScanClient testObj = new SimpleDocScanClient(APP_ID, validKeyPairSource, docScanServiceMock);
+            testObj.getSupportedDocuments();
+        } catch (DocScanException thrown) {
+            assertThat(thrown, is(original));
+            return;
+        }
+        fail("Expected an exception");
+    }
+
 }

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/docs/session/create/SimpleSessionSpecBuilderTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/docs/session/create/SimpleSessionSpecBuilderTest.java
@@ -5,10 +5,15 @@ import static org.hamcrest.Matchers.*;
 
 import com.yoti.api.client.docs.session.create.check.RequestedCheck;
 import com.yoti.api.client.docs.session.create.check.SimpleRequestedCheckBuilderFactory;
+import com.yoti.api.client.docs.session.create.filters.RequiredDocument;
 import com.yoti.api.client.docs.session.create.task.RequestedTask;
 import com.yoti.api.client.docs.session.create.task.SimpleRequestedTaskBuilderFactory;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class SimpleSessionSpecBuilderTest {
 
     private static final Integer SOME_CLIENT_SESSION_TOKEN_TTL = 300;
@@ -27,6 +32,8 @@ public class SimpleSessionSpecBuilderTest {
     private static final String SOME_SDK_CONFIG_SUCCESS_URL = "https://yourdomain.com/some/success/endpoint";
     private static final String SOME_SDK_CONFIG_ERROR_URL = "https://yourdomain.com/some/error/endpoint";
 
+    @Mock RequiredDocument requiredDocumentMock;
+
     @Test
     public void shouldBuildWithMinimalConfiguration() {
         SessionSpec result = new SimpleSessionSpecBuilder()
@@ -39,6 +46,7 @@ public class SimpleSessionSpecBuilderTest {
         assertThat(result.getClientSessionTokenTtl(), is(SOME_CLIENT_SESSION_TOKEN_TTL));
         assertThat(result.getResourcesTtl(), is(SOME_RESOURCES_TTL));
         assertThat(result.getUserTrackingId(), is(SOME_USER_TRACKING_ID));
+        assertThat(result.getRequiredDocuments(), hasSize(0));
     }
 
     @Test
@@ -167,6 +175,24 @@ public class SimpleSessionSpecBuilderTest {
         assertThat(result.getSdkConfig().getPresetIssuingCountry(), is(SOME_SDK_CONFIG_PRESET_ISSUING_COUNTRY));
         assertThat(result.getSdkConfig().getSuccessUrl(), is(SOME_SDK_CONFIG_SUCCESS_URL));
         assertThat(result.getSdkConfig().getErrorUrl(), is(SOME_SDK_CONFIG_ERROR_URL));
+    }
+
+    @Test
+    public void withRequiredDocument_shouldAddRequiredDocumentToList() {
+        SessionSpec result = new SimpleSessionSpecBuilder()
+                .withClientSessionTokenTtl(SOME_CLIENT_SESSION_TOKEN_TTL)
+                .withResourcesTtl(SOME_RESOURCES_TTL)
+                .withUserTrackingId(SOME_USER_TRACKING_ID)
+                .withRequiredDocument(requiredDocumentMock)
+                .build();
+
+        assertThat(result, is(instanceOf(SimpleSessionSpec.class)));
+        assertThat(result.getClientSessionTokenTtl(), is(SOME_CLIENT_SESSION_TOKEN_TTL));
+        assertThat(result.getResourcesTtl(), is(SOME_RESOURCES_TTL));
+        assertThat(result.getUserTrackingId(), is(SOME_USER_TRACKING_ID));
+
+        assertThat(result.getRequiredDocuments(), hasSize(1));
+        assertThat(result.getRequiredDocuments(), contains(requiredDocumentMock));
     }
 
 }

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/docs/session/create/filters/SimpleDocumentRestrictionBuilderTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/docs/session/create/filters/SimpleDocumentRestrictionBuilderTest.java
@@ -1,0 +1,50 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+public class SimpleDocumentRestrictionBuilderTest {
+
+    private static final List<String> COUNTRY_CODES = Arrays.asList("GBR", "USA", "UKR");
+    private static final List<String> DOCUMENT_TYPES = Arrays.asList("PASSPORT", "DRIVING_LICENCE");
+
+    @Test
+    public void shouldBuildWithBothPropertiesOptional() {
+        DocumentRestriction result = new SimpleDocumentRestrictionBuilder()
+                .build();
+
+        assertThat(result.getCountryCodes(), is(nullValue()));
+        assertThat(result.getDocumentTypes(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldBuildWithCountryCodesOnly() {
+        DocumentRestriction result = new SimpleDocumentRestrictionBuilder()
+                .withCountries(COUNTRY_CODES)
+                .build();
+
+        assertThat(result.getCountryCodes(), hasSize(3));
+        assertThat(result.getCountryCodes(), containsInAnyOrder("GBR", "USA", "UKR"));
+        assertThat(result.getDocumentTypes(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldBuildWithDocumentTypesOnly() {
+        DocumentRestriction result = new SimpleDocumentRestrictionBuilder()
+                .withDocumentTypes(DOCUMENT_TYPES)
+                .build();
+
+        assertThat(result.getDocumentTypes(), hasSize(2));
+        assertThat(result.getDocumentTypes(), containsInAnyOrder("PASSPORT", "DRIVING_LICENCE"));
+        assertThat(result.getCountryCodes(), is(nullValue()));
+    }
+
+}

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/docs/session/create/filters/SimpleDocumentRestrictionsFilterTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/docs/session/create/filters/SimpleDocumentRestrictionsFilterTest.java
@@ -1,0 +1,95 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SimpleDocumentRestrictionsFilterTest {
+
+    private static final String EXPECTED_TYPE = "DOCUMENT_RESTRICTIONS";
+    private static final String EXPECTED_INCLUSION_WHITELIST = "WHITELIST";
+    private static final String EXPECTED_INCLUSION_BLACKLIST = "BLACKLIST";
+
+    private static final List<String> COUNTRY_CODES = Arrays.asList("GBR", "USA", "UKR");
+    private static final List<String> DOCUMENT_TYPES = Arrays.asList("PASSPORT", "DRIVING_LICENCE");
+
+    @Mock DocumentRestriction documentRestrictionMock;
+
+    @Test
+    public void shouldThrowExceptionForMissingInclusion() {
+        try {
+            new SimpleDocumentRestrictionsFilterBuilder()
+                    .build();
+        } catch (IllegalArgumentException ex) {
+            assertThat(ex.getMessage(), containsString("inclusion"));
+            return;
+        }
+        fail("Expected an exception");
+    }
+
+    @Test
+    public void shouldSetCorrectType() {
+        DocumentRestrictionsFilter result = new SimpleDocumentRestrictionsFilterBuilder()
+                .forWhitelist()
+                .withDocumentRestriction(COUNTRY_CODES, DOCUMENT_TYPES)
+                .build();
+
+        assertThat(result.getType(), is(EXPECTED_TYPE));
+    }
+
+    @Test
+    public void shouldSetCorrectValueForWhitelist() {
+        DocumentRestrictionsFilter result = new SimpleDocumentRestrictionsFilterBuilder()
+                .forWhitelist()
+                .withDocumentRestriction(COUNTRY_CODES, DOCUMENT_TYPES)
+                .build();
+
+        assertThat(result.getInclusion(), is(EXPECTED_INCLUSION_WHITELIST));
+    }
+
+    @Test
+    public void shouldSetCorrectValueForBlacklist() {
+        DocumentRestrictionsFilter result = new SimpleDocumentRestrictionsFilterBuilder()
+                .forBlacklist()
+                .withDocumentRestriction(COUNTRY_CODES, DOCUMENT_TYPES)
+                .build();
+
+        assertThat(result.getInclusion(), is(EXPECTED_INCLUSION_BLACKLIST));
+    }
+
+    @Test
+    public void shouldAddDocumentRestrictionToList() {
+        DocumentRestrictionsFilter result = new SimpleDocumentRestrictionsFilterBuilder()
+                .forWhitelist()
+                .withDocumentRestriction(COUNTRY_CODES, DOCUMENT_TYPES)
+                .build();
+
+        assertThat(result.getDocuments(), hasSize(1));
+        assertThat(result.getDocuments().get(0).getCountryCodes(), containsInAnyOrder("GBR", "USA", "UKR"));
+        assertThat(result.getDocuments().get(0).getDocumentTypes(), containsInAnyOrder("PASSPORT", "DRIVING_LICENCE"));
+    }
+
+    @Test
+    public void shouldAcceptPreBuiltDocumentRestriction() {
+        DocumentRestrictionsFilter result = new SimpleDocumentRestrictionsFilterBuilder()
+                .forWhitelist()
+                .withDocumentRestriction(documentRestrictionMock)
+                .build();
+
+        assertThat(result.getDocuments(), hasSize(1));
+        assertThat(result.getDocuments(), containsInAnyOrder(documentRestrictionMock));
+    }
+
+}

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/docs/session/create/filters/SimpleOrthogonalRestrictionsFilterTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/docs/session/create/filters/SimpleOrthogonalRestrictionsFilterTest.java
@@ -1,0 +1,82 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SimpleOrthogonalRestrictionsFilterTest {
+
+    private static final String EXPECTED_TYPE = "ORTHOGONAL_RESTRICTIONS";
+    private static final String EXPECTED_INCLUSION_WHITELIST = "WHITELIST";
+    private static final String EXPECTED_INCLUSION_BLACKLIST = "BLACKLIST";
+
+    private static final List<String> COUNTRY_CODES = Arrays.asList("GBR", "USA", "UKR");
+    private static final List<String> DOCUMENT_TYPES = Arrays.asList("PASSPORT", "DRIVING_LICENCE");
+
+    @Test
+    public void shouldHaveCorrectType() {
+        OrthogonalRestrictionsFilter result = new SimpleOrthogonalRestrictionsFilterBuilder()
+                .build();
+
+        assertThat(result.getType(), is(EXPECTED_TYPE));
+    }
+
+    @Test
+    public void shouldBuildWithoutCountryRestrictionOrTypeRestriction() {
+        OrthogonalRestrictionsFilter result = new SimpleOrthogonalRestrictionsFilterBuilder()
+                .build();
+
+        assertThat(result.getCountryRestriction(), is(nullValue()));
+        assertThat(result.getTypeRestriction(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldBuildWhitelistedCountryRestriction() {
+        OrthogonalRestrictionsFilter result = new SimpleOrthogonalRestrictionsFilterBuilder()
+                .withWhitelistedCountries(COUNTRY_CODES)
+                .build();
+
+        assertThat(result.getCountryRestriction().getInclusion(), is(EXPECTED_INCLUSION_WHITELIST));
+        assertThat(result.getCountryRestriction().getCountryCodes(), containsInAnyOrder("GBR", "USA", "UKR"));
+    }
+
+    @Test
+    public void shouldBuildBlacklistedCountryRestriction() {
+        OrthogonalRestrictionsFilter result = new SimpleOrthogonalRestrictionsFilterBuilder()
+                .withBlacklistedCountries(COUNTRY_CODES)
+                .build();
+
+        assertThat(result.getCountryRestriction().getInclusion(), is(EXPECTED_INCLUSION_BLACKLIST));
+        assertThat(result.getCountryRestriction().getCountryCodes(), containsInAnyOrder("GBR", "USA", "UKR"));
+    }
+
+    @Test
+    public void shouldBuildWhitelistedDocumentTypeRestriction() {
+        OrthogonalRestrictionsFilter result = new SimpleOrthogonalRestrictionsFilterBuilder()
+                .withWhitelistedDocumentTypes(DOCUMENT_TYPES)
+                .build();
+
+        assertThat(result.getTypeRestriction().getInclusion(), is(EXPECTED_INCLUSION_WHITELIST));
+        assertThat(result.getTypeRestriction().getDocumentTypes(), containsInAnyOrder("PASSPORT", "DRIVING_LICENCE"));
+    }
+
+    @Test
+    public void shouldBuildBlacklistedDocumentTypeRestriction() {
+        OrthogonalRestrictionsFilter result = new SimpleOrthogonalRestrictionsFilterBuilder()
+                .withBlacklistedDocumentTypes(DOCUMENT_TYPES)
+                .build();
+
+        assertThat(result.getTypeRestriction().getInclusion(), is(EXPECTED_INCLUSION_BLACKLIST));
+        assertThat(result.getTypeRestriction().getDocumentTypes(), containsInAnyOrder("PASSPORT", "DRIVING_LICENCE"));
+    }
+
+}

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/docs/session/create/filters/SimpleRequiredIdDocumentTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/docs/session/create/filters/SimpleRequiredIdDocumentTest.java
@@ -1,0 +1,44 @@
+package com.yoti.api.client.docs.session.create.filters;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SimpleRequiredIdDocumentTest {
+
+    private static final String EXPECTED_TYPE = "ID_DOCUMENT";
+
+    @Mock DocumentFilter documentFilterMock;
+
+    @Test
+    public void shouldHaveTheCorrectType() {
+        RequiredIdDocument result = new SimpleRequiredIdDocumentBuilder()
+                .build();
+
+        assertThat(result.getType(), is(EXPECTED_TYPE));
+    }
+
+    @Test
+    public void shouldBuildWithoutAFilter() {
+        RequiredIdDocument result = new SimpleRequiredIdDocumentBuilder()
+                .build();
+
+        assertThat(result.getFilter(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldBuildWithAFilter() {
+        RequiredIdDocument result = new SimpleRequiredIdDocumentBuilder()
+                .withFilter(documentFilterMock)
+                .build();
+
+        assertThat(result, is(notNullValue()));
+        assertThat(result.getFilter(), is(documentFilterMock));
+    }
+
+}

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/call/factory/PathFactoryTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/spi/remote/call/factory/PathFactoryTest.java
@@ -81,4 +81,14 @@ public class PathFactoryTest {
         assertTrue(uri.getQuery().contains("timestamp="));
     }
 
+    @Test
+    public void shouldCreateSupportedDocumentsPath() {
+        String result = testObj.createGetSupportedDocumentsPath();
+
+        URI uri = URI.create(result);
+        assertEquals("/supported-documents", uri.getPath());
+        assertTrue(uri.getQuery().matches("(.*)nonce=(?i)[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}(.*)"));
+        assertTrue(uri.getQuery().contains("timestamp="));
+    }
+
 }


### PR DESCRIPTION
## Added

* `DocScanClient`
  * `getSupportedDocuments()` - retrieves the list of supported documents within Doc Scan, returned as `SupportedDocumentResponse`

- `SessionSpec`
  - Can now have an optional list of `RequiredDocument` allowing relying businesses to specify certain documents required by users
- `RequiredDocument`
  - `RequiredIdentityDocument`
- `RequiredDocumentFilter`
  - `OrthogonalRestrictionsFilter`
    * `CountryRestriction`
    * `TypeRestriction`
  * `DocumentRestrictionsFilter`
    * `DocumentRestriction`