### PR TITLE
Hotfix 3.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,13 @@ If you are using Maven, you need to add the following dependency:
 <dependency>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-api</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
 </dependency>
 ```
 
 If you are using Gradle, here is the dependency to add:
 
-`compile group: 'com.yoti', name: 'yoti-sdk-api', version: '3.2.0'`
+`compile group: 'com.yoti', name: 'yoti-sdk-api', version: '3.2.1-SNAPSHOT'`
 
 You will find all classes packaged under `com.yoti.api`
 

--- a/README.md
+++ b/README.md
@@ -101,13 +101,13 @@ If you are using Maven, you need to add the following dependency:
 <dependency>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-api</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.1</version>
 </dependency>
 ```
 
 If you are using Gradle, here is the dependency to add:
 
-`compile group: 'com.yoti', name: 'yoti-sdk-api', version: '3.2.1-SNAPSHOT'`
+`compile group: 'com.yoti', name: 'yoti-sdk-api', version: '3.2.1'`
 
 You will find all classes packaged under `com.yoti.api`
 

--- a/examples/doc-scan/pom.xml
+++ b/examples/doc-scan/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>com.yoti</groupId>
       <artifactId>yoti-sdk-api</artifactId>
-      <version>3.2.0</version>
+      <version>3.2.1-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/examples/doc-scan/pom.xml
+++ b/examples/doc-scan/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>com.yoti</groupId>
       <artifactId>yoti-sdk-api</artifactId>
-      <version>3.2.1-SNAPSHOT</version>
+      <version>3.2.1</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk</artifactId>
   <packaging>pom</packaging>
-  <version>3.2.0</version>
+  <version>3.2.1-SNAPSHOT</version>
   <name>Yoti SDK</name>
   <description>Java SDK for simple integration with the Yoti platform</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk</artifactId>
   <packaging>pom</packaging>
-  <version>3.2.1-SNAPSHOT</version>
+  <version>3.2.1</version>
   <name>Yoti SDK</name>
   <description>Java SDK for simple integration with the Yoti platform</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>

--- a/yoti-sdk-api/pom.xml
+++ b/yoti-sdk-api/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
 

--- a/yoti-sdk-api/pom.xml
+++ b/yoti-sdk-api/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.1</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
 

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/DocScanService.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/DocScanService.java
@@ -31,6 +31,7 @@ import com.yoti.api.client.spi.remote.call.SignedRequestResponse;
 import com.yoti.api.client.spi.remote.call.factory.UnsignedPathFactory;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.slf4j.Logger;

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/BreakdownResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/BreakdownResponse.java
@@ -2,10 +2,8 @@ package com.yoti.api.client.docs.session.retrieve;
 
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class BreakdownResponse {
 
     @JsonProperty("sub_check")

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/CheckResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/CheckResponse.java
@@ -4,12 +4,10 @@ import java.util.List;
 
 import com.yoti.api.client.docs.DocScanConstants;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
         property = "type",

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/DocumentFieldsResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/DocumentFieldsResponse.java
@@ -1,9 +1,7 @@
 package com.yoti.api.client.docs.session.retrieve;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class DocumentFieldsResponse {
 
     @JsonProperty("media")

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/FileResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/FileResponse.java
@@ -1,9 +1,7 @@
 package com.yoti.api.client.docs.session.retrieve;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class FileResponse {
 
     @JsonProperty("media")

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/FrameResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/FrameResponse.java
@@ -1,9 +1,7 @@
 package com.yoti.api.client.docs.session.retrieve;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class FrameResponse {
 
     @JsonProperty("media")

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/GeneratedCheckResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/GeneratedCheckResponse.java
@@ -2,12 +2,10 @@ package com.yoti.api.client.docs.session.retrieve;
 
 import com.yoti.api.client.docs.DocScanConstants;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = GeneratedCheckResponse.class, visible = true)
 @JsonSubTypes({
         @JsonSubTypes.Type(value = GeneratedTextDataCheckResponse.class, name = DocScanConstants.ID_DOCUMENT_TEXT_DATA_CHECK),

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/GeneratedMedia.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/GeneratedMedia.java
@@ -1,9 +1,7 @@
 package com.yoti.api.client.docs.session.retrieve;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class GeneratedMedia {
 
     @JsonProperty("id")

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/IdDocTextExtractionTaskResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/IdDocTextExtractionTaskResponse.java
@@ -2,9 +2,6 @@ package com.yoti.api.client.docs.session.retrieve;
 
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class IdDocTextExtractionTaskResponse extends TaskResponse {
 
     public List<GeneratedTextDataCheckResponse> getGeneratedTextDataChecks() {

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/LivenessResourceResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/LivenessResourceResponse.java
@@ -2,12 +2,10 @@ package com.yoti.api.client.docs.session.retrieve;
 
 import com.yoti.api.client.docs.DocScanConstants;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "liveness_type", defaultImpl = LivenessResourceResponse.class, visible = true)
 @JsonSubTypes({
         @JsonSubTypes.Type(value = ZoomLivenessResourceResponse.class, name = DocScanConstants.ZOOM),

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/MediaResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/MediaResponse.java
@@ -1,9 +1,7 @@
 package com.yoti.api.client.docs.session.retrieve;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class MediaResponse {
 
     @JsonProperty("id")

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/PageResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/PageResponse.java
@@ -2,10 +2,8 @@ package com.yoti.api.client.docs.session.retrieve;
 
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class PageResponse {
 
     @JsonProperty("capture_method")

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/RecommendationResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/RecommendationResponse.java
@@ -1,9 +1,7 @@
 package com.yoti.api.client.docs.session.retrieve;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class RecommendationResponse {
 
     @JsonProperty("value")

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/ReportResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/ReportResponse.java
@@ -2,10 +2,8 @@ package com.yoti.api.client.docs.session.retrieve;
 
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ReportResponse {
 
     @JsonProperty("recommendation")

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/ResourceContainer.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/ResourceContainer.java
@@ -3,10 +3,8 @@ package com.yoti.api.client.docs.session.retrieve;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ResourceContainer {
 
     @JsonProperty("id_documents")

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/ResourceResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/ResourceResponse.java
@@ -3,10 +3,8 @@ package com.yoti.api.client.docs.session.retrieve;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class ResourceResponse {
 
     @JsonProperty("id")

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/SupplementaryDocumentResourceResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/SupplementaryDocumentResourceResponse.java
@@ -2,10 +2,8 @@ package com.yoti.api.client.docs.session.retrieve;
 
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class SupplementaryDocumentResourceResponse extends ResourceResponse {
 
     @JsonProperty("document_type")

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/TaskResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/TaskResponse.java
@@ -5,12 +5,10 @@ import java.util.List;
 
 import com.yoti.api.client.docs.DocScanConstants;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = TaskResponse.class, visible = true)
 @JsonSubTypes({
         @JsonSubTypes.Type(value = IdDocTextExtractionTaskResponse.class, name = DocScanConstants.ID_DOCUMENT_TEXT_DATA_EXTRACTION),

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/WatchlistAdvancedCaSearchConfigResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/WatchlistAdvancedCaSearchConfigResponse.java
@@ -2,12 +2,10 @@ package com.yoti.api.client.docs.session.retrieve;
 
 import com.yoti.api.client.docs.DocScanConstants;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = YotiAccountWatchlistCaSearchConfigResponse.class, visible = true)
 @JsonSubTypes({
         @JsonSubTypes.Type(value = YotiAccountWatchlistCaSearchConfigResponse.class, name = DocScanConstants.WITH_YOTI_ACCOUNT),

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/WatchlistAdvancedCaSearchConfigResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/WatchlistAdvancedCaSearchConfigResponse.java
@@ -38,4 +38,11 @@ public abstract class WatchlistAdvancedCaSearchConfigResponse extends WatchlistS
         return shareUrl;
     }
 
+    public CaSourcesResponse getSources() {
+        return sources;
+    }
+
+    public CaMatchingStrategyResponse getMatchingStrategy() {
+        return matchingStrategy;
+    }
 }

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/ZoomLivenessResourceResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/ZoomLivenessResourceResponse.java
@@ -2,10 +2,8 @@ package com.yoti.api.client.docs.session.retrieve;
 
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ZoomLivenessResourceResponse extends LivenessResourceResponse {
 
     @JsonProperty("facemap")

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/spi/remote/call/JsonResourceFetcher.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/spi/remote/call/JsonResourceFetcher.java
@@ -2,6 +2,7 @@ package com.yoti.api.client.spi.remote.call;
 
 import java.io.IOException;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public final class JsonResourceFetcher implements ResourceFetcher {
@@ -14,7 +15,9 @@ public final class JsonResourceFetcher implements ResourceFetcher {
     }
 
     public static JsonResourceFetcher newInstance(RawResourceFetcher rawResourceFetcher) {
-        return new JsonResourceFetcher(new ObjectMapper(), rawResourceFetcher);
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        return new JsonResourceFetcher(objectMapper, rawResourceFetcher);
     }
 
     private JsonResourceFetcher(ObjectMapper objectMapper,

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/spi/remote/call/ProfileResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/spi/remote/call/ProfileResponse.java
@@ -1,9 +1,7 @@
 package com.yoti.api.client.spi.remote.call;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 class ProfileResponse {
 
     @JsonProperty("session_data")

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/spi/remote/call/Receipt.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/spi/remote/call/Receipt.java
@@ -4,10 +4,8 @@ import static org.bouncycastle.util.encoders.Base64.toBase64String;
 
 import java.util.Arrays;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public final class Receipt {
     @JsonProperty("receipt_id")
     private byte[] receiptId;

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/spi/remote/call/YotiConstants.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/spi/remote/call/YotiConstants.java
@@ -25,7 +25,7 @@ public final class YotiConstants {
     public static final String CONTENT_TYPE_JPEG = "image/jpeg";
 
     public static final String JAVA = "Java";
-    public static final String SDK_VERSION = JAVA + "-3.2.0";
+    public static final String SDK_VERSION = JAVA + "-3.2.1-SNAPSHOT";
     public static final String SIGNATURE_ALGORITHM = "SHA256withRSA";
     public static final String ASYMMETRIC_CIPHER = "RSA/NONE/PKCS1Padding";
     public static final String SYMMETRIC_CIPHER = "AES/CBC/PKCS7Padding";

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/spi/remote/call/YotiConstants.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/spi/remote/call/YotiConstants.java
@@ -25,7 +25,7 @@ public final class YotiConstants {
     public static final String CONTENT_TYPE_JPEG = "image/jpeg";
 
     public static final String JAVA = "Java";
-    public static final String SDK_VERSION = JAVA + "-3.2.1-SNAPSHOT";
+    public static final String SDK_VERSION = JAVA + "-3.2.1";
     public static final String SIGNATURE_ALGORITHM = "SHA256withRSA";
     public static final String ASYMMETRIC_CIPHER = "RSA/NONE/PKCS1Padding";
     public static final String SYMMETRIC_CIPHER = "AES/CBC/PKCS7Padding";

--- a/yoti-sdk-parent/pom.xml
+++ b/yoti-sdk-parent/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-parent</artifactId>
   <packaging>pom</packaging>
-  <version>3.2.0</version>
+  <version>3.2.1-SNAPSHOT</version>
   <name>Yoti SDK Parent Pom</name>
   <description>Parent pom for the Java SDK projects</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>

--- a/yoti-sdk-parent/pom.xml
+++ b/yoti-sdk-parent/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-parent</artifactId>
   <packaging>pom</packaging>
-  <version>3.2.1-SNAPSHOT</version>
+  <version>3.2.1</version>
   <name>Yoti SDK Parent Pom</name>
   <description>Parent pom for the Java SDK projects</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>

--- a/yoti-sdk-sandbox/pom.xml
+++ b/yoti-sdk-sandbox/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
   

--- a/yoti-sdk-sandbox/pom.xml
+++ b/yoti-sdk-sandbox/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.1</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
   

--- a/yoti-sdk-spring-boot-auto-config/README.md
+++ b/yoti-sdk-spring-boot-auto-config/README.md
@@ -18,7 +18,7 @@ If you are using Maven, you need to add the following dependencies:
 <dependency>
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-boot-auto-config</artifactId>
-  <version>3.2.0</version>
+  <version>3.2.1-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -26,7 +26,7 @@ If you are using Maven, you need to add the following dependencies:
 If you are using Gradle, here is the dependency to add:
 
 ```
-compile group: 'com.yoti', name: 'yoti-sdk-spring-boot-auto-config', version: '3.2.0'
+compile group: 'com.yoti', name: 'yoti-sdk-spring-boot-auto-config', version: '3.2.1-SNAPSHOT'
 ```
 
 

--- a/yoti-sdk-spring-boot-auto-config/README.md
+++ b/yoti-sdk-spring-boot-auto-config/README.md
@@ -18,7 +18,7 @@ If you are using Maven, you need to add the following dependencies:
 <dependency>
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-boot-auto-config</artifactId>
-  <version>3.2.1-SNAPSHOT</version>
+  <version>3.2.1</version>
 </dependency>
 ```
 
@@ -26,7 +26,7 @@ If you are using Maven, you need to add the following dependencies:
 If you are using Gradle, here is the dependency to add:
 
 ```
-compile group: 'com.yoti', name: 'yoti-sdk-spring-boot-auto-config', version: '3.2.1-SNAPSHOT'
+compile group: 'com.yoti', name: 'yoti-sdk-spring-boot-auto-config', version: '3.2.1'
 ```
 
 

--- a/yoti-sdk-spring-boot-auto-config/pom.xml
+++ b/yoti-sdk-spring-boot-auto-config/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
 

--- a/yoti-sdk-spring-boot-auto-config/pom.xml
+++ b/yoti-sdk-spring-boot-auto-config/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.1</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
 

--- a/yoti-sdk-spring-boot-example/README.md
+++ b/yoti-sdk-spring-boot-example/README.md
@@ -16,7 +16,7 @@ Before you start, you'll need to create an Application in [Yoti Hub](https://hub
     <dependency>
       <groupId>com.yoti</groupId>
       <artifactId>yoti-sdk-api</artifactId>
-      <version>3.2.0</version>
+      <version>3.2.1-SNAPSHOT</version>
     </dependency>
 ```
 
@@ -29,8 +29,8 @@ Before you start, you'll need to create an Application in [Yoti Hub](https://hub
 1. Run `mvn clean package` to build the project.
 
 ## Running
-* You can run your server-app by executing `java -jar target/yoti-sdk-spring-boot-example-3.2.0.jar`
-  * If you are using Java 9, you can run the server-app as follows `java -jar target/yoti-sdk-spring-boot-example-3.2.0.jar --add-exports java.base/jdk.internal.ref=ALL-UNNAMED`
+* You can run your server-app by executing `java -jar target/yoti-sdk-spring-boot-example-3.2.1-SNAPSHOT.jar`
+  * If you are using Java 9, you can run the server-app as follows `java -jar target/yoti-sdk-spring-boot-example-3.2.1-SNAPSHOT.jar --add-exports java.base/jdk.internal.ref=ALL-UNNAMED`
 * Navigate to `https://localhost:8443`
 * You can then initiate a login using Yoti.  The Spring demo is listening for the response on `https://localhost:8443/login`.
 

--- a/yoti-sdk-spring-boot-example/README.md
+++ b/yoti-sdk-spring-boot-example/README.md
@@ -16,7 +16,7 @@ Before you start, you'll need to create an Application in [Yoti Hub](https://hub
     <dependency>
       <groupId>com.yoti</groupId>
       <artifactId>yoti-sdk-api</artifactId>
-      <version>3.2.1-SNAPSHOT</version>
+      <version>3.2.1</version>
     </dependency>
 ```
 
@@ -29,8 +29,8 @@ Before you start, you'll need to create an Application in [Yoti Hub](https://hub
 1. Run `mvn clean package` to build the project.
 
 ## Running
-* You can run your server-app by executing `java -jar target/yoti-sdk-spring-boot-example-3.2.1-SNAPSHOT.jar`
-  * If you are using Java 9, you can run the server-app as follows `java -jar target/yoti-sdk-spring-boot-example-3.2.1-SNAPSHOT.jar --add-exports java.base/jdk.internal.ref=ALL-UNNAMED`
+* You can run your server-app by executing `java -jar target/yoti-sdk-spring-boot-example-3.2.1.jar`
+  * If you are using Java 9, you can run the server-app as follows `java -jar target/yoti-sdk-spring-boot-example-3.2.1.jar --add-exports java.base/jdk.internal.ref=ALL-UNNAMED`
 * Navigate to `https://localhost:8443`
 * You can then initiate a login using Yoti.  The Spring demo is listening for the response on `https://localhost:8443/login`.
 

--- a/yoti-sdk-spring-boot-example/pom.xml
+++ b/yoti-sdk-spring-boot-example/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-boot-example</artifactId>
 
-  <version>3.2.0</version>
+  <version>3.2.1-SNAPSHOT</version>
 
   <name>Yoti Spring Boot Example</name>
   <parent>

--- a/yoti-sdk-spring-boot-example/pom.xml
+++ b/yoti-sdk-spring-boot-example/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-boot-example</artifactId>
 
-  <version>3.2.1-SNAPSHOT</version>
+  <version>3.2.1</version>
 
   <name>Yoti Spring Boot Example</name>
   <parent>

--- a/yoti-sdk-spring-security/README.md
+++ b/yoti-sdk-spring-security/README.md
@@ -25,14 +25,14 @@ If you are using Maven, you need to add the following dependencies:
 <dependency>
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-security</artifactId>
-  <version>3.2.0</version>
+  <version>3.2.1-SNAPSHOT</version>
 </dependency>
 ```
 
 If you are using Gradle, here is the dependency to add:
 
 ```
-compile group: 'com.yoti', name: 'yoti-sdk-spring-security', version: '3.2.0'
+compile group: 'com.yoti', name: 'yoti-sdk-spring-security', version: '3.2.1-SNAPSHOT'
 ```
 
 ### Provide a `YotiClient` instance

--- a/yoti-sdk-spring-security/README.md
+++ b/yoti-sdk-spring-security/README.md
@@ -25,14 +25,14 @@ If you are using Maven, you need to add the following dependencies:
 <dependency>
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-security</artifactId>
-  <version>3.2.1-SNAPSHOT</version>
+  <version>3.2.1</version>
 </dependency>
 ```
 
 If you are using Gradle, here is the dependency to add:
 
 ```
-compile group: 'com.yoti', name: 'yoti-sdk-spring-security', version: '3.2.1-SNAPSHOT'
+compile group: 'com.yoti', name: 'yoti-sdk-spring-security', version: '3.2.1'
 ```
 
 ### Provide a `YotiClient` instance

--- a/yoti-sdk-spring-security/pom.xml
+++ b/yoti-sdk-spring-security/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
 

--- a/yoti-sdk-spring-security/pom.xml
+++ b/yoti-sdk-spring-security/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.1</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
 


### PR DESCRIPTION
## Added

- Added missing getters to WatchlistAdvancedCaSearchConfigResponse

## Fixed

- Added a global property to the internal object mapper to ignore unknown properties, when deserializing JSON data