### PR TITLE
SDK-1548: Expose type properties on doc scan classes

### DIFF
--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/CheckResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/CheckResponse.java
@@ -12,6 +12,13 @@ public interface CheckResponse {
     String getId();
 
     /**
+     * The type of the check
+     *
+     * @return the type
+     */
+    String getType();
+
+    /**
      * The state of the check
      *
      * @return the state

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/GeneratedCheckResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/GeneratedCheckResponse.java
@@ -4,4 +4,6 @@ public interface GeneratedCheckResponse {
 
     String getId();
 
+    String getType();
+
 }

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/LivenessResourceResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/LivenessResourceResponse.java
@@ -2,4 +2,6 @@ package com.yoti.api.client.docs.session.retrieve;
 
 public interface LivenessResourceResponse extends ResourceResponse {
 
+    String getLivenessType();
+
 }

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/TaskResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/TaskResponse.java
@@ -6,6 +6,8 @@ public interface TaskResponse {
 
     String getId();
 
+    String getType();
+
     String getState();
 
     String getCreated();

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleCheckResponse.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleCheckResponse.java
@@ -1,15 +1,21 @@
 package com.yoti.api.client.docs.session.retrieve;
 
+import java.util.List;
+
+import com.yoti.api.client.docs.DocScanConstants;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.yoti.api.client.docs.DocScanConstants;
-
-import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = SimpleCheckResponse.class)
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        property = "type",
+        defaultImpl = SimpleCheckResponse.class,
+        visible = true
+)
 @JsonSubTypes({
         @JsonSubTypes.Type(value = SimpleAuthenticityCheckResponse.class, name = DocScanConstants.ID_DOCUMENT_AUTHENTICITY),
         @JsonSubTypes.Type(value = SimpleTextDataCheckResponse.class, name = DocScanConstants.ID_DOCUMENT_TEXT_DATA_CHECK),
@@ -20,6 +26,9 @@ public class SimpleCheckResponse implements CheckResponse {
 
     @JsonProperty("id")
     private String id;
+
+    @JsonProperty("type")
+    private String type;
 
     @JsonProperty("state")
     private String state;
@@ -42,6 +51,11 @@ public class SimpleCheckResponse implements CheckResponse {
     @Override
     public String getId() {
         return id;
+    }
+
+    @Override
+    public String getType() {
+        return type;
     }
 
     @Override

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleGeneratedCheckResponse.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleGeneratedCheckResponse.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.yoti.api.client.docs.DocScanConstants;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = SimpleGeneratedCheckResponse.class)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = SimpleGeneratedCheckResponse.class, visible = true)
 @JsonSubTypes({
         @JsonSubTypes.Type(value = SimpleGeneratedTextDataCheckResponse.class, name = DocScanConstants.ID_DOCUMENT_TEXT_DATA_CHECK),
 })
@@ -16,8 +16,16 @@ public class SimpleGeneratedCheckResponse implements GeneratedCheckResponse {
     @JsonProperty("id")
     private String id;
 
+    @JsonProperty("type")
+    private String type;
+
     public String getId() {
         return id;
+    }
+
+    @Override
+    public String getType() {
+        return type;
     }
 
 }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleLivenessResourceResponse.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleLivenessResourceResponse.java
@@ -3,14 +3,22 @@ package com.yoti.api.client.docs.session.retrieve;
 import com.yoti.api.client.docs.DocScanConstants;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "liveness_type", defaultImpl = SimpleLivenessResourceResponse.class)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "liveness_type", defaultImpl = SimpleLivenessResourceResponse.class, visible = true)
 @JsonSubTypes({
         @JsonSubTypes.Type(value = SimpleZoomLivenessResourceResponse.class, name = DocScanConstants.ZOOM),
 })
 public class SimpleLivenessResourceResponse extends SimpleResourceResponse implements LivenessResourceResponse {
 
+    @JsonProperty("liveness_type")
+    private String livenessType;
+
+    @Override
+    public String getLivenessType() {
+        return livenessType;
+    }
 }

--- a/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleTaskResponse.java
+++ b/yoti-sdk-impl/src/main/java/com/yoti/api/client/docs/session/retrieve/SimpleTaskResponse.java
@@ -9,7 +9,7 @@ import com.yoti.api.client.docs.DocScanConstants;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = SimpleTaskResponse.class)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = SimpleTaskResponse.class, visible = true)
 @JsonSubTypes({
         @JsonSubTypes.Type(value = SimpleTextExtractionTaskResponse.class, name = DocScanConstants.ID_DOCUMENT_TEXT_DATA_EXTRACTION),
 })
@@ -17,6 +17,9 @@ public class SimpleTaskResponse implements TaskResponse {
 
     @JsonProperty("id")
     private String id;
+
+    @JsonProperty("type")
+    private String type;
 
     @JsonProperty("state")
     private String state;
@@ -36,6 +39,11 @@ public class SimpleTaskResponse implements TaskResponse {
     @Override
     public String getId() {
         return id;
+    }
+
+    @Override
+    public String getType() {
+        return type;
     }
 
     @Override


### PR DESCRIPTION
* This change stops Jackson from throwing away the type property for various response classes in Doc Scan