### PR TITLE
Release 2.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,13 @@ If you are using Maven, you need to add the following dependency:
 <dependency>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-impl</artifactId>
-    <version>2.7.1-SNAPSHOT</version>
+    <version>2.7.1</version>
 </dependency>
 ```
 
 If you are using Gradle, here is the dependency to add:
 
-`compile group: 'com.yoti', name: 'yoti-sdk-impl', version: '2.7.1-SNAPSHOT'`
+`compile group: 'com.yoti', name: 'yoti-sdk-impl', version: '2.7.1'`
 
 You will find all classes packaged under `com.yoti.api`
 

--- a/README.md
+++ b/README.md
@@ -104,13 +104,13 @@ If you are using Maven, you need to add the following dependency:
 <dependency>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-impl</artifactId>
-    <version>2.7.0</version>
+    <version>2.7.1-SNAPSHOT</version>
 </dependency>
 ```
 
 If you are using Gradle, here is the dependency to add:
 
-`compile group: 'com.yoti', name: 'yoti-sdk-impl', version: '2.7.0'`
+`compile group: 'com.yoti', name: 'yoti-sdk-impl', version: '2.7.1-SNAPSHOT'`
 
 You will find all classes packaged under `com.yoti.api`
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk</artifactId>
   <packaging>pom</packaging>
-  <version>2.7.1-SNAPSHOT</version>
+  <version>2.7.1</version>
   <name>Yoti SDK</name>
   <description>Java SDK for simple integration with the Yoti platform</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk</artifactId>
   <packaging>pom</packaging>
-  <version>2.7.0</version>
+  <version>2.7.1-SNAPSHOT</version>
   <name>Yoti SDK</name>
   <description>Java SDK for simple integration with the Yoti platform</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>

--- a/yoti-sdk-api/pom.xml
+++ b/yoti-sdk-api/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.7.1-SNAPSHOT</version>
+    <version>2.7.1</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
 

--- a/yoti-sdk-api/pom.xml
+++ b/yoti-sdk-api/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.7.0</version>
+    <version>2.7.1-SNAPSHOT</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
 

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/shareurl/extension/ThirdPartyAttributeContent.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/shareurl/extension/ThirdPartyAttributeContent.java
@@ -23,6 +23,7 @@ public class ThirdPartyAttributeContent {
     @JsonProperty("expiry_date")
     public String getExpiryDate() {
         SimpleDateFormat rfcDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        rfcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
         return rfcDateFormat.format(expiryDate.getTime());
     }
 

--- a/yoti-sdk-impl/pom.xml
+++ b/yoti-sdk-impl/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.7.1-SNAPSHOT</version>
+    <version>2.7.1</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
   

--- a/yoti-sdk-impl/pom.xml
+++ b/yoti-sdk-impl/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.7.0</version>
+    <version>2.7.1-SNAPSHOT</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
   

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/YotiConstants.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/YotiConstants.java
@@ -25,7 +25,7 @@ public final class YotiConstants {
     public static final String CONTENT_TYPE_JPEG = "image/jpeg";
 
     public static final String JAVA = "Java";
-    public static final String SDK_VERSION = JAVA + "-2.7.1-SNAPSHOT";
+    public static final String SDK_VERSION = JAVA + "-2.7.1";
     public static final String SIGNATURE_ALGORITHM = "SHA256withRSA";
     public static final String ASYMMETRIC_CIPHER = "RSA/NONE/PKCS1Padding";
     public static final String SYMMETRIC_CIPHER = "AES/CBC/PKCS7Padding";

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/YotiConstants.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/YotiConstants.java
@@ -25,7 +25,7 @@ public final class YotiConstants {
     public static final String CONTENT_TYPE_JPEG = "image/jpeg";
 
     public static final String JAVA = "Java";
-    public static final String SDK_VERSION = JAVA + "-2.7.0";
+    public static final String SDK_VERSION = JAVA + "-2.7.1-SNAPSHOT";
     public static final String SIGNATURE_ALGORITHM = "SHA256withRSA";
     public static final String ASYMMETRIC_CIPHER = "RSA/NONE/PKCS1Padding";
     public static final String SYMMETRIC_CIPHER = "AES/CBC/PKCS7Padding";

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/shareurl/extension/SimpleThirdPartyAttributeExtensionBuilderTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/shareurl/extension/SimpleThirdPartyAttributeExtensionBuilderTest.java
@@ -1,9 +1,10 @@
 package com.yoti.api.client.shareurl.extension;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.yoti.api.client.AttributeDefinition;
-import com.yoti.api.client.spi.remote.call.YotiConstants;
-import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -11,11 +12,10 @@ import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import com.yoti.api.client.AttributeDefinition;
+import com.yoti.api.client.spi.remote.call.YotiConstants;
+
+import org.junit.Test;
 
 public class SimpleThirdPartyAttributeExtensionBuilderTest {
 
@@ -68,9 +68,7 @@ public class SimpleThirdPartyAttributeExtensionBuilderTest {
                 .withDefinition(SOME_DEFINITION)
                 .build();
 
-        SimpleDateFormat sdf = new SimpleDateFormat(YotiConstants.RFC3339_PATTERN_MILLIS);
-        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
-        String formattedTestDate = sdf.format(SOME_DATE);
+        String formattedTestDate = formatDateToString(SOME_DATE);
 
         assertEquals(ExtensionConstants.THIRD_PARTY_ATTRIBUTE, extension.getType());
         assertEquals(formattedTestDate, extension.getContent().getExpiryDate());
@@ -81,7 +79,7 @@ public class SimpleThirdPartyAttributeExtensionBuilderTest {
     }
 
     @Test
-    public void shouldBuildThirdPartyAttributeExtensionWithCorrectDateValue() {
+    public void shouldBuildThirdPartyAttributeExtensionWithCorrectlyFormattedDateString() {
         TimeZone.setDefault(TimeZone.getTimeZone("America/New_York"));
         Date date = new Date();
 
@@ -90,16 +88,23 @@ public class SimpleThirdPartyAttributeExtensionBuilderTest {
                 .withDefinition(SOME_DEFINITION)
                 .build();
 
-        SimpleDateFormat sdf = new SimpleDateFormat(YotiConstants.RFC3339_PATTERN_MILLIS);
-        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
-        String formattedTestDate = sdf.format(date);
+        String formattedTestDate = formatDateToString(date);
 
-        assertEquals(ExtensionConstants.THIRD_PARTY_ATTRIBUTE, extension.getType());
         assertEquals(formattedTestDate, extension.getContent().getExpiryDate());
+    }
 
-        List<AttributeDefinition> definitions = extension.getContent().getDefinitions();
-        assertThat(definitions.size(), is(1));
-        assertThat(definitions.get(0).getName(), is(SOME_DEFINITION));
+    @Test
+    public void shouldWorkCorrectlyWithDateCreatedFromTimestamp() {
+        Date date = new Date(1586252260);
+
+        Extension<ThirdPartyAttributeContent> extension = new SimpleThirdPartyAttributeExtensionBuilder()
+                .withExpiryDate(date)
+                .withDefinition(SOME_DEFINITION)
+                .build();
+
+        String formattedTestDate = formatDateToString(date);
+
+        assertEquals(formattedTestDate, extension.getContent().getExpiryDate());
     }
 
     @Test
@@ -139,6 +144,12 @@ public class SimpleThirdPartyAttributeExtensionBuilderTest {
         assertThat(definitions.size(), is(2));
         assertThat(definitions.get(0).getName(), is("firstDefinition"));
         assertThat(definitions.get(1).getName(), is("secondDefinition"));
+    }
+
+    private String formatDateToString(Date date) {
+        SimpleDateFormat sdf = new SimpleDateFormat(YotiConstants.RFC3339_PATTERN_MILLIS);
+        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return sdf.format(date);
     }
 
 }

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/shareurl/extension/SimpleThirdPartyAttributeExtensionBuilderTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/shareurl/extension/SimpleThirdPartyAttributeExtensionBuilderTest.java
@@ -81,6 +81,28 @@ public class SimpleThirdPartyAttributeExtensionBuilderTest {
     }
 
     @Test
+    public void shouldBuildThirdPartyAttributeExtensionWithCorrectDateValue() {
+        TimeZone.setDefault(TimeZone.getTimeZone("America/New_York"));
+        Date date = new Date();
+
+        Extension<ThirdPartyAttributeContent> extension = new SimpleThirdPartyAttributeExtensionBuilder()
+                .withExpiryDate(date)
+                .withDefinition(SOME_DEFINITION)
+                .build();
+
+        SimpleDateFormat sdf = new SimpleDateFormat(YotiConstants.RFC3339_PATTERN_MILLIS);
+        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        String formattedTestDate = sdf.format(date);
+
+        assertEquals(ExtensionConstants.THIRD_PARTY_ATTRIBUTE, extension.getType());
+        assertEquals(formattedTestDate, extension.getContent().getExpiryDate());
+
+        List<AttributeDefinition> definitions = extension.getContent().getDefinitions();
+        assertThat(definitions.size(), is(1));
+        assertThat(definitions.get(0).getName(), is(SOME_DEFINITION));
+    }
+
+    @Test
     public void shouldBuildThirdPartyAttributeExtensionWithMultipleDefinitions() {
         List<String> theDefinitions = new ArrayList<>();
         theDefinitions.add("firstDefinition");

--- a/yoti-sdk-parent/pom.xml
+++ b/yoti-sdk-parent/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-parent</artifactId>
   <packaging>pom</packaging>
-  <version>2.7.0</version>
+  <version>2.7.1-SNAPSHOT</version>
   <name>Yoti SDK Parent Pom</name>
   <description>Parent pom for the Java SDK projects</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>

--- a/yoti-sdk-parent/pom.xml
+++ b/yoti-sdk-parent/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-parent</artifactId>
   <packaging>pom</packaging>
-  <version>2.7.1-SNAPSHOT</version>
+  <version>2.7.1</version>
   <name>Yoti SDK Parent Pom</name>
   <description>Parent pom for the Java SDK projects</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>

--- a/yoti-sdk-sandbox/pom.xml
+++ b/yoti-sdk-sandbox/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.7.1-SNAPSHOT</version>
+    <version>2.7.1</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
   

--- a/yoti-sdk-sandbox/pom.xml
+++ b/yoti-sdk-sandbox/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.7.0</version>
+    <version>2.7.1-SNAPSHOT</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
   

--- a/yoti-sdk-spring-boot-auto-config/README.md
+++ b/yoti-sdk-spring-boot-auto-config/README.md
@@ -18,7 +18,7 @@ If you are using Maven, you need to add the following dependencies:
 <dependency>
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-boot-auto-config</artifactId>
-  <version>2.7.1-SNAPSHOT</version>
+  <version>2.7.1</version>
 </dependency>
 ```
 
@@ -26,7 +26,7 @@ If you are using Maven, you need to add the following dependencies:
 If you are using Gradle, here is the dependency to add:
 
 ```
-compile group: 'com.yoti', name: 'yoti-sdk-spring-boot-auto-config', version: '2.7.1-SNAPSHOT'
+compile group: 'com.yoti', name: 'yoti-sdk-spring-boot-auto-config', version: '2.7.1'
 ```
 
 

--- a/yoti-sdk-spring-boot-auto-config/README.md
+++ b/yoti-sdk-spring-boot-auto-config/README.md
@@ -18,7 +18,7 @@ If you are using Maven, you need to add the following dependencies:
 <dependency>
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-boot-auto-config</artifactId>
-  <version>2.7.0</version>
+  <version>2.7.1-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -26,7 +26,7 @@ If you are using Maven, you need to add the following dependencies:
 If you are using Gradle, here is the dependency to add:
 
 ```
-compile group: 'com.yoti', name: 'yoti-sdk-spring-boot-auto-config', version: '2.7.0'
+compile group: 'com.yoti', name: 'yoti-sdk-spring-boot-auto-config', version: '2.7.1-SNAPSHOT'
 ```
 
 

--- a/yoti-sdk-spring-boot-auto-config/pom.xml
+++ b/yoti-sdk-spring-boot-auto-config/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.7.1-SNAPSHOT</version>
+    <version>2.7.1</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
 

--- a/yoti-sdk-spring-boot-auto-config/pom.xml
+++ b/yoti-sdk-spring-boot-auto-config/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.7.0</version>
+    <version>2.7.1-SNAPSHOT</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
 

--- a/yoti-sdk-spring-boot-example/README.md
+++ b/yoti-sdk-spring-boot-example/README.md
@@ -16,7 +16,7 @@ Before you start, you'll need to create an Application in [Yoti Hub](https://hub
     <dependency>
       <groupId>com.yoti</groupId>
       <artifactId>yoti-sdk-impl</artifactId>
-      <version>2.7.1-SNAPSHOT</version>
+      <version>2.7.1</version>
     </dependency>
 ```
 
@@ -29,8 +29,8 @@ Before you start, you'll need to create an Application in [Yoti Hub](https://hub
 1. Run `mvn clean package` to build the project.
 
 ## Running
-* You can run your server-app by executing `java -jar target/yoti-sdk-spring-boot-example-2.7.1-SNAPSHOT.jar`
-  * If you are using Java 9, you can run the server-app as follows `java -jar target/yoti-sdk-spring-boot-example-2.7.1-SNAPSHOT.jar --add-exports java.base/jdk.internal.ref=ALL-UNNAMED`
+* You can run your server-app by executing `java -jar target/yoti-sdk-spring-boot-example-2.7.1.jar`
+  * If you are using Java 9, you can run the server-app as follows `java -jar target/yoti-sdk-spring-boot-example-2.7.1.jar --add-exports java.base/jdk.internal.ref=ALL-UNNAMED`
 * Navigate to `https://localhost:8443`
 * You can then initiate a login using Yoti.  The Spring demo is listening for the response on `https://localhost:8443/login`.
 

--- a/yoti-sdk-spring-boot-example/README.md
+++ b/yoti-sdk-spring-boot-example/README.md
@@ -16,7 +16,7 @@ Before you start, you'll need to create an Application in [Yoti Hub](https://hub
     <dependency>
       <groupId>com.yoti</groupId>
       <artifactId>yoti-sdk-impl</artifactId>
-      <version>2.7.0</version>
+      <version>2.7.1-SNAPSHOT</version>
     </dependency>
 ```
 
@@ -29,8 +29,8 @@ Before you start, you'll need to create an Application in [Yoti Hub](https://hub
 1. Run `mvn clean package` to build the project.
 
 ## Running
-* You can run your server-app by executing `java -jar target/yoti-sdk-spring-boot-example-2.7.0.jar`
-  * If you are using Java 9, you can run the server-app as follows `java -jar target/yoti-sdk-spring-boot-example-2.7.0.jar --add-exports java.base/jdk.internal.ref=ALL-UNNAMED`
+* You can run your server-app by executing `java -jar target/yoti-sdk-spring-boot-example-2.7.1-SNAPSHOT.jar`
+  * If you are using Java 9, you can run the server-app as follows `java -jar target/yoti-sdk-spring-boot-example-2.7.1-SNAPSHOT.jar --add-exports java.base/jdk.internal.ref=ALL-UNNAMED`
 * Navigate to `https://localhost:8443`
 * You can then initiate a login using Yoti.  The Spring demo is listening for the response on `https://localhost:8443/login`.
 

--- a/yoti-sdk-spring-boot-example/pom.xml
+++ b/yoti-sdk-spring-boot-example/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-boot-example</artifactId>
 
-  <version>2.7.0</version>
+  <version>2.7.1-SNAPSHOT</version>
 
   <name>Yoti Spring Boot Example</name>
   <parent>

--- a/yoti-sdk-spring-boot-example/pom.xml
+++ b/yoti-sdk-spring-boot-example/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-boot-example</artifactId>
 
-  <version>2.7.1-SNAPSHOT</version>
+  <version>2.7.1</version>
 
   <name>Yoti Spring Boot Example</name>
   <parent>

--- a/yoti-sdk-spring-security/README.md
+++ b/yoti-sdk-spring-security/README.md
@@ -25,14 +25,14 @@ If you are using Maven, you need to add the following dependencies:
 <dependency>
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-security</artifactId>
-  <version>2.7.1-SNAPSHOT</version>
+  <version>2.7.1</version>
 </dependency>
 ```
 
 If you are using Gradle, here is the dependency to add:
 
 ```
-compile group: 'com.yoti', name: 'yoti-sdk-spring-security', version: '2.7.1-SNAPSHOT'
+compile group: 'com.yoti', name: 'yoti-sdk-spring-security', version: '2.7.1'
 ```
 
 ### Provide a `YotiClient` instance

--- a/yoti-sdk-spring-security/README.md
+++ b/yoti-sdk-spring-security/README.md
@@ -25,14 +25,14 @@ If you are using Maven, you need to add the following dependencies:
 <dependency>
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-security</artifactId>
-  <version>2.7.0</version>
+  <version>2.7.1-SNAPSHOT</version>
 </dependency>
 ```
 
 If you are using Gradle, here is the dependency to add:
 
 ```
-compile group: 'com.yoti', name: 'yoti-sdk-spring-security', version: '2.7.0'
+compile group: 'com.yoti', name: 'yoti-sdk-spring-security', version: '2.7.1-SNAPSHOT'
 ```
 
 ### Provide a `YotiClient` instance

--- a/yoti-sdk-spring-security/pom.xml
+++ b/yoti-sdk-spring-security/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.7.1-SNAPSHOT</version>
+    <version>2.7.1</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
 

--- a/yoti-sdk-spring-security/pom.xml
+++ b/yoti-sdk-spring-security/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>2.7.0</version>
+    <version>2.7.1-SNAPSHOT</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
 


### PR DESCRIPTION
**This fix does not require any changes from an integrators perspective**

### Fixed

* Fixed a bug in `ThirdPartyAttributeContent` extension, whereby the timezone offset on supplied expiry date was being ignored when being converted into UTC date string.