### PR TITLE
Release 4.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,13 @@ If you are using Maven, you need to add the following dependency:
 <dependency>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-api</artifactId>
-    <version>4.3.0</version>
+    <version>4.4.0-SNAPSHOT</version>
 </dependency>
 ```
 
 If you are using Gradle, here is the dependency to add:
 
-`compile group: 'com.yoti', name: 'yoti-sdk-api', version: '4.3.0'`
+`compile group: 'com.yoti', name: 'yoti-sdk-api', version: '4.4.0-SNAPSHOT'`
 
 You will find all classes packaged under `com.yoti.api`
 

--- a/examples/doc-scan/pom.xml
+++ b/examples/doc-scan/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>com.yoti</groupId>
       <artifactId>yoti-sdk-api</artifactId>
-      <version>4.3.0</version>
+      <version>4.4.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk</artifactId>
   <packaging>pom</packaging>
-  <version>4.3.0</version>
+  <version>4.4.0-SNAPSHOT</version>
   <name>Yoti SDK</name>
   <description>Java SDK for simple integration with the Yoti platform</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>

--- a/yoti-sdk-api/pom.xml
+++ b/yoti-sdk-api/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>4.3.0</version>
+    <version>4.4.0-SNAPSHOT</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
   

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/AmlException.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/AmlException.java
@@ -2,7 +2,11 @@ package com.yoti.api.client;
 
 /**
  * Signals that a problem occurred while performing an AML check
+ *
+ * @deprecated The AML check service has been discontinued and this class is no longer used.
+ *             This API will be removed in the next major release.
  */
+@Deprecated
 public class AmlException extends Exception {
 
     private static final long serialVersionUID = 3210133542178934016L;

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/YotiClient.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/YotiClient.java
@@ -93,7 +93,11 @@ public class YotiClient {
      *
      * @throws AmlException
      *             aggregate exception signalling issues during the call
+     *
+     * @deprecated The AML check service has been discontinued and this call will no longer succeed.
+     *             This API will be removed in the next major release.
      */
+    @Deprecated
     public AmlResult performAmlCheck(AmlProfile amlProfile) throws AmlException {
         LOG.debug("Performing aml check...");
         return remoteAmlService.performCheck(amlProfile);

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/aml/AmlAddress.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/aml/AmlAddress.java
@@ -2,6 +2,11 @@ package com.yoti.api.client.aml;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * @deprecated The AML check service has been discontinued and this class is no longer used.
+ *             This API will be removed in the next major release.
+ */
+@Deprecated
 public class AmlAddress {
 
     @JsonProperty("post_code")

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/aml/AmlProfile.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/aml/AmlProfile.java
@@ -2,6 +2,11 @@ package com.yoti.api.client.aml;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * @deprecated The AML check service has been discontinued and this class is no longer used.
+ *             This API will be removed in the next major release.
+ */
+@Deprecated
 public class AmlProfile {
 
     @JsonProperty("given_names")

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/aml/AmlResult.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/aml/AmlResult.java
@@ -4,7 +4,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * The results of the aml check.
+ *
+ * @deprecated The AML check service has been discontinued and this class is no longer used.
+ *             This API will be removed in the next major release.
  */
+@Deprecated
 public class AmlResult {
 
     @JsonProperty("on_fraud_list")

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/CompanyProfilePayload.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/CompanyProfilePayload.java
@@ -1,0 +1,45 @@
+package com.yoti.api.client.docs.session.create;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CompanyProfilePayload {
+
+    @JsonProperty("company_name")
+    private final String companyName;
+
+    private CompanyProfilePayload(String companyName) {
+        this.companyName = companyName;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getCompanyName() {
+        return companyName;
+    }
+
+    public static class Builder {
+
+        private String companyName;
+
+        Builder() {}
+
+        /**
+         * Sets the company name to be used for the session
+         *
+         * @param companyName the company name
+         * @return the builder
+         */
+        public Builder withCompanyName(String companyName) {
+            this.companyName = companyName;
+            return this;
+        }
+
+        public CompanyProfilePayload build() {
+            return new CompanyProfilePayload(companyName);
+        }
+
+    }
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/SessionSpec.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/SessionSpec.java
@@ -69,6 +69,9 @@ public class SessionSpec {
     @JsonProperty("create_identity_profile_preview")
     private final Boolean createIdentityProfilePreview;
 
+    @JsonProperty("company_profile")
+    private final CompanyProfilePayload companyProfile;
+
     private SessionSpec(Integer clientSessionTokenTtl,
             Integer resourcesTtl,
             ImportTokenPayload importToken,
@@ -85,7 +88,8 @@ public class SessionSpec {
             SubjectPayload subject,
             ResourceCreationContainer resources,
             Boolean createIdentityProfilePreview,
-            AdvancedIdentityProfileRequirementsPayload advancedIdentityProfileRequirements) {
+            AdvancedIdentityProfileRequirementsPayload advancedIdentityProfileRequirements,
+            CompanyProfilePayload companyProfile) {
         this.clientSessionTokenTtl = clientSessionTokenTtl;
         this.resourcesTtl = resourcesTtl;
         this.importToken = importToken;
@@ -103,6 +107,7 @@ public class SessionSpec {
         this.resources = resources;
         this.createIdentityProfilePreview = createIdentityProfilePreview;
         this.advancedIdentityProfileRequirements = advancedIdentityProfileRequirements;
+        this.companyProfile = companyProfile;
     }
 
     public static Builder builder() {
@@ -263,6 +268,15 @@ public class SessionSpec {
         return advancedIdentityProfileRequirements;
     }
 
+    /**
+     * The company profile to be used for the session
+     *
+     * @return the company profile
+     */
+    public CompanyProfilePayload getCompanyProfile() {
+        return companyProfile;
+    }
+
     public static class Builder {
 
         private final List<RequestedCheck<?>> requestedChecks;
@@ -282,6 +296,7 @@ public class SessionSpec {
         private SubjectPayload subject;
         private ResourceCreationContainer resources;
         private Boolean createIdentityProfilePreview;
+        private CompanyProfilePayload companyProfile;
 
         private Builder() {
             requestedChecks = new ArrayList<>();
@@ -478,6 +493,17 @@ public class SessionSpec {
         }
 
         /**
+         * Sets the company profile to be used for the session
+         *
+         * @param companyProfile the company profile
+         * @return the builder
+         */
+        public Builder withCompanyProfile(CompanyProfilePayload companyProfile) {
+            this.companyProfile = companyProfile;
+            return this;
+        }
+
+        /**
          * Builds the {@link SessionSpec} based on the values supplied to the builder
          *
          * @return the built {@link SessionSpec}
@@ -500,7 +526,8 @@ public class SessionSpec {
                     subject,
                     resources,
                     createIdentityProfilePreview,
-                    advancedIdentityProfileRequirementsPayload);
+                    advancedIdentityProfileRequirementsPayload,
+                    companyProfile);
         }
     }
 

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/CompanyProfileResponse.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/CompanyProfileResponse.java
@@ -1,0 +1,14 @@
+package com.yoti.api.client.docs.session.retrieve;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CompanyProfileResponse {
+
+    @JsonProperty("company_name")
+    private String companyName;
+
+    public String getCompanyName() {
+        return companyName;
+    }
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/GetSessionResult.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/retrieve/GetSessionResult.java
@@ -17,6 +17,12 @@ public class GetSessionResult {
     @JsonProperty("session_id")
     private String sessionId;
 
+    @JsonProperty("organisation_name")
+    private String organisationName;
+
+    @JsonProperty("company_profile")
+    private CompanyProfileResponse companyProfileResponse;
+
     @JsonProperty("user_tracking_id")
     private String userTrackingId;
 
@@ -59,6 +65,14 @@ public class GetSessionResult {
 
     public String getSessionId() {
         return sessionId;
+    }
+
+    public String getOrganisationName() {
+        return organisationName;
+    }
+
+    public CompanyProfileResponse getCompanyProfile() {
+        return companyProfileResponse;
     }
 
     public String getUserTrackingId() {

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/spi/remote/call/YotiConstants.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/spi/remote/call/YotiConstants.java
@@ -30,7 +30,7 @@ public final class YotiConstants {
     public static final String CONTENT_TYPE_JPEG = "image/jpeg";
 
     public static final String JAVA = "Java";
-    public static final String SDK_VERSION = JAVA + "-4.3.0";
+    public static final String SDK_VERSION = JAVA + "-4.4.0-SNAPSHOT";
     public static final String SIGNATURE_ALGORITHM = "SHA256withRSA";
     public static final String ASYMMETRIC_CIPHER = "RSA/NONE/PKCS1Padding";
     public static final String SYMMETRIC_CIPHER = "AES/CBC/PKCS7Padding";

--- a/yoti-sdk-api/src/test/java/com/yoti/api/client/docs/session/create/CompanyProfilePayloadTest.java
+++ b/yoti-sdk-api/src/test/java/com/yoti/api/client/docs/session/create/CompanyProfilePayloadTest.java
@@ -1,0 +1,30 @@
+package com.yoti.api.client.docs.session.create;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.junit.Test;
+
+public class CompanyProfilePayloadTest {
+
+    private static final String SOME_COMPANY_NAME = "someCompanyName";
+
+    @Test
+    public void shouldBuildWithCompanyName() {
+        CompanyProfilePayload result = CompanyProfilePayload.builder()
+                .withCompanyName(SOME_COMPANY_NAME)
+                .build();
+
+        assertThat(result.getCompanyName(), is(SOME_COMPANY_NAME));
+    }
+
+    @Test
+    public void companyName_shouldBeNullWhenNotSet() {
+        CompanyProfilePayload result = CompanyProfilePayload.builder()
+                .build();
+
+        assertThat(result.getCompanyName(), is(nullValue()));
+    }
+
+}

--- a/yoti-sdk-api/src/test/java/com/yoti/api/client/docs/session/create/SessionSpecTest.java
+++ b/yoti-sdk-api/src/test/java/com/yoti/api/client/docs/session/create/SessionSpecTest.java
@@ -50,6 +50,7 @@ public class SessionSpecTest {
     @Mock ImportTokenPayload importTokenMock;
     @Mock IdentityProfileRequirementsPayload identityProfileRequirementsPayloadMock;
     @Mock SubjectPayload subjectPayloadMock;
+    @Mock CompanyProfilePayload companyProfilePayloadMock;
 
     @Test
     public void shouldBuildWithMinimalConfiguration() {
@@ -72,6 +73,7 @@ public class SessionSpecTest {
         assertThat(result.getSubject(), is(nullValue()));
         assertThat(result.getResources(), is(nullValue()));
         assertThat(result.getCreateIdentityProfilePreview(), is(nullValue()));
+        assertThat(result.getCompanyProfile(), is(nullValue()));
     }
 
     @Test
@@ -250,6 +252,15 @@ public class SessionSpecTest {
                 .build();
 
         assertThat(sessionSpec.getImportToken(), is(importTokenMock));
+    }
+
+    @Test
+    public void withCompanyProfile_shouldSetTheCompanyProfile() {
+        SessionSpec result = SessionSpec.builder()
+                .withCompanyProfile(companyProfilePayloadMock)
+                .build();
+
+        assertThat(result.getCompanyProfile(), is(companyProfilePayloadMock));
     }
 
 }

--- a/yoti-sdk-auth/pom.xml
+++ b/yoti-sdk-auth/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>4.3.0</version>
+    <version>4.4.0-SNAPSHOT</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
   

--- a/yoti-sdk-parent/pom.xml
+++ b/yoti-sdk-parent/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-parent</artifactId>
   <packaging>pom</packaging>
-  <version>4.3.0</version>
+  <version>4.4.0-SNAPSHOT</version>
   <name>Yoti SDK Parent Pom</name>
   <description>Parent pom for the Java SDK projects</description>
   <url>https://github.com/getyoti/yoti-java-sdk</url>
@@ -137,7 +137,7 @@
 
     <maven-project-info-reports-plugin.version>3.9.0</maven-project-info-reports-plugin.version>
 
-    <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
+    <coveralls-maven-plugin.version>4.4.0-SNAPSHOT</coveralls-maven-plugin.version>
 
     <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
   </properties>

--- a/yoti-sdk-sandbox/pom.xml
+++ b/yoti-sdk-sandbox/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>4.3.0</version>
+    <version>4.4.0-SNAPSHOT</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
   

--- a/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxCheck.java
+++ b/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxCheck.java
@@ -17,12 +17,20 @@ public abstract class SandboxCheck {
     @JsonProperty("result")
     private final SandboxCheckResult result;
 
-    SandboxCheck(SandboxCheckResult result) {
+    @JsonProperty("handled_check_limit")
+    private final Integer handledCheckLimit;
+
+    SandboxCheck(SandboxCheckResult result, Integer handledCheckLimit) {
         this.result = result;
+        this.handledCheckLimit = handledCheckLimit;
     }
 
     public SandboxCheckResult getResult() {
         return result;
+    }
+
+    public Integer getHandledCheckLimit() {
+        return handledCheckLimit;
     }
 
     static abstract class Builder<T extends Builder<T>> {
@@ -30,6 +38,7 @@ public abstract class SandboxCheck {
         protected SandboxRecommendation recommendation;
         protected List<SandboxBreakdown> breakdown;
         protected String reportTemplate;
+        protected Integer handledCheckLimit;
 
         public T withRecommendation(SandboxRecommendation recommendation) {
             this.recommendation = recommendation;
@@ -51,6 +60,11 @@ public abstract class SandboxCheck {
 
         public T withReportTemplate(String reportTemplate) {
             this.reportTemplate = reportTemplate;
+            return self();
+        }
+
+        public T withHandledCheckLimit(Integer handledCheckLimit) {
+            this.handledCheckLimit = handledCheckLimit;
             return self();
         }
 

--- a/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxDocumentAuthenticityCheck.java
+++ b/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxDocumentAuthenticityCheck.java
@@ -5,8 +5,8 @@ import com.yoti.api.client.sandbox.docs.request.check.report.SandboxCheckReport;
 
 public class SandboxDocumentAuthenticityCheck extends SandboxDocumentCheck {
 
-    private SandboxDocumentAuthenticityCheck(SandboxCheckResult result, SandboxDocumentFilter documentFilter) {
-        super(result, documentFilter);
+    private SandboxDocumentAuthenticityCheck(SandboxCheckResult result, Integer handledCheckLimit, SandboxDocumentFilter documentFilter) {
+        super(result, handledCheckLimit, documentFilter);
     }
 
     public static Builder builder() {
@@ -33,7 +33,7 @@ public class SandboxDocumentAuthenticityCheck extends SandboxDocumentCheck {
                     : new SandboxCheckReport(recommendation, breakdown);
             SandboxCheckResult result = new SandboxCheckResult(report, reportTemplate);
 
-            return new SandboxDocumentAuthenticityCheck(result, documentFilter);
+            return new SandboxDocumentAuthenticityCheck(result, handledCheckLimit, documentFilter);
         }
 
     }

--- a/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxDocumentCheck.java
+++ b/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxDocumentCheck.java
@@ -11,8 +11,8 @@ class SandboxDocumentCheck extends SandboxCheck {
     @JsonProperty("document_filter")
     private SandboxDocumentFilter documentFilter;
 
-    SandboxDocumentCheck(SandboxCheckResult result, SandboxDocumentFilter documentFilter) {
-        super(result);
+    SandboxDocumentCheck(SandboxCheckResult result, Integer handledCheckLimit, SandboxDocumentFilter documentFilter) {
+        super(result, handledCheckLimit);
         this.documentFilter = documentFilter;
     }
 

--- a/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxDocumentFaceMatchCheck.java
+++ b/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxDocumentFaceMatchCheck.java
@@ -5,8 +5,8 @@ import com.yoti.api.client.sandbox.docs.request.check.report.SandboxCheckReport;
 
 public class SandboxDocumentFaceMatchCheck extends SandboxDocumentCheck {
 
-    private SandboxDocumentFaceMatchCheck(SandboxCheckResult result, SandboxDocumentFilter documentFilter) {
-        super(result, documentFilter);
+    private SandboxDocumentFaceMatchCheck(SandboxCheckResult result, Integer handledCheckLimit, SandboxDocumentFilter documentFilter) {
+        super(result, handledCheckLimit, documentFilter);
     }
 
     public static Builder builder() {
@@ -33,7 +33,7 @@ public class SandboxDocumentFaceMatchCheck extends SandboxDocumentCheck {
                     : new SandboxCheckReport(recommendation, breakdown);
             SandboxCheckResult result = new SandboxCheckResult(report, reportTemplate);
 
-            return new SandboxDocumentFaceMatchCheck(result, documentFilter);
+            return new SandboxDocumentFaceMatchCheck(result, handledCheckLimit, documentFilter);
         }
 
     }

--- a/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxDocumentTextDataCheck.java
+++ b/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxDocumentTextDataCheck.java
@@ -11,8 +11,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class SandboxDocumentTextDataCheck extends SandboxDocumentCheck {
 
-    private SandboxDocumentTextDataCheck(SandboxDocumentTextDataCheckResult result, SandboxDocumentFilter documentFilter) {
-        super(result, documentFilter);
+    private SandboxDocumentTextDataCheck(SandboxDocumentTextDataCheckResult result, Integer handledCheckLimit, SandboxDocumentFilter documentFilter) {
+        super(result, handledCheckLimit, documentFilter);
     }
 
     public static Builder builder() {
@@ -60,7 +60,7 @@ public class SandboxDocumentTextDataCheck extends SandboxDocumentCheck {
                     : new SandboxCheckReport(recommendation, breakdown);
             SandboxDocumentTextDataCheckResult result = new SandboxDocumentTextDataCheckResult(report, reportTemplate, documentFields);
 
-            return new SandboxDocumentTextDataCheck(result, documentFilter);
+            return new SandboxDocumentTextDataCheck(result, handledCheckLimit, documentFilter);
         }
 
     }

--- a/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxFaceComparisonCheck.java
+++ b/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxFaceComparisonCheck.java
@@ -4,8 +4,8 @@ import com.yoti.api.client.sandbox.docs.request.check.report.SandboxCheckReport;
 
 public class SandboxFaceComparisonCheck extends SandboxCheck {
 
-    private SandboxFaceComparisonCheck(SandboxCheckResult result) {
-        super(result);
+    private SandboxFaceComparisonCheck(SandboxCheckResult result, Integer handledCheckLimit) {
+        super(result, handledCheckLimit);
     }
 
     public static Builder builder() {
@@ -31,7 +31,7 @@ public class SandboxFaceComparisonCheck extends SandboxCheck {
                     : new SandboxCheckReport(recommendation, breakdown);
             SandboxCheckResult result = new SandboxCheckResult(report, reportTemplate);
 
-            return new SandboxFaceComparisonCheck(result);
+            return new SandboxFaceComparisonCheck(result, handledCheckLimit);
         }
 
     }

--- a/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxIdDocumentComparisonCheck.java
+++ b/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxIdDocumentComparisonCheck.java
@@ -10,8 +10,8 @@ public class SandboxIdDocumentComparisonCheck extends SandboxCheck {
     @JsonProperty("secondary_document_filter")
     private final SandboxDocumentFilter secondaryDocumentFilter;
 
-    private SandboxIdDocumentComparisonCheck(SandboxCheckResult result, SandboxDocumentFilter secondaryDocumentFilter) {
-        super(result);
+    private SandboxIdDocumentComparisonCheck(SandboxCheckResult result, Integer handledCheckLimit, SandboxDocumentFilter secondaryDocumentFilter) {
+        super(result, handledCheckLimit);
         this.secondaryDocumentFilter = secondaryDocumentFilter;
     }
 
@@ -44,7 +44,7 @@ public class SandboxIdDocumentComparisonCheck extends SandboxCheck {
                     : new SandboxCheckReport(recommendation, breakdown);
             SandboxCheckResult result = new SandboxCheckResult(report, reportTemplate);
 
-            return new SandboxIdDocumentComparisonCheck(result, secondaryDocumentFilter);
+            return new SandboxIdDocumentComparisonCheck(result, handledCheckLimit, secondaryDocumentFilter);
         }
     }
 

--- a/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxLivenessCheck.java
+++ b/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxLivenessCheck.java
@@ -10,8 +10,8 @@ public class SandboxLivenessCheck extends SandboxCheck {
     @JsonProperty("response_delay")
     private final Integer responseDelay;
 
-    SandboxLivenessCheck(SandboxCheckResult result, String livenessType, Integer responseDelay) {
-        super(result);
+    SandboxLivenessCheck(SandboxCheckResult result, Integer handledCheckLimit, String livenessType, Integer responseDelay) {
+        super(result, handledCheckLimit);
         this.livenessType = livenessType;
         this.responseDelay = responseDelay;
     }

--- a/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxStaticLivenessCheckBuilder.java
+++ b/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxStaticLivenessCheckBuilder.java
@@ -26,7 +26,7 @@ public class SandboxStaticLivenessCheckBuilder extends SandboxCheck.Builder<Sand
                 : new SandboxCheckReport(recommendation, breakdown);
         SandboxCheckResult result = new SandboxCheckResult(report, reportTemplate);
 
-        return new SandboxLivenessCheck(result, DocScanConstants.STATIC, responseDelay);
+        return new SandboxLivenessCheck(result, handledCheckLimit, DocScanConstants.STATIC, responseDelay);
     }
 
 }

--- a/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxSupplementaryDocumentTextDataCheck.java
+++ b/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxSupplementaryDocumentTextDataCheck.java
@@ -8,8 +8,8 @@ import com.yoti.api.client.sandbox.docs.request.check.report.SandboxCheckReport;
 
 public class SandboxSupplementaryDocumentTextDataCheck extends SandboxDocumentCheck {
 
-    private SandboxSupplementaryDocumentTextDataCheck(SandboxSupplementaryDocumentTextDataCheckResult result, SandboxDocumentFilter documentFilter) {
-        super(result, documentFilter);
+    private SandboxSupplementaryDocumentTextDataCheck(SandboxSupplementaryDocumentTextDataCheckResult result, Integer handledCheckLimit, SandboxDocumentFilter documentFilter) {
+        super(result, handledCheckLimit, documentFilter);
     }
 
     public static Builder builder() {
@@ -57,7 +57,7 @@ public class SandboxSupplementaryDocumentTextDataCheck extends SandboxDocumentCh
                     : new SandboxCheckReport(recommendation, breakdown);
             SandboxSupplementaryDocumentTextDataCheckResult result = new SandboxSupplementaryDocumentTextDataCheckResult(report, reportTemplate, documentFields);
 
-            return new SandboxSupplementaryDocumentTextDataCheck(result, documentFilter);
+            return new SandboxSupplementaryDocumentTextDataCheck(result, handledCheckLimit, documentFilter);
         }
     }
 }

--- a/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxSynecticsIdentityFraudCheck.java
+++ b/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxSynecticsIdentityFraudCheck.java
@@ -4,8 +4,8 @@ import com.yoti.api.client.sandbox.docs.request.check.report.SandboxCheckReport;
 
 public class SandboxSynecticsIdentityFraudCheck extends SandboxCheck {
 
-    private SandboxSynecticsIdentityFraudCheck(SandboxCheckResult result) {
-        super(result);
+    private SandboxSynecticsIdentityFraudCheck(SandboxCheckResult result, Integer handledCheckLimit) {
+        super(result, handledCheckLimit);
     }
 
     public static Builder builder() {
@@ -31,7 +31,7 @@ public class SandboxSynecticsIdentityFraudCheck extends SandboxCheck {
                     : new SandboxCheckReport(recommendation, breakdown);
             SandboxCheckResult result = new SandboxCheckResult(report, reportTemplate);
 
-            return new SandboxSynecticsIdentityFraudCheck(result);
+            return new SandboxSynecticsIdentityFraudCheck(result, handledCheckLimit);
         }
 
     }

--- a/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxThirdPartyIdentityCheck.java
+++ b/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxThirdPartyIdentityCheck.java
@@ -4,8 +4,8 @@ import com.yoti.api.client.sandbox.docs.request.check.report.SandboxCheckReport;
 
 public class SandboxThirdPartyIdentityCheck extends SandboxCheck {
 
-    private SandboxThirdPartyIdentityCheck(SandboxCheckResult result) {
-        super(result);
+    private SandboxThirdPartyIdentityCheck(SandboxCheckResult result, Integer handledCheckLimit) {
+        super(result, handledCheckLimit);
     }
 
     public static Builder builder() {
@@ -32,7 +32,7 @@ public class SandboxThirdPartyIdentityCheck extends SandboxCheck {
                     : new SandboxCheckReport(recommendation, breakdown);
             SandboxCheckResult result = new SandboxCheckResult(report, reportTemplate);
 
-            return new SandboxThirdPartyIdentityCheck(result);
+            return new SandboxThirdPartyIdentityCheck(result, handledCheckLimit);
         }
 
     }

--- a/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxThirdPartyIdentityFraudOneCheck.java
+++ b/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxThirdPartyIdentityFraudOneCheck.java
@@ -4,8 +4,8 @@ import com.yoti.api.client.sandbox.docs.request.check.report.SandboxCheckReport;
 
 public class SandboxThirdPartyIdentityFraudOneCheck extends SandboxCheck {
 
-    private SandboxThirdPartyIdentityFraudOneCheck(SandboxCheckResult result) {
-        super(result);
+    private SandboxThirdPartyIdentityFraudOneCheck(SandboxCheckResult result, Integer handledCheckLimit) {
+        super(result, handledCheckLimit);
     }
 
     public static Builder builder() {
@@ -31,7 +31,7 @@ public class SandboxThirdPartyIdentityFraudOneCheck extends SandboxCheck {
                     : new SandboxCheckReport(recommendation, breakdown);
             SandboxCheckResult result = new SandboxCheckResult(report, reportTemplate);
 
-            return new SandboxThirdPartyIdentityFraudOneCheck(result);
+            return new SandboxThirdPartyIdentityFraudOneCheck(result, handledCheckLimit);
         }
 
     }

--- a/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxWatchlistAdvancedCaCheck.java
+++ b/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxWatchlistAdvancedCaCheck.java
@@ -11,8 +11,8 @@ public class SandboxWatchlistAdvancedCaCheck extends SandboxCheck {
     @JsonProperty("sources_filter")
     private final SandboxCaSourcesFilter sourcesFilter;
 
-    private SandboxWatchlistAdvancedCaCheck(SandboxCheckResult result, SandboxCaSourcesFilter sourcesFilter) {
-        super(result);
+    private SandboxWatchlistAdvancedCaCheck(SandboxCheckResult result, Integer handledCheckLimit, SandboxCaSourcesFilter sourcesFilter) {
+        super(result, handledCheckLimit);
         this.sourcesFilter = sourcesFilter;
     }
 
@@ -55,7 +55,7 @@ public class SandboxWatchlistAdvancedCaCheck extends SandboxCheck {
                     : new SandboxCheckReport(recommendation, breakdown);
             SandboxCheckResult result = new SandboxCheckResult(report, reportTemplate);
 
-            return new SandboxWatchlistAdvancedCaCheck(result, sourcesFilter);
+            return new SandboxWatchlistAdvancedCaCheck(result, handledCheckLimit, sourcesFilter);
         }
 
     }

--- a/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxWatchlistScreeningCheck.java
+++ b/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxWatchlistScreeningCheck.java
@@ -4,8 +4,8 @@ import com.yoti.api.client.sandbox.docs.request.check.report.SandboxCheckReport;
 
 public class SandboxWatchlistScreeningCheck extends SandboxCheck {
 
-    private SandboxWatchlistScreeningCheck(SandboxCheckResult result) {
-        super(result);
+    private SandboxWatchlistScreeningCheck(SandboxCheckResult result, Integer handledCheckLimit) {
+        super(result, handledCheckLimit);
     }
 
     public static Builder builder() {
@@ -31,7 +31,7 @@ public class SandboxWatchlistScreeningCheck extends SandboxCheck {
                     : new SandboxCheckReport(recommendation, breakdown);
             SandboxCheckResult result = new SandboxCheckResult(report, reportTemplate);
 
-            return new SandboxWatchlistScreeningCheck(result);
+            return new SandboxWatchlistScreeningCheck(result, handledCheckLimit);
         }
 
     }

--- a/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxZoomLivenessCheckBuilder.java
+++ b/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/SandboxZoomLivenessCheckBuilder.java
@@ -26,7 +26,7 @@ public class SandboxZoomLivenessCheckBuilder extends SandboxCheck.Builder<Sandbo
                 : new SandboxCheckReport(recommendation, breakdown);
         SandboxCheckResult result = new SandboxCheckResult(report, reportTemplate);
 
-        return new SandboxLivenessCheck(result, DocScanConstants.ZOOM, responseDelay);
+        return new SandboxLivenessCheck(result, handledCheckLimit, DocScanConstants.ZOOM, responseDelay);
     }
 
 }

--- a/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/report/SandboxBreakdown.java
+++ b/yoti-sdk-sandbox/src/main/java/com/yoti/api/client/sandbox/docs/request/check/report/SandboxBreakdown.java
@@ -15,12 +15,16 @@ public class SandboxBreakdown {
     @JsonProperty("result")
     private final String result;
 
+    @JsonProperty("process")
+    private final String process;
+
     @JsonProperty("details")
     private final List<SandboxDetail> details;
 
-    private SandboxBreakdown(String subCheck, String result, List<SandboxDetail> details) {
+    private SandboxBreakdown(String subCheck, String result, String process, List<SandboxDetail> details) {
         this.subCheck = subCheck;
         this.result = result;
+        this.process = process;
         this.details = details;
     }
 
@@ -36,6 +40,10 @@ public class SandboxBreakdown {
         return result;
     }
 
+    public String getProcess() {
+        return process;
+    }
+
     public List<SandboxDetail> getDetails() {
         return details;
     }
@@ -47,6 +55,7 @@ public class SandboxBreakdown {
 
         private String subCheck;
         private String result;
+        private String process;
         private List<SandboxDetail> details = new ArrayList<>();
 
         private Builder() {
@@ -62,6 +71,11 @@ public class SandboxBreakdown {
             return this;
         }
 
+        public Builder withProcess(String process) {
+            this.process = process;
+            return this;
+        }
+
         public Builder withDetail(String name, String value) {
             SandboxDetail detail = new SandboxDetail(name, value);
             details.add(detail);
@@ -72,7 +86,7 @@ public class SandboxBreakdown {
             notNullOrEmpty(subCheck, "subCheck");
             notNullOrEmpty(result, "result");
 
-            return new SandboxBreakdown(subCheck, result, details);
+            return new SandboxBreakdown(subCheck, result, process, details);
         }
     }
 }

--- a/yoti-sdk-sandbox/src/test/java/com/yoti/api/client/sandbox/docs/request/SandboxBreakdownTest.java
+++ b/yoti-sdk-sandbox/src/test/java/com/yoti/api/client/sandbox/docs/request/SandboxBreakdownTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.fail;
 
 import com.yoti.api.client.sandbox.docs.request.check.report.SandboxBreakdown;
@@ -13,7 +14,8 @@ import org.junit.Test;
 public class SandboxBreakdownTest {
     
     private static final String SOME_SUB_CHECK = "someSubCheck";
-    private static final String SOME_RESULT = "someResult";    
+    private static final String SOME_RESULT = "someResult";
+    private static final String SOME_PROCESS = "someProcess";
     private static final String SOME_DETAIL_NAME = "someDetailName";
     private static final String SOME_DETAIL_VALUE = "someDetailValue";
 
@@ -50,7 +52,19 @@ public class SandboxBreakdownTest {
 
         assertThat(result.getSubCheck(), is(SOME_SUB_CHECK));
         assertThat(result.getResult(), is(SOME_RESULT));
+        assertThat(result.getProcess(), is(nullValue()));
         assertThat(result.getDetails(), hasSize(0));
+    }
+
+    @Test
+    public void builder_shouldBuildCorrectlyWithProcess() {
+        SandboxBreakdown result = SandboxBreakdown.builder()
+                .withSubCheck(SOME_SUB_CHECK)
+                .withResult(SOME_RESULT)
+                .withProcess(SOME_PROCESS)
+                .build();
+
+        assertThat(result.getProcess(), is(SOME_PROCESS));
     }
 
     @Test

--- a/yoti-sdk-sandbox/src/test/java/com/yoti/api/client/sandbox/docs/request/check/SandboxDocumentAuthenticityCheckTest.java
+++ b/yoti-sdk-sandbox/src/test/java/com/yoti/api/client/sandbox/docs/request/check/SandboxDocumentAuthenticityCheckTest.java
@@ -64,4 +64,15 @@ public class SandboxDocumentAuthenticityCheckTest {
         assertThat(result.getResult().getReport().getBreakdown(), hasSize(3));
     }
 
+    @Test
+    public void builder_shouldAllowSettingHandledCheckLimit() {
+        SandboxDocumentAuthenticityCheck result = SandboxDocumentAuthenticityCheck.builder()
+                .withRecommendation(sandboxRecommendationMock)
+                .withBreakdown(sandboxBreakdownMock)
+                .withHandledCheckLimit(3)
+                .build();
+
+        assertThat(result.getHandledCheckLimit(), is(3));
+    }
+
 }

--- a/yoti-sdk-sandbox/src/test/java/com/yoti/api/client/sandbox/docs/request/check/SandboxDocumentFaceMatchCheckTest.java
+++ b/yoti-sdk-sandbox/src/test/java/com/yoti/api/client/sandbox/docs/request/check/SandboxDocumentFaceMatchCheckTest.java
@@ -33,4 +33,15 @@ public class SandboxDocumentFaceMatchCheckTest {
         assertThat(result.getDocumentFilter(), is(nullValue()));
     }
 
+    @Test
+    public void builder_shouldAllowSettingHandledCheckLimit() {
+        SandboxDocumentFaceMatchCheck result = SandboxDocumentFaceMatchCheck.builder()
+                .withRecommendation(sandboxRecommendationMock)
+                .withBreakdown(sandboxBreakdownMock)
+                .withHandledCheckLimit(3)
+                .build();
+
+        assertThat(result.getHandledCheckLimit(), is(3));
+    }
+
 }

--- a/yoti-sdk-sandbox/src/test/java/com/yoti/api/client/sandbox/docs/request/check/SandboxDocumentTextDataCheckTest.java
+++ b/yoti-sdk-sandbox/src/test/java/com/yoti/api/client/sandbox/docs/request/check/SandboxDocumentTextDataCheckTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.fail;
 
 import java.util.HashMap;
@@ -55,5 +56,16 @@ public class SandboxDocumentTextDataCheckTest {
 
         assertThat(result.getResult().getDocumentFields(), hasEntry("firstKey", (Object) "firstValue"));
         assertThat(result.getResult().getDocumentFields(), hasEntry("secondKey", (Object) 100));
+    }
+
+    @Test
+    public void builder_shouldAllowSettingHandledCheckLimit() {
+        SandboxDocumentTextDataCheck result = SandboxDocumentTextDataCheck.builder()
+                .withRecommendation(sandboxRecommendationMock)
+                .withBreakdown(sandboxBreakdownMock)
+                .withHandledCheckLimit(3)
+                .build();
+
+        assertThat(result.getHandledCheckLimit(), is(3));
     }
 }

--- a/yoti-sdk-sandbox/src/test/java/com/yoti/api/client/sandbox/docs/request/check/SandboxIdDocumentComparisonCheckTest.java
+++ b/yoti-sdk-sandbox/src/test/java/com/yoti/api/client/sandbox/docs/request/check/SandboxIdDocumentComparisonCheckTest.java
@@ -35,4 +35,15 @@ public class SandboxIdDocumentComparisonCheckTest {
         assertThat(result.getResult().getReport().getRecommendation(), is(sandboxRecommendationMock));
     }
 
+    @Test
+    public void builder_shouldAllowSettingHandledCheckLimit() {
+        SandboxIdDocumentComparisonCheck result = SandboxIdDocumentComparisonCheck.builder()
+                .withRecommendation(sandboxRecommendationMock)
+                .withBreakdown(sandboxBreakdownMock)
+                .withHandledCheckLimit(3)
+                .build();
+
+        assertThat(result.getHandledCheckLimit(), is(3));
+    }
+
 }

--- a/yoti-sdk-sandbox/src/test/java/com/yoti/api/client/sandbox/docs/request/check/SandboxSupplementaryDocumentTextDataCheckTest.java
+++ b/yoti-sdk-sandbox/src/test/java/com/yoti/api/client/sandbox/docs/request/check/SandboxSupplementaryDocumentTextDataCheckTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.fail;
 
 import java.util.HashMap;
@@ -55,5 +56,16 @@ public class SandboxSupplementaryDocumentTextDataCheckTest {
 
         assertThat(result.getResult().getDocumentFields(), hasEntry("firstKey", (Object) "firstValue"));
         assertThat(result.getResult().getDocumentFields(), hasEntry("secondKey", (Object) 100));
+    }
+
+    @Test
+    public void builder_shouldAllowSettingHandledCheckLimit() {
+        SandboxSupplementaryDocumentTextDataCheck result = SandboxSupplementaryDocumentTextDataCheck.builder()
+                .withRecommendation(sandboxRecommendationMock)
+                .withBreakdown(sandboxBreakdownMock)
+                .withHandledCheckLimit(3)
+                .build();
+
+        assertThat(result.getHandledCheckLimit(), is(3));
     }
 }

--- a/yoti-sdk-sandbox/src/test/java/com/yoti/api/client/sandbox/docs/request/check/SandboxZoomLivenessCheckTest.java
+++ b/yoti-sdk-sandbox/src/test/java/com/yoti/api/client/sandbox/docs/request/check/SandboxZoomLivenessCheckTest.java
@@ -53,4 +53,26 @@ public class SandboxZoomLivenessCheckTest {
         assertThat(result.getLivenessType(), is("STATIC"));
     }
 
+    @Test
+    public void builder_shouldAllowSettingHandledCheckLimitForZoom() {
+        SandboxLivenessCheck result = new SandboxZoomLivenessCheckBuilder()
+                .withRecommendation(sandboxRecommendationMock)
+                .withBreakdown(sandboxBreakdownMock)
+                .withHandledCheckLimit(3)
+                .build();
+
+        assertThat(result.getHandledCheckLimit(), is(3));
+    }
+
+    @Test
+    public void builder_shouldAllowSettingHandledCheckLimitForStatic() {
+        SandboxLivenessCheck result = new SandboxStaticLivenessCheckBuilder()
+                .withRecommendation(sandboxRecommendationMock)
+                .withBreakdown(sandboxBreakdownMock)
+                .withHandledCheckLimit(3)
+                .build();
+
+        assertThat(result.getHandledCheckLimit(), is(3));
+    }
+
 }

--- a/yoti-sdk-spring-boot-auto-config/README.md
+++ b/yoti-sdk-spring-boot-auto-config/README.md
@@ -18,7 +18,7 @@ If you are using Maven, you need to add the following dependencies:
 <dependency>
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-boot-auto-config</artifactId>
-  <version>4.3.0</version>
+  <version>4.4.0-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -26,7 +26,7 @@ If you are using Maven, you need to add the following dependencies:
 If you are using Gradle, here is the dependency to add:
 
 ```
-compile group: 'com.yoti', name: 'yoti-sdk-spring-boot-auto-config', version: '4.3.0'
+compile group: 'com.yoti', name: 'yoti-sdk-spring-boot-auto-config', version: '4.4.0-SNAPSHOT'
 ```
 
 

--- a/yoti-sdk-spring-boot-auto-config/pom.xml
+++ b/yoti-sdk-spring-boot-auto-config/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>4.3.0</version>
+    <version>4.4.0-SNAPSHOT</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
 

--- a/yoti-sdk-spring-boot-example/README.md
+++ b/yoti-sdk-spring-boot-example/README.md
@@ -17,7 +17,7 @@ Note that:
     <dependency>
       <groupId>com.yoti</groupId>
       <artifactId>yoti-sdk-api</artifactId>
-      <version>4.3.0</version>
+      <version>4.4.0-SNAPSHOT</version>
     </dependency>
 ```
 

--- a/yoti-sdk-spring-boot-example/pom.xml
+++ b/yoti-sdk-spring-boot-example/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-boot-example</artifactId>
   <name>Yoti Spring Boot Example</name>
-  <version>4.3.0</version>
+  <version>4.4.0-SNAPSHOT</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>

--- a/yoti-sdk-spring-security/README.md
+++ b/yoti-sdk-spring-security/README.md
@@ -25,14 +25,14 @@ If you are using Maven, you need to add the following dependencies:
 <dependency>
   <groupId>com.yoti</groupId>
   <artifactId>yoti-sdk-spring-security</artifactId>
-  <version>4.3.0</version>
+  <version>4.4.0-SNAPSHOT</version>
 </dependency>
 ```
 
 If you are using Gradle, here is the dependency to add:
 
 ```
-compile group: 'com.yoti', name: 'yoti-sdk-spring-security', version: '4.3.0'
+compile group: 'com.yoti', name: 'yoti-sdk-spring-security', version: '4.4.0-SNAPSHOT'
 ```
 
 ### Provide a `YotiClient` instance

--- a/yoti-sdk-spring-security/pom.xml
+++ b/yoti-sdk-spring-security/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.yoti</groupId>
     <artifactId>yoti-sdk-parent</artifactId>
-    <version>4.3.0</version>
+    <version>4.4.0-SNAPSHOT</version>
     <relativePath>../yoti-sdk-parent</relativePath>
   </parent>
 


### PR DESCRIPTION
### Changes

#### Added

- Support for setting and fetching `company_name`, allowing for generated documentation to contain a different name from the organisation name
- `process` field has been exposed for `WATCHLIST_SCREENING` check in the IDV sandbox
- `handled_check_limit` is now supported for the IDV sandbox

#### Deprecated

- The AML service has now been discontinued.
  - All relevant classes and methods have been marked as `@Deprecated` and will be removed in the next major version