### PR TITLE
SDK-2364: Map attribute alternative names

### DIFF
--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/policy/WantedAttribute.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/policy/WantedAttribute.java
@@ -1,11 +1,12 @@
 package com.yoti.api.client.identity.policy;
 
+import static com.yoti.validation.Validation.notNullOrEmpty;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import com.yoti.api.client.identity.constraint.Constraint;
-import com.yoti.validation.Validation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/policy/WantedAttribute.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/identity/policy/WantedAttribute.java
@@ -4,7 +4,9 @@ import static com.yoti.validation.Validation.notNullOrEmpty;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import com.yoti.api.client.identity.constraint.Constraint;
 
@@ -27,12 +29,16 @@ public class WantedAttribute {
     @JsonProperty(Property.CONSTRAINTS)
     private final List<Constraint> constraints;
 
+    @JsonProperty(Property.ALTERNATIVE_NAMES)
+    private final Set<String> alternativeNames;
+
     private WantedAttribute(Builder builder) {
         name = builder.name;
         derivation = builder.derivation;
         optional = builder.optional;
         acceptSelfAsserted = builder.acceptSelfAsserted;
-        constraints = builder.constraints;
+        constraints = Collections.unmodifiableList(builder.constraints);
+        alternativeNames = Collections.unmodifiableSet(builder.alternativeNames);
     }
 
     public String getName() {
@@ -59,6 +65,10 @@ public class WantedAttribute {
         return !constraints.isEmpty();
     }
 
+    public Set<String> getAlternativeNames() {
+        return alternativeNames;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -70,9 +80,11 @@ public class WantedAttribute {
         private boolean optional;
         private Boolean acceptSelfAsserted;
         private List<Constraint> constraints;
+        private Set<String> alternativeNames;
 
         private Builder() {
-            this.constraints = new ArrayList<>();
+            constraints = new ArrayList<>();
+            alternativeNames = new HashSet<>();
         }
         
         public Builder withName(String name) {
@@ -96,17 +108,27 @@ public class WantedAttribute {
         }
 
         public Builder withConstraints(List<Constraint> constraints) {
-            this.constraints = Collections.unmodifiableList(constraints);
+            this.constraints.addAll(constraints);
             return this;
         }
 
         public Builder withConstraint(Constraint constraint) {
-            this.constraints.add(constraint);
+            constraints.add(constraint);
+            return this;
+        }
+
+        public Builder withAlternativeNames(Set<String> alternativeNames) {
+            this.alternativeNames.addAll(alternativeNames);
+            return this;
+        }
+
+        public Builder withAlternativeName(String alternativeName) {
+            alternativeNames.add(alternativeName);
             return this;
         }
 
         public WantedAttribute build() {
-            Validation.notNullOrEmpty(name, Property.NAME);
+            notNullOrEmpty(name, Property.NAME);
 
             return new WantedAttribute(this);
         }
@@ -120,6 +142,9 @@ public class WantedAttribute {
         private static final String OPTIONAL = "optional";
         private static final String ACCEPT_SELF_ASSERTED = "accept_self_asserted";
         private static final String CONSTRAINTS = "constraints";
+        private static final String ALTERNATIVE_NAMES = "alternative_names";
+
+        private Property() { }
 
     }
 

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/shareurl/policy/WantedAttribute.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/shareurl/policy/WantedAttribute.java
@@ -4,49 +4,48 @@ import static com.yoti.validation.Validation.notNullOrEmpty;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import com.yoti.api.client.shareurl.constraint.Constraint;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * Type and content of an user detail
+ * Type and content of a user detail
  */
 public class WantedAttribute {
 
-    @JsonProperty("name")
+    @JsonProperty(Property.NAME)
     private final String name;
 
-    @JsonProperty("derivation")
+    @JsonProperty(Property.DERIVATION)
     private final String derivation;
 
-    @JsonProperty("optional")
+    @JsonProperty(Property.OPTIONAL)
     private final boolean optional;
 
-    @JsonProperty("accept_self_asserted")
+    @JsonProperty(Property.ACCEPT_SELF_ASSERTED)
     private final Boolean acceptSelfAsserted;
 
-    @JsonProperty("constraints")
+    @JsonProperty(Property.CONSTRAINTS)
     private final List<Constraint> constraints;
 
-    WantedAttribute(String name, String derivation, boolean optional, Boolean acceptSelfAsserted, List<Constraint> constraints) {
-        notNullOrEmpty(name, "name");
+    @JsonProperty(Property.ALTERNATIVE_NAMES)
+    private final Set<String> alternativeNames;
 
-        this.name = name;
-        this.derivation = derivation;
-        this.optional = optional;
-        this.acceptSelfAsserted = acceptSelfAsserted;
-
-        if (constraints == null) {
-            this.constraints = Collections.emptyList();
-        } else {
-            this.constraints = constraints;
-        }
+    private WantedAttribute(Builder builder) {
+        name = builder.name;
+        derivation = builder.derivation;
+        optional = builder.optional;
+        acceptSelfAsserted = builder.acceptSelfAsserted;
+        constraints = Collections.unmodifiableList(builder.constraints);
+        alternativeNames = Collections.unmodifiableSet(builder.alternativeNames);
     }
 
-    public static WantedAttribute.Builder builder() {
-        return new WantedAttribute.Builder();
+    public static Builder builder() {
+        return new Builder();
     }
 
     /**
@@ -78,6 +77,7 @@ public class WantedAttribute {
 
     /**
      * Allows self asserted attributes
+     *
      * @return accept self asserted
      */
     public Boolean getAcceptSelfAsserted() {
@@ -93,6 +93,21 @@ public class WantedAttribute {
         return constraints;
     }
 
+    /**
+     * <pre>
+     * Alternatives for the attribute name that is being requested.
+     *
+     * The provided alternative attribute will be used exactly in the same way:
+     *     - if a derivation is requested it will be applied on the alternative
+     *     - if constraints are defined the alternative attribute will have to comply
+     * </pre>
+     *
+     * @return the Set of alternative names
+     */
+    public Set<String> getAlternativeNames() {
+        return alternativeNames;
+    }
+
     public static class Builder {
 
         private String name;
@@ -100,9 +115,11 @@ public class WantedAttribute {
         private boolean optional;
         private Boolean acceptSelfAsserted;
         private List<Constraint> constraints;
+        private Set<String> alternativeNames;
 
         private Builder() {
-            this.constraints = new ArrayList<>();
+            constraints = new ArrayList<>();
+            alternativeNames = new HashSet<>();
         }
         
         public Builder withName(String name) {
@@ -126,18 +143,43 @@ public class WantedAttribute {
         }
 
         public Builder withConstraints(List<Constraint> constraints) {
-            this.constraints = Collections.unmodifiableList(constraints);
+            this.constraints.addAll(constraints);
             return this;
         }
 
         public Builder withConstraint(Constraint constraint) {
-            this.constraints.add(constraint);
+            constraints.add(constraint);
+            return this;
+        }
+
+        public Builder withAlternativeNames(Set<String> alternativeNames) {
+            this.alternativeNames.addAll(alternativeNames);
+            return this;
+        }
+
+        public Builder withAlternativeName(String alternativeName) {
+            alternativeNames.add(alternativeName);
             return this;
         }
 
         public WantedAttribute build() {
-            return new WantedAttribute(name, derivation, optional, acceptSelfAsserted, constraints);
+            notNullOrEmpty(name, Property.NAME);
+
+            return new WantedAttribute(this);
         }
+
+    }
+
+    private static final class Property {
+
+        private static final String NAME = "name";
+        private static final String DERIVATION = "derivation";
+        private static final String OPTIONAL = "optional";
+        private static final String ACCEPT_SELF_ASSERTED = "accept_self_asserted";
+        private static final String CONSTRAINTS = "constraints";
+        private static final String ALTERNATIVE_NAMES = "alternative_names";
+
+        private Property() { }
 
     }
 

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/shareurl/policy/WantedAttribute.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/shareurl/policy/WantedAttribute.java
@@ -1,6 +1,6 @@
 package com.yoti.api.client.shareurl.policy;
 
-import static com.yoti.api.client.spi.remote.util.Validation.notNullOrEmpty;
+import static com.yoti.validation.Validation.notNullOrEmpty;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/yoti-sdk-api/src/test/java/com/yoti/api/client/shareurl/policy/WantedAttributeTest.java
+++ b/yoti-sdk-api/src/test/java/com/yoti/api/client/shareurl/policy/WantedAttributeTest.java
@@ -1,20 +1,23 @@
 package com.yoti.api.client.shareurl.policy;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 import com.yoti.api.client.shareurl.constraint.Constraint;
 
-import org.junit.Test;
+import org.junit.*;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.*;
+import org.mockito.junit.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class WantedAttributeTest {
@@ -22,8 +25,7 @@ public class WantedAttributeTest {
     public static final String SOME_NAME = "someName";
     public static final String SOME_DERIVATION = "someDerivation";
 
-    @Mock
-    List<Constraint> constraintListMock;
+    @Mock Constraint constraintMock;
 
     @Test
     public void buildsAnAttribute() {
@@ -31,31 +33,107 @@ public class WantedAttributeTest {
                 .withName(SOME_NAME)
                 .withDerivation(SOME_DERIVATION)
                 .withOptional(true)
-                .build();
-
-        assertEquals(SOME_NAME, result.getName());
-        assertEquals(SOME_DERIVATION, result.getDerivation());
-        assertEquals(true, result.isOptional());
-    }
-
-    @Test
-    public void buildsAnAttributeWithSourceConstraint() {
-        when(constraintListMock.size()).thenReturn(1);
-
-        WantedAttribute result = WantedAttribute.builder()
-                .withName(SOME_NAME)
-                .withDerivation(SOME_DERIVATION)
-                .withOptional(true)
-                .withConstraints(constraintListMock)
                 .withAcceptSelfAsserted(true)
                 .build();
 
         assertEquals(SOME_NAME, result.getName());
         assertEquals(SOME_DERIVATION, result.getDerivation());
-        assertEquals(true, result.isOptional());
-        assertEquals(true, result.getAcceptSelfAsserted());
+        assertTrue(result.isOptional());
+        assertTrue(result.getAcceptSelfAsserted());
+    }
+
+    @Test
+    public void buildsAnAttributeWithSourceConstraints() {
+        List<Constraint> constraints = new ArrayList<>();
+        constraints.add(constraintMock);
+
+        WantedAttribute result = WantedAttribute.builder()
+                .withName(SOME_NAME)
+                .withConstraints(constraints)
+                .build();
+
+        assertEquals(SOME_NAME, result.getName());
         assertThat(result.getConstraints(), hasSize(1));
-        assertEquals(result.getConstraints(), constraintListMock);
+        assertTrue(result.getConstraints().contains(constraintMock));
+    }
+
+    @Test
+    public void buildsAnAttributeWithSourceConstraint() {
+        WantedAttribute result = WantedAttribute.builder()
+                .withName(SOME_NAME)
+                .withConstraint(constraintMock)
+                .build();
+
+        assertEquals(SOME_NAME, result.getName());
+        assertThat(result.getConstraints(), hasSize(1));
+        assertTrue(result.getConstraints().contains(constraintMock));
+    }
+
+    @Test
+    public void buildsAnAttributeWithSingleAndMultipleSourceConstraint() {
+        List<Constraint> constraints = new ArrayList<>();
+        constraints.add(constraintMock);
+
+        Constraint extraConstraintMock = mock(Constraint.class);
+
+        WantedAttribute result = WantedAttribute.builder()
+                .withName(SOME_NAME)
+                .withConstraints(constraints)
+                .withConstraint(extraConstraintMock)
+                .build();
+
+        assertEquals(SOME_NAME, result.getName());
+        assertThat(result.getConstraints(), hasSize(2));
+        assertTrue(result.getConstraints().contains(constraintMock));
+        assertTrue(result.getConstraints().contains(extraConstraintMock));
+    }
+
+    @Test
+    public void buildsAnAttributeWithAlternativeNames() {
+        String anAlternativeName = "anAlternativeName";
+        HashSet<String> alternativeNames = new HashSet<>();
+        alternativeNames.add(anAlternativeName);
+
+        WantedAttribute result = WantedAttribute.builder()
+                .withName(SOME_NAME)
+                .withAlternativeNames(alternativeNames)
+                .build();
+
+        assertEquals(SOME_NAME, result.getName());
+        assertThat(result.getAlternativeNames(), hasSize(1));
+        assertTrue(result.getAlternativeNames().contains(anAlternativeName));
+    }
+
+    @Test
+    public void buildsAnAttributeWithAlternativeName() {
+        String anAlternativeName = "anAlternativeName";
+        WantedAttribute result = WantedAttribute.builder()
+                .withName(SOME_NAME)
+                .withAlternativeName(anAlternativeName)
+                .build();
+
+        assertEquals(SOME_NAME, result.getName());
+        assertThat(result.getAlternativeNames(), hasSize(1));
+        assertTrue(result.getAlternativeNames().contains(anAlternativeName));
+    }
+
+    @Test
+    public void buildsAnAttributeWithSingleAndMultipleAlternativeNames() {
+        String anAlternativeName = "anAlternativeName";
+        String anExtraAlternativeName = "anExtraAlternativeName";
+        HashSet<String> alternativeNames = new HashSet<>();
+        alternativeNames.add(anAlternativeName);
+
+        WantedAttribute result = WantedAttribute.builder()
+                .withName(SOME_NAME)
+                .withAlternativeNames(alternativeNames)
+                .withAlternativeName(anExtraAlternativeName)
+                .build();
+
+        assertEquals(SOME_NAME, result.getName());
+        assertThat(result.getAlternativeNames(), hasSize(2));
+        assertTrue(result.getAlternativeNames().contains(anAlternativeName));
+        assertTrue(result.getAlternativeNames().contains(anExtraAlternativeName));
     }
 
     @Test


### PR DESCRIPTION
The [epic](https://lampkicking.atlassian.net/browse/SDK-2360) suggests to map both `anchors: []` and `alternative_names: []` but turns out the `Attribute.anchors` has been [deprecated](https://github.com/lampkicking/core-api/blob/7da190ab1e4eb2b8c29fe973e80b91f015e91278/sharepubapi_v1/Policy.proto#L129) for years (see [conversation](https://yoti.slack.com/archives/C3B8FSJMV/p1710427120485889) for details)