### PR TITLE
SDK-1539: Rename withCheckReport to withCheckReports

### DIFF
--- a/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/ResponseConfig.java
+++ b/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/ResponseConfig.java
@@ -43,7 +43,7 @@ public class ResponseConfig {
             return this;
         }
 
-        public Builder withCheckReport(SandboxCheckReports sandboxCheckReports) {
+        public Builder withCheckReports(SandboxCheckReports sandboxCheckReports) {
             this.sandboxCheckReports = sandboxCheckReports;
             return this;
         }

--- a/yoti-sdk-sandbox/src/test/java/com/yoti/api/client/sandbox/docs/request/ResponseConfigTest.java
+++ b/yoti-sdk-sandbox/src/test/java/com/yoti/api/client/sandbox/docs/request/ResponseConfigTest.java
@@ -17,7 +17,7 @@ public class ResponseConfigTest {
     @Test
     public void builder_shouldAllowCheckReportsToBeProvided() {
         ResponseConfig result = ResponseConfig.builder()
-                .withCheckReport(checkReportsMock)
+                .withCheckReports(checkReportsMock)
                 .build();
 
         assertThat(result.getCheckReports(), is(checkReportsMock));


### PR DESCRIPTION
### Fixed
- Renamed `withCheckReport` to `withCheckReports`
