### PR TITLE
SDK-1464: Doc Scan filtering methods

### DIFF
--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/GetSessionResult.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/GetSessionResult.java
@@ -18,4 +18,12 @@ public interface GetSessionResult {
 
     ResourceContainer getResources();
 
+    List<AuthenticityCheckResponse> getAuthenticityChecks();
+
+    List<FaceMatchCheckResponse> getFaceMatchChecks();
+
+    List<TextDataCheckResponse> getTextDataChecks();
+
+    List<LivenessCheckResponse> getLivenessChecks();
+
 }

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/IdDocumentResourceResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/IdDocumentResourceResponse.java
@@ -12,4 +12,6 @@ public interface IdDocumentResourceResponse extends ResourceResponse {
 
     DocumentFieldsResponse getDocumentFields();
 
+    List<TextExtractionTaskResponse> getTextExtractionTasks();
+
 }

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/ResourceContainer.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/ResourceContainer.java
@@ -8,4 +8,6 @@ public interface ResourceContainer {
 
     List<? extends LivenessResourceResponse> getLivenessCapture();
 
+    List<ZoomLivenessResourceResponse> getZoomLivenessResources();
+
 }

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/TextExtractionTaskResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/TextExtractionTaskResponse.java
@@ -1,5 +1,9 @@
 package com.yoti.api.client.docs.session.retrieve;
 
+import java.util.List;
+
 public interface TextExtractionTaskResponse extends TaskResponse {
+
+    List<GeneratedTextDataCheckResponse> getGeneratedTextDataChecks();
 
 }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleGetSessionResult.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleGetSessionResult.java
@@ -1,9 +1,10 @@
 package com.yoti.api.client.docs.session.retrieve;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SimpleGetSessionResult implements GetSessionResult {
@@ -63,4 +64,35 @@ public class SimpleGetSessionResult implements GetSessionResult {
     public String getUserTrackingId() {
         return userTrackingId;
     }
+
+    @Override
+    public List<AuthenticityCheckResponse> getAuthenticityChecks() {
+        return filterChecksByType(AuthenticityCheckResponse.class);
+    }
+
+    @Override
+    public List<FaceMatchCheckResponse> getFaceMatchChecks() {
+        return filterChecksByType(FaceMatchCheckResponse.class);
+    }
+
+    @Override
+    public List<TextDataCheckResponse> getTextDataChecks() {
+        return filterChecksByType(TextDataCheckResponse.class);
+    }
+
+    @Override
+    public List<LivenessCheckResponse> getLivenessChecks() {
+        return filterChecksByType(LivenessCheckResponse.class);
+    }
+
+    private <T extends CheckResponse> List<T> filterChecksByType(Class<T> clazz) {
+        List<T> filteredList = new ArrayList<>();
+        for (CheckResponse checkResponse : checks) {
+            if (checkResponse.getClass().isInstance(clazz)) {
+                filteredList.add((T) checkResponse);
+            }
+        }
+        return filteredList;
+    }
+
 }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleGetSessionResult.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleGetSessionResult.java
@@ -88,8 +88,8 @@ public class SimpleGetSessionResult implements GetSessionResult {
     private <T extends CheckResponse> List<T> filterChecksByType(Class<T> clazz) {
         List<T> filteredList = new ArrayList<>();
         for (CheckResponse checkResponse : checks) {
-            if (checkResponse.getClass().isInstance(clazz)) {
-                filteredList.add((T) checkResponse);
+            if (clazz.isInstance(checkResponse)) {
+                filteredList.add(clazz.cast(checkResponse));
             }
         }
         return filteredList;

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleIdDocumentResourceResponse.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleIdDocumentResourceResponse.java
@@ -3,6 +3,7 @@ package com.yoti.api.client.docs.session.retrieve;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -34,6 +35,11 @@ public class SimpleIdDocumentResourceResponse extends SimpleResourceResponse imp
 
     public DocumentFieldsResponse getDocumentFields() {
         return documentFields;
+    }
+
+    @Override
+    public List<TextExtractionTaskResponse> getTextExtractionTasks() {
+        return filterTasksByType(TextExtractionTaskResponse.class);
     }
 
 }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleResourceContainer.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleResourceContainer.java
@@ -1,5 +1,6 @@
 package com.yoti.api.client.docs.session.retrieve;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -32,6 +33,21 @@ public class SimpleResourceContainer implements ResourceContainer {
     @Override
     public List<? extends LivenessResourceResponse> getLivenessCapture() {
         return livenessCapture;
+    }
+
+    @Override
+    public List<ZoomLivenessResourceResponse> getZoomLivenessResources() {
+        return filterLivenessResourcesByType(ZoomLivenessResourceResponse.class);
+    }
+
+    private <T extends LivenessResourceResponse> List<T> filterLivenessResourcesByType(Class<T> clazz) {
+        List<T> filteredList = new ArrayList<>();
+        for (LivenessResourceResponse livenessResourceResponse : livenessCapture) {
+            if (livenessResourceResponse.getClass().isInstance(clazz)) {
+                filteredList.add((T) livenessResourceResponse);
+            }
+        }
+        return filteredList;
     }
 
 }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleResourceContainer.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleResourceContainer.java
@@ -43,8 +43,8 @@ public class SimpleResourceContainer implements ResourceContainer {
     private <T extends LivenessResourceResponse> List<T> filterLivenessResourcesByType(Class<T> clazz) {
         List<T> filteredList = new ArrayList<>();
         for (LivenessResourceResponse livenessResourceResponse : livenessCapture) {
-            if (livenessResourceResponse.getClass().isInstance(clazz)) {
-                filteredList.add((T) livenessResourceResponse);
+            if (clazz.isInstance(livenessResourceResponse)) {
+                filteredList.add(clazz.cast(livenessResourceResponse));
             }
         }
         return filteredList;

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleResourceResponse.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleResourceResponse.java
@@ -28,8 +28,8 @@ public abstract class SimpleResourceResponse implements ResourceResponse {
     protected <T extends TaskResponse> List<T> filterTasksByType(Class<T> clazz) {
         List<T> filteredList = new ArrayList<>();
         for (TaskResponse taskResponse : tasks) {
-            if (taskResponse.getClass().isInstance(clazz)) {
-                filteredList.add((T) taskResponse);
+            if (clazz.isInstance(taskResponse)) {
+                filteredList.add(clazz.cast(taskResponse));
             }
         }
         return filteredList;

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleResourceResponse.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleResourceResponse.java
@@ -3,6 +3,7 @@ package com.yoti.api.client.docs.session.retrieve;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -22,6 +23,16 @@ public abstract class SimpleResourceResponse implements ResourceResponse {
     @Override
     public List<? extends TaskResponse> getTasks() {
         return tasks;
+    }
+
+    protected <T extends TaskResponse> List<T> filterTasksByType(Class<T> clazz) {
+        List<T> filteredList = new ArrayList<>();
+        for (TaskResponse taskResponse : tasks) {
+            if (taskResponse.getClass().isInstance(clazz)) {
+                filteredList.add((T) taskResponse);
+            }
+        }
+        return filteredList;
     }
 
 }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleTaskResponse.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleTaskResponse.java
@@ -76,8 +76,8 @@ public class SimpleTaskResponse implements TaskResponse {
     protected <T extends GeneratedCheckResponse> List<T> filterGeneratedChecksByType(Class<T> clazz) {
         List<T> filteredList = new ArrayList<>();
         for (GeneratedCheckResponse generatedCheckResponse : generatedChecks) {
-            if (generatedCheckResponse.getClass().isInstance(clazz)) {
-                filteredList.add((T) generatedCheckResponse);
+            if (clazz.isInstance(generatedCheckResponse)) {
+                filteredList.add(clazz.cast(generatedCheckResponse));
             }
         }
         return filteredList;

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleTaskResponse.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleTaskResponse.java
@@ -1,12 +1,14 @@
 package com.yoti.api.client.docs.session.retrieve;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import com.yoti.api.client.docs.DocScanConstants;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.yoti.api.client.docs.DocScanConstants;
-
-import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = SimpleTaskResponse.class, visible = true)
@@ -69,6 +71,16 @@ public class SimpleTaskResponse implements TaskResponse {
     @Override
     public List<? extends GeneratedMedia> getGeneratedMedia() {
         return generatedMedia;
+    }
+
+    protected <T extends GeneratedCheckResponse> List<T> filterGeneratedChecksByType(Class<T> clazz) {
+        List<T> filteredList = new ArrayList<>();
+        for (GeneratedCheckResponse generatedCheckResponse : generatedChecks) {
+            if (generatedCheckResponse.getClass().isInstance(clazz)) {
+                filteredList.add((T) generatedCheckResponse);
+            }
+        }
+        return filteredList;
     }
 
 }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleTextExtractionTaskResponse.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleTextExtractionTaskResponse.java
@@ -1,8 +1,15 @@
 package com.yoti.api.client.docs.session.retrieve;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SimpleTextExtractionTaskResponse extends SimpleTaskResponse implements TextExtractionTaskResponse {
+
+    @Override
+    public List<GeneratedTextDataCheckResponse> getGeneratedTextDataChecks() {
+        return filterGeneratedChecksByType(GeneratedTextDataCheckResponse.class);
+    }
 
 }

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/docs/session/retrieve/SimpleGetSessionResultTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/docs/session/retrieve/SimpleGetSessionResultTest.java
@@ -1,0 +1,123 @@
+package com.yoti.api.client.docs.session.retrieve;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.internal.util.reflection.FieldSetter;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SimpleGetSessionResultTest {
+
+    @Mock AuthenticityCheckResponse authenticityCheckResponseMock;
+    @Mock FaceMatchCheckResponse faceMatchCheckResponseMock;
+    @Mock TextDataCheckResponse textDataCheckResponseMock;
+    @Mock LivenessCheckResponse livenessCheckResponseMock;
+
+    SimpleGetSessionResult getSessionResult;
+
+    @Test
+    public void shouldFilterAuthenticityChecks() throws NoSuchFieldException {
+        getSessionResult = new SimpleGetSessionResult();
+
+        FieldSetter.setField(
+                getSessionResult,
+                getSessionResult.getClass().getDeclaredField("checks"),
+                Arrays.asList(
+                        authenticityCheckResponseMock,
+                        livenessCheckResponseMock,
+                        textDataCheckResponseMock,
+                        faceMatchCheckResponseMock
+                )
+        );
+
+        List<AuthenticityCheckResponse> result = getSessionResult.getAuthenticityChecks();
+        assertThat(getSessionResult.getChecks(), hasSize(4));
+        assertThat(result, hasSize(1));
+    }
+
+    @Test
+    public void shouldFilterLivenessChecks() throws NoSuchFieldException {
+        getSessionResult = new SimpleGetSessionResult();
+
+        FieldSetter.setField(
+                getSessionResult,
+                getSessionResult.getClass().getDeclaredField("checks"),
+                Arrays.asList(
+                        authenticityCheckResponseMock,
+                        livenessCheckResponseMock,
+                        textDataCheckResponseMock,
+                        faceMatchCheckResponseMock
+                )
+        );
+
+        List<LivenessCheckResponse> result = getSessionResult.getLivenessChecks();
+        assertThat(getSessionResult.getChecks(), hasSize(4));
+        assertThat(result, hasSize(1));
+    }
+
+    @Test
+    public void shouldFilterTextDataChecks() throws NoSuchFieldException {
+        getSessionResult = new SimpleGetSessionResult();
+
+        FieldSetter.setField(
+                getSessionResult,
+                getSessionResult.getClass().getDeclaredField("checks"),
+                Arrays.asList(
+                        authenticityCheckResponseMock,
+                        livenessCheckResponseMock,
+                        textDataCheckResponseMock,
+                        faceMatchCheckResponseMock
+                )
+        );
+
+        List<TextDataCheckResponse> result = getSessionResult.getTextDataChecks();
+        assertThat(getSessionResult.getChecks(), hasSize(4));
+        assertThat(result, hasSize(1));
+    }
+
+    @Test
+    public void shouldFilterFaceMatchChecks() throws NoSuchFieldException {
+        getSessionResult = new SimpleGetSessionResult();
+
+        FieldSetter.setField(
+                getSessionResult,
+                getSessionResult.getClass().getDeclaredField("checks"),
+                Arrays.asList(
+                        authenticityCheckResponseMock,
+                        livenessCheckResponseMock,
+                        textDataCheckResponseMock,
+                        faceMatchCheckResponseMock
+                )
+        );
+
+        List<FaceMatchCheckResponse> result = getSessionResult.getFaceMatchChecks();
+        assertThat(getSessionResult.getChecks(), hasSize(4));
+        assertThat(result, hasSize(1));
+    }
+
+    @Test
+    public void shouldReturnEmptyLists() throws NoSuchFieldException {
+        getSessionResult = new SimpleGetSessionResult();
+
+        FieldSetter.setField(
+                getSessionResult,
+                getSessionResult.getClass().getDeclaredField("checks"),
+                new ArrayList<>()
+        );
+
+        assertThat(getSessionResult.getChecks(), hasSize(0));
+        assertThat(getSessionResult.getAuthenticityChecks(), hasSize(0));
+        assertThat(getSessionResult.getFaceMatchChecks(), hasSize(0));
+        assertThat(getSessionResult.getTextDataChecks(), hasSize(0));
+        assertThat(getSessionResult.getLivenessChecks(), hasSize(0));
+    }
+
+}

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/docs/session/retrieve/SimpleIdDocumentResourceResponseTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/docs/session/retrieve/SimpleIdDocumentResourceResponseTest.java
@@ -1,0 +1,57 @@
+package com.yoti.api.client.docs.session.retrieve;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.internal.util.reflection.FieldSetter;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SimpleIdDocumentResourceResponseTest {
+
+    @Mock TextExtractionTaskResponse textExtractionTaskResponseMock;
+    @Mock TaskResponse taskResponseMock;
+
+    SimpleIdDocumentResourceResponse simpleIdDocumentResourceResponse;
+
+    @Test
+    public void shouldFilterTextExtractionTasks() throws NoSuchFieldException {
+        simpleIdDocumentResourceResponse = new SimpleIdDocumentResourceResponse();
+
+        FieldSetter.setField(
+                simpleIdDocumentResourceResponse,
+                simpleIdDocumentResourceResponse.getClass().getSuperclass().getDeclaredField("tasks"),
+                Arrays.asList(
+                        textExtractionTaskResponseMock,
+                        taskResponseMock
+                )
+        );
+
+        List<TextExtractionTaskResponse> result = simpleIdDocumentResourceResponse.getTextExtractionTasks();
+        assertThat(simpleIdDocumentResourceResponse.getTasks(), hasSize(2));
+        assertThat(result, hasSize(1));
+    }
+
+    @Test
+    public void shouldReturnEmptyList() throws NoSuchFieldException {
+        simpleIdDocumentResourceResponse = new SimpleIdDocumentResourceResponse();
+
+        FieldSetter.setField(
+                simpleIdDocumentResourceResponse,
+                simpleIdDocumentResourceResponse.getClass().getSuperclass().getDeclaredField("tasks"),
+                new ArrayList<>()
+        );
+
+        List<TextExtractionTaskResponse> result = simpleIdDocumentResourceResponse.getTextExtractionTasks();
+        assertThat(simpleIdDocumentResourceResponse.getTasks(), hasSize(0));
+        assertThat(result, hasSize(0));
+    }
+
+}

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/docs/session/retrieve/SimpleResourceContainerTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/docs/session/retrieve/SimpleResourceContainerTest.java
@@ -1,0 +1,58 @@
+package com.yoti.api.client.docs.session.retrieve;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.internal.util.reflection.FieldSetter;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SimpleResourceContainerTest {
+
+    @Mock ZoomLivenessResourceResponse zoomLivenessResourceResponseMock;
+    @Mock LivenessResourceResponse livenessResourceResponse;
+
+    SimpleResourceContainer simpleResourceContainer;
+
+    @Test
+    public void shouldFilterZoomLivenessResources() throws NoSuchFieldException {
+        simpleResourceContainer = new SimpleResourceContainer();
+
+        FieldSetter.setField(
+                simpleResourceContainer,
+                simpleResourceContainer.getClass().getDeclaredField("livenessCapture"),
+                Arrays.asList(
+                        zoomLivenessResourceResponseMock,
+                        livenessResourceResponse,
+                        livenessResourceResponse
+                )
+        );
+
+        List<ZoomLivenessResourceResponse> result = simpleResourceContainer.getZoomLivenessResources();
+        assertThat(simpleResourceContainer.getLivenessCapture(), hasSize(3));
+        assertThat(result, hasSize(1));
+    }
+
+    @Test
+    public void shouldReturnEmptyList() throws NoSuchFieldException {
+        simpleResourceContainer = new SimpleResourceContainer();
+
+        FieldSetter.setField(
+                simpleResourceContainer,
+                simpleResourceContainer.getClass().getDeclaredField("livenessCapture"),
+                new ArrayList<>()
+        );
+
+        List<ZoomLivenessResourceResponse> result = simpleResourceContainer.getZoomLivenessResources();
+        assertThat(simpleResourceContainer.getLivenessCapture(), hasSize(0));
+        assertThat(result, hasSize(0));
+    }
+
+}

--- a/yoti-sdk-impl/src/test/java/com/yoti/api/client/docs/session/retrieve/SimpleTextExtractionTaskResponseTest.java
+++ b/yoti-sdk-impl/src/test/java/com/yoti/api/client/docs/session/retrieve/SimpleTextExtractionTaskResponseTest.java
@@ -1,0 +1,42 @@
+package com.yoti.api.client.docs.session.retrieve;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.internal.util.reflection.FieldSetter;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SimpleTextExtractionTaskResponseTest {
+
+    @Mock GeneratedTextDataCheckResponse textDataCheckResponseMock;
+    @Mock GeneratedCheckResponse checkResponse;
+
+    SimpleTextExtractionTaskResponse textExtractionTaskResponse;
+
+    @Test
+    public void shouldFilterGeneratedTextDataChecks() throws NoSuchFieldException {
+        textExtractionTaskResponse = new SimpleTextExtractionTaskResponse();
+
+        FieldSetter.setField(
+                textExtractionTaskResponse,
+                textExtractionTaskResponse.getClass().getSuperclass().getDeclaredField("generatedChecks"),
+                Arrays.asList(
+                        textDataCheckResponseMock,
+                        checkResponse,
+                        checkResponse
+                )
+        );
+
+        List<GeneratedTextDataCheckResponse> result = textExtractionTaskResponse.getGeneratedTextDataChecks();
+        assertThat(textExtractionTaskResponse.getGeneratedChecks(), hasSize(3));
+        assertThat(result, hasSize(1));
+    }
+
+}


### PR DESCRIPTION
## Added

* `GetSessionResult`
  * `getAuthenticityChecks()`
  * `getFaceMatchChecks()`
  * `getTextDataChecks()`
  * `getLivenessChecks()`
* `IdDocumentResourceResponse`
  * `getTextExtractionTasks()`
* `ResourceContainer`
  * `getZoomLivenessResources()`
* `TextExtractionTaskResponse`
  * `getGeneratedTextDataChecks()`