### PR TITLE
SDK-2231: Add Identity Session creation service

### DIFF
--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/DigitalIdentityClient.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/DigitalIdentityClient.java
@@ -7,7 +7,10 @@ import java.io.IOException;
 import java.security.KeyPair;
 import java.security.Security;
 
+import com.yoti.api.client.identity.ShareSession;
+import com.yoti.api.client.identity.ShareSessionRequest;
 import com.yoti.api.client.spi.remote.KeyStreamVisitor;
+import com.yoti.api.client.spi.remote.call.identity.DigitalIdentityException;
 import com.yoti.api.client.spi.remote.call.identity.DigitalIdentityService;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -28,11 +31,21 @@ public class DigitalIdentityClient {
         this.identityService = identityService;
     }
 
-    public Object createShareSession() {
+    /**
+     * Create a sharing session to initiate a sharing process based on a policy
+     *
+     * @param request
+     *              Details of the request like policy, extensions and push notification for the application
+     * @return an {@link ShareSession}
+     *              Id, status and expiry of the newly created Share Session
+     * @throws DigitalIdentityException
+     *              Aggregate exception signalling issues during the call
+     */
+    public ShareSession createShareSession(ShareSessionRequest request) throws DigitalIdentityException {
         notNullOrEmpty(sdkId, "SDK ID");
         notNull(keyPair, "Application Key Pair");
 
-        return identityService.createShareSession();
+        return identityService.createShareSession(sdkId, keyPair, request);
     }
 
     public Object fetchShareSession(String sessionId) {
@@ -63,9 +76,9 @@ public class DigitalIdentityClient {
         return identityService.fetchShareReceipt(receiptId);
     }
 
-    private KeyPair loadKeyPair(KeyPairSource keyPair) throws InitialisationException {
+    private KeyPair loadKeyPair(KeyPairSource keyPairSource) throws InitialisationException {
         try {
-            return keyPair.getFromStream(new KeyStreamVisitor());
+            return keyPairSource.getFromStream(new KeyStreamVisitor());
         } catch (IOException ex) {
             throw new InitialisationException("Cannot load Key Pair", ex);
         }

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/ShareSession.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/ShareSession.java
@@ -1,0 +1,36 @@
+package com.yoti.api.client.identity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ShareSession {
+
+    @JsonProperty(Property.ID)
+    private String id;
+
+    @JsonProperty(Property.STATUS)
+    private String status;
+
+    @JsonProperty(Property.EXPIRY)
+    private String expiry;
+
+    public String getId() {
+        return id;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getExpiry() {
+        return expiry;
+    }
+
+    private static final class Property {
+
+        private static final String ID = "id";
+        private static final String STATUS = "status";
+        private static final String EXPIRY = "expiry";
+
+    }
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/ShareSessionNotification.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/ShareSessionNotification.java
@@ -1,0 +1,104 @@
+package com.yoti.api.client.identity;
+
+import static com.yoti.api.client.spi.remote.util.Validation.notNullOrEmpty;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public final class ShareSessionNotification {
+
+    @JsonProperty(Property.URL)
+    private final String url;
+
+    @JsonProperty(Property.METHOD)
+    private final String method;
+
+    @JsonProperty(Property.VERIFY_TLS)
+    private final boolean verifyTls;
+
+    @JsonProperty(Property.HEADERS)
+    private final Map<String, String> headers;
+
+    private ShareSessionNotification(Builder builder) {
+        url = builder.url;
+        method = builder.method;
+        verifyTls = builder.verifyTls;
+        headers = builder.headers;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public boolean isVerifyTls() {
+        return verifyTls;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    public static Builder builder(URI uri) {
+        return new Builder(uri);
+    }
+
+    public static final class Builder {
+
+        private final String url;
+        private final Map<String, String> headers;
+
+        private String method;
+        private boolean verifyTls;
+
+        private Builder(URI uri) {
+            url = uri.toString();
+            method = "POST";
+            verifyTls = true;
+            headers = new HashMap<>();
+        }
+
+        public Builder withMethod(String method) {
+            this.method = method;
+            return this;
+        }
+
+        public Builder withVerifyTls(boolean verifyTls) {
+            this.verifyTls = verifyTls;
+            return this;
+        }
+
+        public Builder withHeaders(Map<String, String> headers) {
+            this.headers.putAll(headers);
+            return this;
+        }
+
+        public Builder withHeader(String key, String value) {
+            headers.put(key, value);
+            return this;
+        }
+
+        public ShareSessionNotification build() {
+            notNullOrEmpty(url, Property.URL);
+
+            return new ShareSessionNotification(this);
+        }
+
+    }
+
+    private static final class Property {
+
+        private static final String URL = "url";
+        private static final String METHOD = "method";
+        private static final String VERIFY_TLS = "verifyTls";
+        private static final String HEADERS = "headers";
+
+    }
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/ShareSessionRequest.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/ShareSessionRequest.java
@@ -1,0 +1,127 @@
+package com.yoti.api.client.identity;
+
+import static com.yoti.api.client.spi.remote.util.Validation.notNull;
+import static com.yoti.api.client.spi.remote.util.Validation.notNullOrEmpty;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import com.yoti.api.client.identity.extension.Extension;
+import com.yoti.api.client.identity.policy.Policy;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ShareSessionRequest {
+
+    @JsonProperty(Property.SUBJECT)
+    private final Map<String, Object> subject;
+
+    @JsonProperty(Property.POLICY)
+    private final Policy policy;
+
+    @JsonProperty(Property.EXTENSIONS)
+    private final List<Extension> extensions;
+
+    @JsonProperty(Property.REDIRECT_URI)
+    private final String redirectUri;
+
+    @JsonProperty(Property.NOTIFICATION)
+    private final ShareSessionNotification notification;
+
+    private ShareSessionRequest(Builder builder) {
+        subject = builder.subject;
+        policy = builder.policy;
+        extensions = builder.extensions;
+        redirectUri = builder.redirectUri;
+        notification = builder.notification;
+    }
+
+    public Map<String, Object> getSubject() {
+        return subject;
+    }
+
+    public Policy getPolicy() {
+        return policy;
+    }
+
+    public List<Extension> getExtensions() {
+        return extensions;
+    }
+
+    public String getRedirectUri() {
+        return redirectUri;
+    }
+
+    public ShareSessionNotification getNotification() {
+        return notification;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+
+        private Map<String, Object> subject;
+        private Policy policy;
+        private List<Extension> extensions;
+        private String redirectUri;
+        private ShareSessionNotification notification;
+
+        private Builder() {
+            extensions = new ArrayList<>();
+        }
+
+        public Builder withSubject(Map<String, Object> subject) {
+            this.subject = subject;
+            return this;
+        }
+
+        public Builder withPolicy(Policy policy) {
+            this.policy = policy;
+            return this;
+        }
+
+        public Builder withExtensions(List<Extension> extensions) {
+            this.extensions = Collections.unmodifiableList(extensions);
+            return this;
+        }
+
+        public Builder withExtension(Extension extension) {
+            extensions.add(extension);
+            return this;
+        }
+
+        public Builder withRedirectUri(URI redirectUri) {
+            this.redirectUri = redirectUri.toString();
+            return this;
+        }
+
+        public Builder withNotification(ShareSessionNotification notification) {
+            this.notification = notification;
+            return this;
+        }
+
+        public ShareSessionRequest build() {
+            notNull(policy, Property.POLICY);
+            notNullOrEmpty(redirectUri, Property.REDIRECT_URI);
+
+            return new ShareSessionRequest(this);
+        }
+
+    }
+
+    private static final class Property {
+
+        private static final String SUBJECT = "subject";
+        private static final String POLICY = "policy";
+        private static final String EXTENSIONS = "extensions";
+        private static final String REDIRECT_URI = "redirectUri";
+        private static final String NOTIFICATION = "notification";
+
+    }
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/constraint/Constraint.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/constraint/Constraint.java
@@ -1,0 +1,7 @@
+package com.yoti.api.client.identity.constraint;
+
+public interface Constraint {
+
+    String getType();
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/constraint/PreferredSources.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/constraint/PreferredSources.java
@@ -1,0 +1,37 @@
+package com.yoti.api.client.identity.constraint;
+
+import java.util.List;
+
+import com.yoti.api.client.identity.policy.WantedAnchor;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class PreferredSources {
+
+    @JsonProperty(Property.ANCHORS)
+    private final List<WantedAnchor> wantedAnchors;
+
+    @JsonProperty(Property.SOFT_PREFERENCE)
+    private final boolean softPreference;
+
+    PreferredSources(List<WantedAnchor> wantedAnchors, boolean softPreference) {
+        this.wantedAnchors = wantedAnchors;
+        this.softPreference = softPreference;
+    }
+
+    public List<WantedAnchor> getWantedAnchors() {
+        return wantedAnchors;
+    }
+
+    public boolean isSoftPreference() {
+        return softPreference;
+    }
+
+    private static final class Property {
+
+        private static final String ANCHORS = "anchors";
+        private static final String SOFT_PREFERENCE = "soft_preference";
+
+    }
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/constraint/SourceConstraint.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/constraint/SourceConstraint.java
@@ -1,0 +1,74 @@
+package com.yoti.api.client.identity.constraint;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.yoti.api.client.identity.policy.WantedAnchor;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SourceConstraint implements Constraint {
+
+    @JsonProperty(Property.TYPE)
+    private final String type;
+
+    @JsonProperty(Property.PREFERRED_SOURCES)
+    private final PreferredSources preferredSources;
+
+    SourceConstraint(List<WantedAnchor> wantedAnchors, boolean softPreference) {
+        type = "SOURCE";
+        preferredSources = new PreferredSources(wantedAnchors, softPreference);
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    public PreferredSources getPreferredSources() {
+        return preferredSources;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private List<WantedAnchor> wantedAnchors;
+        private boolean softPreference;
+
+        private Builder() {
+            this.wantedAnchors = new ArrayList<>();
+        }
+
+        public Builder withWantedAnchors(List<WantedAnchor> wantedAnchors) {
+            this.wantedAnchors = Collections.unmodifiableList(wantedAnchors);
+            return this;
+        }
+
+        public Builder withWantedAnchor(WantedAnchor wantedAnchor) {
+            this.wantedAnchors.add(wantedAnchor);
+            return this;
+        }
+
+        public Builder withSoftPreference(boolean softPreference) {
+            this.softPreference = softPreference;
+            return this;
+        }
+
+        public SourceConstraint build() {
+            return new SourceConstraint(Collections.unmodifiableList(wantedAnchors),  softPreference);
+        }
+
+    }
+
+    private static final class Property {
+
+        private static final String TYPE = "type";
+        private static final String PREFERRED_SOURCES = "preferred_sources";
+
+    }
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/extension/BasicExtensionBuilder.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/extension/BasicExtensionBuilder.java
@@ -1,0 +1,31 @@
+package com.yoti.api.client.identity.extension;
+
+public class BasicExtensionBuilder implements ExtensionBuilder<Object> {
+
+    private String type;
+    private Object content;
+
+    public BasicExtensionBuilder withType(String type) {
+        this.type = type;
+        return this;
+    }
+
+    public BasicExtensionBuilder withContent(Object content) {
+        this.content = content;
+        return this;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public Object getContent() {
+        return content;
+    }
+
+    @Override
+    public Extension<Object> build() {
+        return new Extension<>(type, content);
+    }
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/extension/Extension.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/extension/Extension.java
@@ -1,0 +1,33 @@
+package com.yoti.api.client.identity.extension;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Extension<T> {
+
+    @JsonProperty(Property.TYPE)
+    private final String type;
+
+    @JsonProperty(Property.CONTENT)
+    private final T content;
+
+    Extension(String type, T content) {
+        this.type = type;
+        this.content = content;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public T getContent() {
+        return content;
+    }
+
+    private static final class Property {
+
+        private static final String TYPE = "type";
+        private static final String CONTENT = "content";
+
+    }
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/extension/ExtensionBuilder.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/extension/ExtensionBuilder.java
@@ -1,0 +1,7 @@
+package com.yoti.api.client.identity.extension;
+
+public interface ExtensionBuilder<T> {
+
+    Extension<T> build();
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/extension/ExtensionBuilderFactory.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/extension/ExtensionBuilderFactory.java
@@ -1,0 +1,27 @@
+package com.yoti.api.client.identity.extension;
+
+public class ExtensionBuilderFactory {
+
+    private ExtensionBuilderFactory() { }
+
+    public static ExtensionBuilderFactory newInstance() {
+        return new ExtensionBuilderFactory();
+    }
+
+    public BasicExtensionBuilder createExtensionBuilder() {
+        return new BasicExtensionBuilder();
+    }
+
+    public LocationConstraintExtensionBuilder createLocationConstraintExtensionBuilder() {
+        return new LocationConstraintExtensionBuilder();
+    }
+
+    public TransactionalFlowExtensionBuilder createTransactionalFlowExtensionBuilder() {
+        return new TransactionalFlowExtensionBuilder();
+    }
+
+    public ThirdPartyAttributeExtensionBuilder createThirdPartyAttributeExtensionBuilder() {
+        return new ThirdPartyAttributeExtensionBuilder();
+    }
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/extension/LocationConstraintContent.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/extension/LocationConstraintContent.java
@@ -1,0 +1,64 @@
+package com.yoti.api.client.identity.extension;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class LocationConstraintContent {
+
+    private final DeviceLocation expectedDeviceLocation;
+
+    LocationConstraintContent(double latitude, double longitude, double radius, double maxUncertainty) {
+        this.expectedDeviceLocation = new DeviceLocation(latitude, longitude, radius, maxUncertainty);
+    }
+
+    @JsonProperty(Property.EXPECTED_DEVICE_LOCATION)
+    public DeviceLocation getExpectedDeviceLocation() {
+        return expectedDeviceLocation;
+    }
+
+    public static final class DeviceLocation {
+
+        private final double latitude;
+        private final double longitude;
+        private final double radius;
+        private final double maxUncertainty;
+
+        DeviceLocation(double latitude, double longitude, double radius, double maxUncertainty) {
+            this.latitude = latitude;
+            this.longitude = longitude;
+            this.radius = radius;
+            this.maxUncertainty = maxUncertainty;
+        }
+
+        @JsonProperty(Property.LATITUDE)
+        public double getLatitude() {
+            return latitude;
+        }
+
+        @JsonProperty(Property.LONGITUDE)
+        public double getLongitude() {
+            return longitude;
+        }
+
+        @JsonProperty(Property.RADIUS)
+        public double getRadius() {
+            return radius;
+        }
+
+        @JsonProperty(Property.MAX_UNCERTAINTY_RADIUS)
+        public double getMaxUncertainty() {
+            return maxUncertainty;
+        }
+
+    }
+
+    private static final class Property {
+
+        private static final String EXPECTED_DEVICE_LOCATION = "expected_device_location";
+        private static final String LATITUDE = "latitude";
+        private static final String LONGITUDE = "longitude";
+        private static final String RADIUS = "radius";
+        private static final String MAX_UNCERTAINTY_RADIUS = "max_uncertainty_radius";
+
+    }
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/extension/LocationConstraintExtensionBuilder.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/extension/LocationConstraintExtensionBuilder.java
@@ -1,0 +1,57 @@
+package com.yoti.api.client.identity.extension;
+
+import com.yoti.api.client.spi.remote.util.Validation;
+
+public class LocationConstraintExtensionBuilder implements ExtensionBuilder<LocationConstraintContent> {
+
+    public static final String TYPE = "LOCATION_CONSTRAINT";
+
+    private double latitude;
+    private double longitude;
+    private double radius = 150d;
+    private double maxUncertainty = 150d;
+
+    public LocationConstraintExtensionBuilder withLatitude(double latitude) {
+        Validation.withinRange(latitude, -90d, 90d, Property.LATITUDE);
+
+        this.latitude = latitude;
+        return this;
+    }
+
+    public LocationConstraintExtensionBuilder withLongitude(double longitude) {
+        Validation.withinRange(longitude, -180d, 180d, Property.LONGITUDE);
+
+        this.longitude = longitude;
+        return this;
+    }
+
+    public LocationConstraintExtensionBuilder withRadius(double radius) {
+        Validation.notLessThan(radius, 0d, Property.RADIUS);
+
+        this.radius = radius;
+        return this;
+    }
+
+    public LocationConstraintExtensionBuilder withMaxUncertainty(double maxUncertainty) {
+        Validation.notLessThan(maxUncertainty, 0d, Property.MAX_UNCERTAINTY);
+
+        this.maxUncertainty = maxUncertainty;
+        return this;
+    }
+
+    @Override
+    public Extension<LocationConstraintContent> build() {
+        LocationConstraintContent content = new LocationConstraintContent(latitude, longitude, radius, maxUncertainty);
+        return new Extension<>(TYPE, content);
+    }
+
+    private static final class Property {
+
+        private static final String LATITUDE = "latitude";
+        private static final String LONGITUDE = "longitude";
+        private static final String RADIUS = "radius";
+        private static final String MAX_UNCERTAINTY = "maxUncertainty";
+
+    }
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/extension/ThirdPartyAttributeContent.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/extension/ThirdPartyAttributeContent.java
@@ -1,0 +1,44 @@
+package com.yoti.api.client.identity.extension;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+
+import com.yoti.api.client.AttributeDefinition;
+import com.yoti.api.client.spi.remote.call.YotiConstants;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ThirdPartyAttributeContent {
+
+    private final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat(YotiConstants.RFC3339_PATTERN_MILLIS);
+
+    private final Date expiryDate;
+
+    @JsonProperty(Property.DEFINITIONS)
+    private final List<AttributeDefinition> definitions;
+
+    ThirdPartyAttributeContent(Date expiryDate, List<AttributeDefinition> definitions) {
+        this.expiryDate = expiryDate;
+        this.definitions = definitions;
+    }
+
+    @JsonProperty(Property.EXPIRY_DATE)
+    public String getExpiryDate() {
+        DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return DATE_FORMAT.format(expiryDate.getTime());
+    }
+
+    public List<AttributeDefinition> getDefinitions() {
+        return definitions;
+    }
+
+    private static final class Property {
+
+        private static final String DEFINITIONS = "definitions";
+        private static final String EXPIRY_DATE = "expiry_date";
+
+    }
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/extension/ThirdPartyAttributeExtensionBuilder.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/extension/ThirdPartyAttributeExtensionBuilder.java
@@ -1,0 +1,58 @@
+package com.yoti.api.client.identity.extension;
+
+import static com.yoti.api.client.spi.remote.util.Validation.notNull;
+import static com.yoti.api.client.spi.remote.util.Validation.notNullOrEmpty;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import com.yoti.api.client.AttributeDefinition;
+
+public class ThirdPartyAttributeExtensionBuilder implements ExtensionBuilder<ThirdPartyAttributeContent> {
+
+    public static final String TYPE = "THIRD_PARTY_ATTRIBUTE";
+
+    private Date expiryDate;
+    private List<AttributeDefinition> definitions;
+
+    public ThirdPartyAttributeExtensionBuilder() {
+        this.definitions = new ArrayList<>();
+    }
+
+    public ThirdPartyAttributeExtensionBuilder withExpiryDate(Date expiryDate) {
+        notNull(expiryDate, Property.EXPIRY_DATE);
+
+        this.expiryDate = new Date(expiryDate.getTime());
+        return this;
+    }
+
+    public ThirdPartyAttributeExtensionBuilder withDefinition(String definition) {
+        notNullOrEmpty(definition, Property.DEFINITION);
+
+        this.definitions.add(new AttributeDefinition(definition));
+        return this;
+    }
+
+    public ThirdPartyAttributeExtensionBuilder withDefinitions(List<String> definitions) {
+        List<AttributeDefinition> attributeDefinitions = new ArrayList<>();
+        for (String definition : definitions) {
+            attributeDefinitions.add(new AttributeDefinition(definition));
+        }
+        this.definitions = attributeDefinitions;
+        return this;
+    }
+
+    public Extension<ThirdPartyAttributeContent> build() {
+        ThirdPartyAttributeContent thirdPartyAttributeContent = new ThirdPartyAttributeContent(expiryDate, definitions);
+        return new Extension<>(TYPE, thirdPartyAttributeContent);
+    }
+
+    private static final class Property {
+
+        private static final String EXPIRY_DATE = "expiryDate";
+        private static final String DEFINITION = "definition";
+
+    }
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/extension/TransactionalFlowExtensionBuilder.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/extension/TransactionalFlowExtensionBuilder.java
@@ -1,0 +1,29 @@
+package com.yoti.api.client.identity.extension;
+
+import com.yoti.api.client.spi.remote.util.Validation;
+
+public class TransactionalFlowExtensionBuilder implements ExtensionBuilder<Object> {
+
+    public static final String TYPE = "TRANSACTIONAL_FLOW";
+
+    private Object content;
+
+    public TransactionalFlowExtensionBuilder withContent(Object content) {
+        Validation.notNull(content, Property.CONTENT);
+
+        this.content = content;
+        return this;
+    }
+
+    @Override
+    public Extension<Object> build() {
+        return new Extension<>(TYPE, content);
+    }
+
+    private static final class Property {
+
+        private static final String CONTENT = "content";
+
+    }
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/policy/Policy.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/policy/Policy.java
@@ -1,0 +1,274 @@
+package com.yoti.api.client.identity.policy;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import com.yoti.api.attributes.AttributeConstants;
+import com.yoti.api.client.identity.constraint.Constraint;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Policy {
+
+    @JsonProperty(Property.WANTED)
+    private final Collection<WantedAttribute> wantedAttributes;
+
+    @JsonProperty(Property.WANTED_AUTH_TYPES)
+    private final Set<Integer> wantedAuthTypes;
+
+    @JsonProperty(Property.WANTED_REMEMBER_ME)
+    private final boolean wantedRememberMe;
+
+    @JsonProperty(Property.WANTED_REMEMBER_ME_OPTIONAL)
+    private final boolean wantedRememberMeOptional;
+
+    @JsonProperty(Property.IDENTITY_PROFILE_REQUIREMENTS)
+    private final Object identityProfile;
+
+    private Policy(Builder builder) {
+        wantedAttributes = builder.wantedAttributes.values();
+        wantedAuthTypes = builder.wantedAuthTypes;
+        wantedRememberMe = builder.wantedRememberMe;
+        wantedRememberMeOptional = builder.wantedRememberMeOptional;
+        identityProfile = builder.identityProfile;
+    }
+
+    public Collection<WantedAttribute> getWantedAttributes() {
+        return wantedAttributes;
+    }
+
+    public Set<Integer> getWantedAuthTypes() {
+        return wantedAuthTypes;
+    }
+
+    public boolean isWantedRememberMe() {
+        return wantedRememberMe;
+    }
+
+    public boolean isWantedRememberMeOptional() {
+        return wantedRememberMeOptional;
+    }
+
+    public Object getIdentityProfile() {
+        return identityProfile;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private static final int SELFIE_AUTH_TYPE = 1;
+        private static final int PIN_AUTH_TYPE = 2;
+
+        private final Map<String, WantedAttribute> wantedAttributes;
+        private final Set<Integer> wantedAuthTypes;
+
+        private boolean wantedRememberMe;
+        private boolean wantedRememberMeOptional;
+        private Object identityProfile;
+
+        private Builder() {
+            wantedAttributes = new HashMap<>();
+            wantedAuthTypes = new HashSet<>();
+        }
+
+        public Builder withWantedAttribute(WantedAttribute wantedAttribute) {
+            String key = Optional.ofNullable(wantedAttribute.getDerivation()).orElseGet(wantedAttribute::getName);
+
+            if (!wantedAttribute.getConstraints().isEmpty()) {
+                key += "-" + wantedAttribute.getConstraints().hashCode();
+            }
+
+            this.wantedAttributes.put(key, wantedAttribute);
+            return this;
+        }
+
+        public Builder withWantedAttribute(boolean optional, String name, List<Constraint> constraints) {
+            return withWantedAttribute(
+                    WantedAttribute.builder()
+                            .withName(name)
+                            .withOptional(optional)
+                            .withConstraints(constraints)
+                            .build()
+            );
+        }
+
+        public Builder withWantedAttribute(boolean optional, String name) {
+            return withWantedAttribute(optional, name, Collections.emptyList());
+        }
+
+        public Builder withFamilyName() {
+            return withFamilyName(false);
+        }
+
+        public Builder withFamilyName(boolean optional) {
+            return withWantedAttribute(optional, AttributeConstants.HumanProfileAttributes.FAMILY_NAME);
+        }
+
+        public Builder withGivenNames() {
+            return withGivenNames(false);
+        }
+
+        public Builder withGivenNames(boolean optional) {
+            return withWantedAttribute(optional, AttributeConstants.HumanProfileAttributes.GIVEN_NAMES);
+        }
+
+        public Builder withFullName() {
+            return withFullName(false);
+        }
+
+        public Builder withFullName(boolean optional) {
+            return withWantedAttribute(optional, AttributeConstants.HumanProfileAttributes.FULL_NAME);
+        }
+
+        public Builder withDateOfBirth() {
+            return withDateOfBirth(false);
+        }
+
+        public Builder withDateOfBirth(boolean optional) {
+            return withWantedAttribute(optional, AttributeConstants.HumanProfileAttributes.DATE_OF_BIRTH);
+        }
+
+        public Builder withAgeOver(int age) {
+            return withAgeOver(false, age);
+        }
+
+        public Builder withAgeOver(boolean optional, int age) {
+            return withAgeDerivedAttribute(optional, AttributeConstants.HumanProfileAttributes.AGE_OVER + age);
+        }
+
+        public Builder withAgeUnder(int age) {
+            return withAgeUnder(false, age);
+        }
+        
+        public Builder withAgeUnder(boolean optional, int age) {
+            return withAgeDerivedAttribute(optional, AttributeConstants.HumanProfileAttributes.AGE_UNDER + age);
+        }
+
+        private Builder withAgeDerivedAttribute(boolean optional, String derivation) {
+            WantedAttribute wantedAttribute = WantedAttribute.builder()
+                    .withName(AttributeConstants.HumanProfileAttributes.DATE_OF_BIRTH)
+                    .withDerivation(derivation)
+                    .withOptional(optional)
+                    .build();
+            return withWantedAttribute(wantedAttribute);
+        }
+
+        public Builder withGender() {
+            return withGender(false);
+        }
+
+        public Builder withGender(boolean optional) {
+            return withWantedAttribute(optional, AttributeConstants.HumanProfileAttributes.GENDER);
+        }
+
+        public Builder withPostalAddress() {
+            return withPostalAddress(false);
+        }
+
+        public Builder withPostalAddress(boolean optional) {
+            return withWantedAttribute(optional, AttributeConstants.HumanProfileAttributes.POSTAL_ADDRESS);
+        }
+
+        public Builder withStructuredPostalAddress() {
+            return withStructuredPostalAddress(false);
+        }
+
+        public Builder withStructuredPostalAddress(boolean optional) {
+            return withWantedAttribute(optional, AttributeConstants.HumanProfileAttributes.STRUCTURED_POSTAL_ADDRESS);
+        }
+
+        public Builder withNationality() {
+            return withNationality(false);
+        }
+
+        public Builder withNationality(boolean optional) {
+            return withWantedAttribute(optional, AttributeConstants.HumanProfileAttributes.NATIONALITY);
+        }
+
+        public Builder withPhoneNumber() {
+            return withPhoneNumber(false);
+        }
+
+        public Builder withPhoneNumber(boolean optional) {
+            return withWantedAttribute(optional, AttributeConstants.HumanProfileAttributes.PHONE_NUMBER);
+        }
+
+        public Builder withSelfie() {
+            return withSelfie(false);
+        }
+
+        public Builder withSelfie(boolean optional) {
+            return withWantedAttribute(optional, AttributeConstants.HumanProfileAttributes.SELFIE);
+        }
+
+        public Builder withEmail() {
+            return withEmail(false);
+        }
+
+        public Builder withEmail(boolean optional) {
+            return withWantedAttribute(optional, AttributeConstants.HumanProfileAttributes.EMAIL_ADDRESS);
+        }
+
+        public Builder withSelfieAuthentication(boolean enabled) {
+            return this.withWantedAuthType(SELFIE_AUTH_TYPE, enabled);
+        }
+
+        public Builder withPinAuthentication(boolean enabled) {
+            return this.withWantedAuthType(PIN_AUTH_TYPE, enabled);
+        }
+
+        public Builder withWantedAuthType(int wantedAuthType) {
+            this.wantedAuthTypes.add(wantedAuthType);
+            return this;
+        }
+
+        public Builder withWantedAuthType(int wantedAuthType, boolean enabled) {
+            if (enabled) {
+                return this.withWantedAuthType(wantedAuthType);
+            } else {
+                this.wantedAuthTypes.remove(wantedAuthType);
+                return this;
+            }
+        }
+
+        public Builder withWantedRememberMe(boolean wantedRememberMe) {
+            this.wantedRememberMe = wantedRememberMe;
+            return this;
+        }
+
+        public Builder withWantedRememberMeOptional(boolean wantedRememberMeOptional) {
+            this.wantedRememberMeOptional = wantedRememberMeOptional;
+            return this;
+        }
+
+        public Builder withIdentityProfile(Object identityProfile) {
+            this.identityProfile = identityProfile;
+            return this;
+        }
+        
+        public Policy build() {
+            return new Policy(this);
+        }
+
+    }
+
+    private static final class Property {
+
+        private static final String WANTED = "wanted";
+        private static final String WANTED_AUTH_TYPES = "wanted_auth_types";
+        private static final String WANTED_REMEMBER_ME = "wanted_remember_me";
+        private static final String WANTED_REMEMBER_ME_OPTIONAL = "wanted_remember_me_optional";
+        private static final String IDENTITY_PROFILE_REQUIREMENTS = "identity_profile_requirements";
+
+    }
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/policy/WantedAnchor.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/policy/WantedAnchor.java
@@ -1,0 +1,64 @@
+package com.yoti.api.client.identity.policy;
+
+import static com.yoti.api.client.spi.remote.util.Validation.notNull;
+import static com.yoti.api.client.spi.remote.util.Validation.notNullOrEmpty;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class WantedAnchor {
+
+    @JsonProperty(Property.NAME)
+    private final String value;
+
+    @JsonProperty(Property.SUB_TYPE)
+    private final String subType;
+
+    private WantedAnchor(Builder builder) {
+        value = builder.value;
+        subType = builder.subType;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String getSubType() {
+        return subType;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String value;
+        private String subType;
+
+        public Builder withValue(String value) {
+            this.value = value;
+            return this;
+        }
+
+        public Builder withSubType(String subType) {
+            this.subType = subType;
+            return this;
+        }
+
+        public WantedAnchor build() {
+            notNullOrEmpty(value, Property.NAME);
+            notNull(subType, Property.SUB_TYPE);
+
+            return new WantedAnchor(this);
+        }
+
+    }
+
+    private static final class Property {
+
+        private static final String NAME = "name";
+        private static final String SUB_TYPE = "sub_type";
+
+    }
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/policy/WantedAttribute.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/policy/WantedAttribute.java
@@ -1,0 +1,122 @@
+package com.yoti.api.client.identity.policy;
+
+import static com.yoti.api.client.spi.remote.util.Validation.notNullOrEmpty;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.yoti.api.client.identity.constraint.Constraint;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class WantedAttribute {
+
+    @JsonProperty(Property.NAME)
+    private final String name;
+
+    @JsonProperty(Property.DERIVATION)
+    private final String derivation;
+
+    @JsonProperty(Property.OPTIONAL)
+    private final boolean optional;
+
+    @JsonProperty(Property.ACCEPT_SELF_ASSERTED)
+    private final Boolean acceptSelfAsserted;
+
+    @JsonProperty(Property.CONSTRAINTS)
+    private final List<Constraint> constraints;
+
+    private WantedAttribute(Builder builder) {
+        name = builder.name;
+        derivation = builder.derivation;
+        optional = builder.optional;
+        acceptSelfAsserted = builder.acceptSelfAsserted;
+        constraints = builder.constraints;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDerivation() {
+        return derivation;
+    }
+
+    public boolean isOptional() {
+        return optional;
+    }
+
+    public Boolean getAcceptSelfAsserted() {
+        return acceptSelfAsserted;
+    }
+
+    public List<Constraint> getConstraints() {
+        return constraints;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String name;
+        private String derivation;
+        private boolean optional;
+        private Boolean acceptSelfAsserted;
+        private List<Constraint> constraints;
+
+        private Builder() {
+            this.constraints = new ArrayList<>();
+        }
+        
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+        
+        public Builder withDerivation(String derivation) {
+            this.derivation = derivation;
+            return this;
+        }
+        
+        public Builder withOptional(boolean optional) {
+            this.optional = optional;
+            return this;
+        }
+
+        public Builder withAcceptSelfAsserted(boolean acceptSelfAsserted) {
+            this.acceptSelfAsserted = acceptSelfAsserted;
+            return this;
+        }
+
+        public Builder withConstraints(List<Constraint> constraints) {
+            this.constraints = Collections.unmodifiableList(constraints);
+            return this;
+        }
+
+        public Builder withConstraint(Constraint constraint) {
+            this.constraints.add(constraint);
+            return this;
+        }
+
+        public WantedAttribute build() {
+            notNullOrEmpty(name, Property.NAME);
+
+            return new WantedAttribute(this);
+        }
+
+    }
+
+    private static final class Property {
+
+        private static final String NAME = "name";
+        private static final String DERIVATION = "derivation";
+        private static final String OPTIONAL = "optional";
+        private static final String ACCEPT_SELF_ASSERTED = "accept_self_asserted";
+        private static final String CONSTRAINTS = "constraints";
+
+    }
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/spi/remote/call/YotiConstants.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/spi/remote/call/YotiConstants.java
@@ -14,6 +14,10 @@ public final class YotiConstants {
     public static final String YOTI_DOCS_PATH_PREFIX = "/idverify/v1";
     public static final String DEFAULT_YOTI_DOCS_URL = DEFAULT_YOTI_HOST + YOTI_DOCS_PATH_PREFIX;
 
+    public static final String IDENTITY_PREFIX = "/share";
+    public static final String DEFAULT_IDENTITY_URL = DEFAULT_YOTI_HOST + IDENTITY_PREFIX;
+
+    public static final String AUTH_ID_HEADER = "X-Yoti-Auth-Id";
     public static final String AUTH_KEY_HEADER = "X-Yoti-Auth-Key";
     public static final String DIGEST_HEADER = "X-Yoti-Auth-Digest";
     public static final String YOTI_SDK_HEADER = "X-Yoti-SDK";

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/spi/remote/call/factory/UnsignedPathFactory.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/spi/remote/call/factory/UnsignedPathFactory.java
@@ -4,21 +4,22 @@ import static java.lang.String.format;
 
 public class UnsignedPathFactory {
 
-    static final String PROFILE_PATH_TEMPLATE = "/profile/%s?appId=%s";
-    static final String AML_PATH_TEMPLATE = "/aml-check?appId=%s";
-    static final String QR_CODE_PATH_TEMPLATE = "/qrcodes/apps/%s";
-    static final String DOCS_CREATE_SESSION_PATH_TEMPLATE = "/sessions?sdkId=%s";
-    static final String DOCS_SESSION_PATH_TEMPLATE = "/sessions/%s?sdkId=%s";
-    static final String DOCS_MEDIA_CONTENT_PATH_TEMPLATE = "/sessions/%s/media/%s/content?sdkId=%s";
-    static final String DOCS_PUT_IBV_INSTRUCTIONS_PATH_TEMPLATE = "/sessions/%s/instructions?sdkId=%s";
-    static final String DOCS_FETCH_IBV_INSTRUCTIONS_PATH_TEMPLATE = "/sessions/%s/instructions?sdkId=%s";
-    static final String DOCS_FETCH_IBV_INSTRUCTIONS_PDF_PATH_TEMPLATE = "/sessions/%s/instructions/pdf?sdkId=%s";
-    static final String DOCS_SUPPORTED_DOCUMENTS_PATH = "/supported-documents";
-    static final String DOCS_FETCH_INSTRUCTION_CONTACT_PROFILE_PATH_TEMPLATE = "/sessions/%s/instructions/contact-profile?sdkId=%s";
-    static final String DOCS_FETCH_SESSION_CONFIGURATION_PATH_TEMPLATE = "/sessions/%s/configuration?sdkId=%s";
-    static final String DOCS_NEW_FACE_CAPTURE_RESOURCE_PATH_TEMPLATE = "/sessions/%s/resources/face-capture?sdkId=%s";
-    static final String DOCS_UPLOAD_FACE_CAPTURE_IMAGE_PATH_TEMPLATE = "/sessions/%s/resources/face-capture/%s/image?sdkId=%s";
-    static final String DOCS_TRIGGER_IBV_NOTIFICATION_PATH_TEMPLATE = "/sessions/%s/instructions/email?sdkId=%s";
+    private static final String PROFILE_PATH_TEMPLATE = "/profile/%s?appId=%s";
+    private static final String AML_PATH_TEMPLATE = "/aml-check?appId=%s";
+    private static final String QR_CODE_PATH_TEMPLATE = "/qrcodes/apps/%s";
+    private static final String DOCS_CREATE_SESSION_PATH_TEMPLATE = "/sessions?sdkId=%s";
+    private static final String DOCS_SESSION_PATH_TEMPLATE = "/sessions/%s?sdkId=%s";
+    private static final String DOCS_MEDIA_CONTENT_PATH_TEMPLATE = "/sessions/%s/media/%s/content?sdkId=%s";
+    private static final String DOCS_PUT_IBV_INSTRUCTIONS_PATH_TEMPLATE = "/sessions/%s/instructions?sdkId=%s";
+    private static final String DOCS_FETCH_IBV_INSTRUCTIONS_PATH_TEMPLATE = "/sessions/%s/instructions?sdkId=%s";
+    private static final String DOCS_FETCH_IBV_INSTRUCTIONS_PDF_PATH_TEMPLATE = "/sessions/%s/instructions/pdf?sdkId=%s";
+    private static final String DOCS_SUPPORTED_DOCUMENTS_PATH = "/supported-documents";
+    private static final String DOCS_FETCH_INSTRUCTION_CONTACT_PROFILE_PATH_TEMPLATE = "/sessions/%s/instructions/contact-profile?sdkId=%s";
+    private static final String DOCS_FETCH_SESSION_CONFIGURATION_PATH_TEMPLATE = "/sessions/%s/configuration?sdkId=%s";
+    private static final String DOCS_NEW_FACE_CAPTURE_RESOURCE_PATH_TEMPLATE = "/sessions/%s/resources/face-capture?sdkId=%s";
+    private static final String DOCS_UPLOAD_FACE_CAPTURE_IMAGE_PATH_TEMPLATE = "/sessions/%s/resources/face-capture/%s/image?sdkId=%s";
+    private static final String DOCS_TRIGGER_IBV_NOTIFICATION_PATH_TEMPLATE = "/sessions/%s/instructions/email?sdkId=%s";
+    private static final String IDENTITY_SESSION_CREATION_TEMPLATE = "/v2/sessions";
 
     public String createProfilePath(String appId, String connectToken) {
         return format(PROFILE_PATH_TEMPLATE, connectToken, appId);
@@ -78,6 +79,10 @@ public class UnsignedPathFactory {
 
     public String createTriggerIbvEmailNotificationPath(String sdkId, String sessionId) {
         return format(DOCS_TRIGGER_IBV_NOTIFICATION_PATH_TEMPLATE, sessionId, sdkId);
+    }
+
+    public String createIdentitySessionPath() {
+        return IDENTITY_SESSION_CREATION_TEMPLATE;
     }
 
 }

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/spi/remote/call/identity/DigitalIdentityService.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/spi/remote/call/identity/DigitalIdentityService.java
@@ -1,13 +1,88 @@
 package com.yoti.api.client.spi.remote.call.identity;
 
+import static com.yoti.api.client.spi.remote.call.HttpMethod.HTTP_POST;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.AUTH_ID_HEADER;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.CONTENT_TYPE;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.CONTENT_TYPE_JSON;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.DEFAULT_IDENTITY_URL;
+import static com.yoti.api.client.spi.remote.call.YotiConstants.PROPERTY_YOTI_API_URL;
+import static com.yoti.validation.Validation.notNull;
+import static com.yoti.validation.Validation.notNullOrEmpty;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+
+import com.yoti.api.client.identity.ShareSession;
+import com.yoti.api.client.identity.ShareSessionRequest;
+import com.yoti.api.client.spi.remote.call.ResourceException;
+import com.yoti.api.client.spi.remote.call.SignedRequest;
+import com.yoti.api.client.spi.remote.call.SignedRequestBuilderFactory;
+import com.yoti.api.client.spi.remote.call.factory.UnsignedPathFactory;
+import com.yoti.json.ResourceMapper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class DigitalIdentityService {
 
-    public static DigitalIdentityService newInstance() {
-        return new DigitalIdentityService();
+    private static final Logger LOG = LoggerFactory.getLogger(DigitalIdentityService.class);
+
+    private final UnsignedPathFactory pathFactory;
+    private final SignedRequestBuilderFactory requestBuilderFactory;
+
+    private final String apiUrl;
+
+    public DigitalIdentityService(UnsignedPathFactory pathFactory, SignedRequestBuilderFactory requestBuilderFactory) {
+        this.pathFactory = pathFactory;
+        this.requestBuilderFactory = requestBuilderFactory;
+
+        this.apiUrl = System.getProperty(PROPERTY_YOTI_API_URL, DEFAULT_IDENTITY_URL);
     }
 
-    public Object createShareSession() {
-        return null;
+    public static DigitalIdentityService newInstance() {
+        return new DigitalIdentityService(new UnsignedPathFactory(), new SignedRequestBuilderFactory());
+    }
+
+    public ShareSession createShareSession(String sdkId, KeyPair keyPair, ShareSessionRequest shareSessionRequest)
+            throws DigitalIdentityException {
+        notNullOrEmpty(sdkId, "SDK ID");
+        notNull(keyPair, "Application Key Pair");
+        notNull(shareSessionRequest, "Share Session request");
+
+        LOG.debug("Requesting Share Session Creation for SDK ID '{}", sdkId);
+
+        String path = pathFactory.createIdentitySessionPath();
+
+        try {
+            byte[] payload = ResourceMapper.writeValueAsString(shareSessionRequest);
+            SignedRequest request = createSignedRequest(sdkId, keyPair, path, payload);
+
+            return request.execute(ShareSession.class);
+        } catch (IOException ex) {
+            throw new DigitalIdentityException("Error parsing the request: ", ex);
+        } catch (URISyntaxException ex) {
+            throw new DigitalIdentityException("Error building the request: ", ex);
+        } catch (GeneralSecurityException ex) {
+            throw new DigitalIdentityException("Error signing the request: ", ex);
+        } catch (ResourceException ex) {
+            throw new DigitalIdentityException("Error posting the request: ", ex);
+        }
+    }
+
+    SignedRequest createSignedRequest(String appId, KeyPair keyPair, String path, byte[] payload)
+            throws GeneralSecurityException, UnsupportedEncodingException, URISyntaxException {
+        return requestBuilderFactory.create()
+                .withKeyPair(keyPair)
+                .withBaseUrl(apiUrl)
+                .withEndpoint(path)
+                .withHeader(AUTH_ID_HEADER, appId)
+                .withHttpMethod(HTTP_POST)
+                .withHeader(CONTENT_TYPE, CONTENT_TYPE_JSON)
+                .withPayload(payload)
+                .build();
     }
 
     public Object fetchShareSession(String sessionId) {

--- a/yoti-sdk-api/src/main/java/com/yoti/json/ResourceMapper.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/json/ResourceMapper.java
@@ -1,0 +1,39 @@
+package com.yoti.json;
+
+import java.nio.charset.StandardCharsets;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.cfg.MapperConfig;
+import com.fasterxml.jackson.databind.introspect.VisibilityChecker;
+
+public final class ResourceMapper {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    static {
+        MAPPER.disable(DeserializationFeature.WRAP_EXCEPTIONS)
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .disable(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                .setVisibility(configureVisibility(MAPPER.getDeserializationConfig()))
+                .setDefaultSetterInfo(JsonSetter.Value.forValueNulls(Nulls.SKIP));
+    }
+
+    private static VisibilityChecker<?> configureVisibility(MapperConfig<?> config) {
+        return config.getDefaultVisibilityChecker()
+                .withFieldVisibility(JsonAutoDetect.Visibility.NONE)
+                .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withIsGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withCreatorVisibility(JsonAutoDetect.Visibility.NONE);
+    }
+
+    public static byte[] writeValueAsString(Object object) throws JsonProcessingException {
+        return MAPPER.writeValueAsString(object).getBytes(StandardCharsets.UTF_8);
+    }
+
+}

--- a/yoti-sdk-api/src/test/java/com/yoti/api/client/spi/remote/call/identity/DigitalIdentityServiceTest.java
+++ b/yoti-sdk-api/src/test/java/com/yoti/api/client/spi/remote/call/identity/DigitalIdentityServiceTest.java
@@ -1,0 +1,344 @@
+package com.yoti.api.client.spi.remote.call.identity;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.*;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.yoti.api.client.identity.ShareSession;
+import com.yoti.api.client.identity.ShareSessionNotification;
+import com.yoti.api.client.identity.ShareSessionRequest;
+import com.yoti.api.client.identity.constraint.SourceConstraint;
+import com.yoti.api.client.identity.extension.Extension;
+import com.yoti.api.client.identity.extension.ThirdPartyAttributeContent;
+import com.yoti.api.client.identity.extension.ThirdPartyAttributeExtensionBuilder;
+import com.yoti.api.client.identity.policy.Policy;
+import com.yoti.api.client.identity.policy.WantedAnchor;
+import com.yoti.api.client.identity.policy.WantedAttribute;
+import com.yoti.api.client.spi.remote.call.SignedRequest;
+import com.yoti.api.client.spi.remote.call.SignedRequestBuilder;
+import com.yoti.api.client.spi.remote.call.SignedRequestBuilderFactory;
+import com.yoti.api.client.spi.remote.call.factory.UnsignedPathFactory;
+import com.yoti.json.ResourceMapper;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.mockito.*;
+import org.mockito.junit.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DigitalIdentityServiceTest {
+
+    private static final String SDK_ID = "anSdkId";
+    private static final String SESSION_CREATION_PATH = "aSessionCreationPath";
+    private static final Date DATE = new Date();
+    private static final byte[] A_BODY_BYTES = "aBody".getBytes(StandardCharsets.UTF_8);
+
+    @Spy @InjectMocks DigitalIdentityService identityService;
+
+    @Mock UnsignedPathFactory unsignedPathFactory;
+    @Mock(answer = RETURNS_DEEP_STUBS) SignedRequestBuilder signedRequestBuilder;
+    @Mock SignedRequestBuilderFactory requestBuilderFactory;
+
+    @Mock ShareSessionRequest shareSessionRequest;
+    @Mock SignedRequest signedRequest;
+    @Mock(answer = RETURNS_DEEP_STUBS) KeyPair keyPair;
+    @Mock ShareSession shareSession;
+
+    @Before
+    public void setUp() {
+        when(unsignedPathFactory.createIdentitySessionPath()).thenReturn(SESSION_CREATION_PATH);
+    }
+
+    @Test
+    public void createShareSession_NullSdkId_Exception() {
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> identityService.createShareSession(null, keyPair, shareSessionRequest)
+        );
+
+        assertThat(ex.getMessage(), containsString("SDK ID"));
+    }
+
+    @Test
+    public void createShareSession_EmptySdkId_Exception() {
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> identityService.createShareSession("", keyPair, shareSessionRequest)
+        );
+
+        assertThat(ex.getMessage(), containsString("SDK ID"));
+    }
+
+    @Test
+    public void createShareSession_NullKeyPair_Exception() {
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> identityService.createShareSession(SDK_ID, null, shareSessionRequest)
+        );
+
+        assertThat(ex.getMessage(), containsString("Application Key Pair"));
+    }
+
+    @Test
+    public void createShareSession_NullShareSessionRequest_Exception() {
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> identityService.createShareSession(SDK_ID, keyPair, null)
+        );
+
+        assertThat(ex.getMessage(), containsString("Share Session request"));
+    }
+
+    @Test
+    public void createShareSession_SerializingWrongPayload_Exception() {
+        JsonProcessingException causeEx = new JsonProcessingException("serialization error") {};
+
+        try (MockedStatic<ResourceMapper> mapper = Mockito.mockStatic(ResourceMapper.class)) {
+            mapper.when(() -> ResourceMapper.writeValueAsString(shareSessionRequest)).thenThrow(causeEx);
+
+            DigitalIdentityException ex = assertThrows(
+                    DigitalIdentityException.class,
+                    () -> identityService.createShareSession(SDK_ID, keyPair, shareSessionRequest)
+            );
+
+            Throwable cause = ex.getCause();
+            assertTrue(cause instanceof JsonProcessingException);
+            assertThat(cause.getMessage(), containsString("serialization error"));
+        }
+    }
+
+    @Test
+    public void createShareSession_BuildingRequestWithWrongUri_Exception()
+            throws GeneralSecurityException, UnsupportedEncodingException, URISyntaxException {
+        try (MockedStatic<ResourceMapper> mapper = Mockito.mockStatic(ResourceMapper.class)) {
+            mapper.when(() -> ResourceMapper.writeValueAsString(shareSessionRequest)).thenReturn(A_BODY_BYTES);
+            when(requestBuilderFactory.create()).thenReturn(signedRequestBuilder);
+
+            String exMessage = "URI wrong format";
+            URISyntaxException causeEx = new URISyntaxException("", exMessage);
+            when(identityService.createSignedRequest(SDK_ID, keyPair, SESSION_CREATION_PATH, A_BODY_BYTES))
+                    .thenThrow(causeEx);
+
+            DigitalIdentityException ex = assertThrows(
+                    DigitalIdentityException.class,
+                    () -> identityService.createShareSession(SDK_ID, keyPair, shareSessionRequest)
+            );
+
+            Throwable cause = ex.getCause();
+            assertTrue(cause instanceof URISyntaxException);
+            assertThat(cause.getMessage(), containsString(exMessage));
+        }
+    }
+
+    @Test
+    public void createShareSession_BuildingRequestWithWrongQueryParams_Exception() throws Exception {
+        try (MockedStatic<ResourceMapper> mapper = Mockito.mockStatic(ResourceMapper.class)) {
+            mapper.when(() -> ResourceMapper.writeValueAsString(shareSessionRequest)).thenReturn(A_BODY_BYTES);
+
+            when(requestBuilderFactory.create()).thenReturn(signedRequestBuilder);
+
+            String exMessage = "Wrong query params format";
+            UnsupportedEncodingException causeEx = new UnsupportedEncodingException(exMessage);
+            when(identityService.createSignedRequest(SDK_ID, keyPair, SESSION_CREATION_PATH, A_BODY_BYTES))
+                    .thenThrow(causeEx);
+
+            DigitalIdentityException ex = assertThrows(
+                    DigitalIdentityException.class,
+                    () -> identityService.createShareSession(SDK_ID, keyPair, shareSessionRequest)
+            );
+
+            Throwable cause = ex.getCause();
+            assertTrue(cause instanceof UnsupportedEncodingException);
+            assertThat(cause.getMessage(), containsString(exMessage));
+        }
+    }
+
+    @Test
+    public void createShareSession_BuildingRequestWithWrongDigest_Exception() throws Exception {
+        try (MockedStatic<ResourceMapper> mapper = Mockito.mockStatic(ResourceMapper.class)) {
+            mapper.when(() -> ResourceMapper.writeValueAsString(shareSessionRequest)).thenReturn(A_BODY_BYTES);
+
+            when(requestBuilderFactory.create()).thenReturn(signedRequestBuilder);
+
+            String exMessage = "Wrong digest";
+            GeneralSecurityException causeEx = new GeneralSecurityException(exMessage);
+            when(identityService.createSignedRequest(SDK_ID, keyPair, SESSION_CREATION_PATH, A_BODY_BYTES))
+                    .thenThrow(causeEx);
+
+            DigitalIdentityException ex = assertThrows(
+                    DigitalIdentityException.class,
+                    () -> identityService.createShareSession(SDK_ID, keyPair, shareSessionRequest)
+            );
+
+            Throwable cause = ex.getCause();
+            assertTrue(cause instanceof GeneralSecurityException);
+            assertThat(cause.getMessage(), containsString(exMessage));
+        }
+    }
+
+    @Test
+    public void createShareSession_SessionRequest_exception() throws Exception {
+        try (MockedStatic<ResourceMapper> mapper = Mockito.mockStatic(ResourceMapper.class)) {
+            mapper.when(() -> ResourceMapper.writeValueAsString(shareSessionRequest)).thenReturn(A_BODY_BYTES);
+
+            when(requestBuilderFactory.create()).thenReturn(signedRequestBuilder);
+
+            when(identityService.createSignedRequest(SDK_ID, keyPair, SESSION_CREATION_PATH, A_BODY_BYTES))
+                    .thenReturn(signedRequest);
+
+            when(signedRequest.execute(ShareSession.class)).thenReturn(shareSession);
+
+            ShareSession result = identityService.createShareSession(SDK_ID, keyPair, shareSessionRequest);
+            assertSame(shareSession, result);
+        }
+    }
+
+    @Test
+    public void serializePayload_CreatesValidShareSessionRequestJson() throws Exception {
+        String subjectId = "subject_id";
+        String subjectIdValue = "00000000-1111-2222-3333-444444444444";
+
+        Map<String, Object> subject = new HashMap<>();
+        subject.put(subjectId, subjectIdValue);
+
+        String wantedAnchorValue = "aAnchorValue";
+        String wantedAnchorSubType = "aAnchorSubType";
+        SourceConstraint constraint = SourceConstraint.builder()
+                .withWantedAnchor(
+                        WantedAnchor.builder()
+                                .withValue(wantedAnchorValue)
+                                .withSubType(wantedAnchorSubType)
+                                .build()
+                )
+                .withSoftPreference(true)
+                .build();
+
+        String wantedAttributeName = "aWantedAttributeName";
+        String wantedAttributeDerivation = "aWantedAttributeDerivation";
+
+        String trustFramework = "trust_framework";
+        String trustFrameworkValue = "aTrustFramework";
+        String scheme = "scheme";
+        String schemeValue = "aScheme";
+        Map<String, Object> identityProfile = new HashMap<>();
+        identityProfile.put(trustFramework, trustFrameworkValue);
+        identityProfile.put(scheme, schemeValue);
+
+        Policy policy = Policy.builder()
+                .withWantedAttribute(
+                        WantedAttribute.builder()
+                                .withName(wantedAttributeName)
+                                .withDerivation(wantedAttributeDerivation)
+                                .withOptional(true)
+                                .withAcceptSelfAsserted(true)
+                                .withConstraint(constraint)
+                                .build()
+                )
+                .withWantedAuthType(1)
+                .withWantedRememberMe(true)
+                .withWantedRememberMeOptional(true)
+                .withIdentityProfile(identityProfile)
+                .build();
+
+        String thirdPartyAttributeDefinition = "aDefinition";
+        Extension<ThirdPartyAttributeContent> extension = new ThirdPartyAttributeExtensionBuilder()
+                .withDefinition(thirdPartyAttributeDefinition)
+                .withExpiryDate(DATE)
+                .build();
+
+        String redirectUriValue = "aRedirectUri";
+        String notificationUriValue = "aNotificationUri";
+        ShareSessionRequest request = ShareSessionRequest.builder()
+                .withSubject(subject)
+                .withPolicy(policy)
+                .withExtension(extension)
+                .withRedirectUri(new URI(redirectUriValue))
+                .withNotification(ShareSessionNotification.builder(new URI(notificationUriValue)).build())
+                .build();
+
+        byte[] payload = ResourceMapper.writeValueAsString(request);
+
+        JsonNode json = new ObjectMapper().readTree(new String(payload));
+
+        JsonNode subjectNode = json.get("subject");
+        assertThat(subjectNode.get(subjectId).asText(), equalTo(subjectIdValue));
+
+        JsonNode policyNode = json.get("policy");
+
+        JsonNode policyWantedNode = policyNode.get("wanted");
+        assertThat(policyWantedNode.size(), equalTo(1));
+
+        JsonNode wantedAttributeNode = policyWantedNode.get(0);
+        assertThat(wantedAttributeNode.get("name").asText(), equalTo(wantedAttributeName));
+        assertThat(wantedAttributeNode.get("derivation").asText(), equalTo(wantedAttributeDerivation));
+        assertTrue(wantedAttributeNode.get("optional").asBoolean());
+        assertTrue(wantedAttributeNode.get("accept_self_asserted").asBoolean());
+
+        JsonNode wantedAttributeConstraintsNode = wantedAttributeNode.get("constraints");
+        assertThat(wantedAttributeConstraintsNode.size(), equalTo(1));
+
+        JsonNode wantedAttributeConstraintNode = wantedAttributeConstraintsNode.get(0);
+        assertThat(wantedAttributeConstraintNode.get("type").asText(), equalTo("SOURCE"));
+        JsonNode preferredSourcesNode = wantedAttributeConstraintNode.get("preferred_sources");
+        assertTrue(preferredSourcesNode.get("soft_preference").asBoolean());
+
+        JsonNode preferredSourceAnchorsNode = preferredSourcesNode.get("anchors");
+        assertThat(preferredSourceAnchorsNode.size(), equalTo(1));
+
+        JsonNode preferredSourceAnchorNode = preferredSourceAnchorsNode.get(0);
+        assertThat(preferredSourceAnchorNode.get("name").asText(), equalTo(wantedAnchorValue));
+        assertThat(preferredSourceAnchorNode.get("sub_type").asText(), equalTo(wantedAnchorSubType));
+
+        JsonNode wantedAuthTypes = policyNode.get("wanted_auth_types");
+        assertThat(wantedAuthTypes.size(), equalTo(1));
+        assertThat(wantedAuthTypes.get(0).asInt(), equalTo(1));
+
+        assertTrue(policyNode.get("wanted_remember_me").asBoolean());
+        assertTrue(policyNode.get("wanted_remember_me_optional").asBoolean());
+
+        JsonNode wantedAttributeIdentityProfile = policyNode.get("identity_profile_requirements");
+        assertThat(wantedAttributeIdentityProfile.get(trustFramework).asText(), equalTo(trustFrameworkValue));
+        assertThat(wantedAttributeIdentityProfile.get(scheme).asText(), equalTo(schemeValue));
+
+        JsonNode extensionsNode = json.get("extensions");
+        assertThat(extensionsNode.size(), equalTo(1));
+
+        JsonNode extensionNode = extensionsNode.get(0);
+        assertThat(extensionNode.get("type").asText(), equalTo("THIRD_PARTY_ATTRIBUTE"));
+
+        JsonNode extensionContent = extensionNode.get("content");
+        assertThat(extensionContent.get("expiry_date").asText(), notNullValue());
+
+        JsonNode extensionDefinitions = extensionContent.get("definitions");
+        assertThat(extensionDefinitions.size(), equalTo(1));
+
+        JsonNode extensionDefinition = extensionDefinitions.get(0);
+        assertThat(extensionDefinition.get("name").asText(), equalTo(thirdPartyAttributeDefinition));
+
+        assertThat(json.get("redirectUri").asText(), equalTo(redirectUriValue));
+
+        JsonNode notificationNode = json.get("notification");
+        assertThat(notificationNode.get("url").asText(), equalTo(notificationUriValue));
+        assertThat(notificationNode.get("method").asText(), equalTo("POST"));
+        assertTrue(notificationNode.get("verifyTls").asBoolean());
+        assertThat(notificationNode.get("headers").size(), equalTo(0));
+    }
+
+}

--- a/yoti-sdk-spring-boot-example/src/main/java/com/yoti/api/examples/springboot/DigitalIdentityController.java
+++ b/yoti-sdk-spring-boot-example/src/main/java/com/yoti/api/examples/springboot/DigitalIdentityController.java
@@ -1,9 +1,17 @@
 package com.yoti.api.examples.springboot;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 import com.yoti.api.client.DigitalIdentityClient;
+import com.yoti.api.client.identity.ShareSession;
+import com.yoti.api.client.identity.ShareSessionRequest;
+import com.yoti.api.client.identity.policy.Policy;
 import com.yoti.api.spring.ClientProperties;
 import com.yoti.api.spring.DigitalIdentityProperties;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -23,6 +31,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @RequestMapping("/v2")
 public class DigitalIdentityController implements WebMvcConfigurer {
 
+    private static final Logger LOG = LoggerFactory.getLogger(DigitalIdentityController.class);
+
     private final DigitalIdentityClient client;
     private final ClientProperties properties;
 
@@ -38,15 +48,37 @@ public class DigitalIdentityController implements WebMvcConfigurer {
     }
 
     @RequestMapping("/")
-    public String home(final Model model) {
+    public String home(Model model) {
         model.addAttribute("clientSdkId", properties.getClientSdkId());
         model.addAttribute("scenarioId", properties.getScenarioId());
         return "index";
     }
 
     @RequestMapping("/digital-identity-share")
-    public String identityShare(final Model model) {
+    public String identityShare(Model model) throws URISyntaxException {
         model.addAttribute("message", "Example page for identity share using Yoti web-share");
+
+        Policy policy = Policy.builder().build();
+
+        ShareSessionRequest shareSessionRequest = ShareSessionRequest.builder()
+                .withPolicy(policy)
+                .withRedirectUri(new URI("https://host/redirect/"))
+                .build();
+
+        ShareSession result = null;
+        try {
+            result = client.createShareSession(shareSessionRequest);
+        } catch (Exception ex) {
+            LOG.error(ex.getMessage());
+        }
+
+        model.addAttribute("message", "Identity creation example");
+
+        model.addAttribute("sdkId", properties.getClientSdkId());
+
+        model.addAttribute("session_id", result.getId());
+        model.addAttribute("session_status", result.getStatus());
+        model.addAttribute("session_expiry", result.getExpiry());
 
         return "digital-identity-share";
     }

--- a/yoti-sdk-spring-boot-example/src/main/resources/templates/digital-identity-share.html
+++ b/yoti-sdk-spring-boot-example/src/main/resources/templates/digital-identity-share.html
@@ -15,6 +15,15 @@
         </div>
 
         <h2 th:text="${message}">Digital Identity Share Example page</h2>
+
+        <p> SdkId: <strong th:text="${sdkId}"></strong></p>
+
+        <div>
+            <p> Id: <strong th:text="${session_id}"></strong></p>
+            <p> Status: <strong th:text="${session_status}"></strong></p>
+            <p> Expiry: <strong th:text="${session_expiry}"></strong></p>
+        </div>
+    </section>
     </section>
 </main>
 


### PR DESCRIPTION
The PR seems big but if excluded the duplicated classes, Extensions, Policy, in common with the Dynamic Scenario the new code isn't that much. I had to duplicate those classes because I cannot move them from their original package and neither I want to use a DynamicPolicy obj in the v2 share. When v1 is going to be deprecated the whole package can be dropped. 

The little example just displays the result session id, status and expiration in page.
Next step Qr code creation and the example will show the resulting session and QR code